### PR TITLE
Let config.toml place the home view on a point, not just a station

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,14 @@ are hidden by default and the legend says so; `w` shows them.
 ## Configuration
 
 `~/.config/omastorm/config.toml` is optional. Without `home_site` the home is
-the station nearest Omarchy's weather location. `Shift+H`, or the HOME
-button, saves the station on screen as `home_site`.
+the station nearest `home_lat`/`home_lon`, or nearest Omarchy's weather
+location. `Shift+H`, or the HOME button, saves the station on screen as
+`home_site`.
 
 ```toml
-home_site = "KTLX"   # a station id; omit to use Omarchy's weather location
+home_site = "KTLX"   # a station id; omit to use the home point or Omarchy's weather location
+home_lat = 35.47     # centre the home view here instead of on the station
+home_lon = -97.52    # both are needed
 follow = true        # follow the nearest station while panning
 treatment = "GLYPHS" # PIXELS, GLYPHS, or STIPPLE at launch
 weak_floor = 5       # dBZ; false draws every measured return

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -322,6 +322,8 @@ another file for checks and captures; a missing file is no configuration.
 
 ```toml
 home_site = "KJAX"   # a station id from hello.sites
+home_lat = 30.33     # the home view centres here rather than on the station
+home_lon = -81.66    # both are needed; omit both to keep the station's own home view
 follow = true        # the map centre picks the station; omit to leave the shared flag alone
 treatment = "GLYPHS" # PIXELS, GLYPHS, or STIPPLE at launch; Glyphs when omitted
 weak_floor = 5       # dBZ; measured returns under it draw nothing; false draws them all; 5 when omitted
@@ -333,8 +335,8 @@ zoom_in = "+ ="
 
 - `home_site`: when the engine's state first arrives (and again after a
   reconnect, since a restarted daemon starts with no station) the
-  window puts the camera on this station's home view and sends
-  `select_site`; an id outside the table shows the engine's rejection in the
+  window puts the camera on this station's home view (or on `home_lat`/
+  `home_lon` when the file names them) and sends `select_site`; an id outside the table shows the engine's rejection in the
   status slot. Without it, the home is the station nearest Omarchy's own
   location when `~/.local/state/omarchy/settings/weather.json` (`name`,
   `latitude`, `longitude`, written by the shell's weather panel) has one,
@@ -345,6 +347,18 @@ zoom_in = "+ ="
   another location file; when `OMASTORM_CONFIG` is set the machine's own
   location file is not read unless `OMASTORM_LOCATION` names one, so a check
   or capture with its own config is isolated from the desktop's settings.
+- `home_lat` and `home_lon`: the point the home view centres on, in degrees.
+  The home view otherwise sits at the home station's own offset (5 km west and
+  15 km north of the site), which is the station, not the user; a place well
+  inside the station's range needs a pan on every open. Given both, the camera
+  lands on the point itself in the window and in the popover, and `Shift+H`,
+  RESET, and every later hand-off return to it. Without a `home_site` the home
+  station is the one nearest the point, so naming a place is enough on its own;
+  with one, the station is honoured and the camera still sits on the point.
+  Both are needed: one alone, a latitude outside ±90, or a longitude outside
+  ±180 is reported like a bad `treatment` and leaves the station's own home
+  view standing. The point is the user's, so it outranks Omarchy's weather
+  location for choosing the home station.
 - `follow`: sent as the `follow` command at the same moments when it differs
   from the state. An edit to the file applies to the open window at once.
 - `treatment`: the treatment at launch and whenever the file changes; the

--- a/scripts/check-map-home.sh
+++ b/scripts/check-map-home.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# The home view (docs/protocol.md, configuration) in two passes: the camera
+# itself in the map harness, then the real window driven through its IPC
+# handler against a config.toml that names a home point, including a
+# coordinate out of range reported in the status slot with the station's own
+# home view left standing. The window pass selects the point's station, so
+# it hands the scratch daemon back on the fixture station for the checks
+# that follow.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+check_dir="$PWD/target/check-map-home"
+mkdir -p "$check_dir"
+export QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME=basic QT_QUICK_BACKEND=rhi QSG_RHI_BACKEND=opengl
+
+# The camera: no point, a point, a pan, a reset, a hand-off, and a station
+# chosen by hand, against the real RadarMap.
+cp ui/RadarMap.qml ui/Engine.qml "$check_dir/"
+cp tests/map-home.qml "$check_dir/shell.qml"
+ln -sfn "$PWD/ui/shaders" "$check_dir/shaders"
+OMASTORM_QML="$check_dir/shell.qml" timeout 25 bash run.sh > "$check_dir/result.log" 2>&1
+cat "$check_dir/result.log"
+rg -q MAP_HOME_PASSED "$check_dir/result.log"
+if rg -q 'TypeError|ReferenceError|Unable to assign|Failed to create.*context' "$check_dir/result.log"; then exit 1; fi
+
+# The window: config.toml to camera, station, and status slot. Oklahoma
+# City, well inside the fixture station's range and not the station.
+printf 'home_lat = 35.47\nhome_lon = -97.52\n' > "$check_dir/config.toml"
+OMASTORM_CONFIG="$check_dir/config.toml" bash run.sh > "$check_dir/window.log" 2>&1 &
+pid=$!
+trap 'kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true' EXIT
+call() { quickshell ipc --pid "$pid" call keys "$@"; }
+field() { call field "$1"; }
+fail() { printf '%s\n' "$@" >&2; cat "$check_dir/window.log" >&2; exit 1; }
+expect() { [[ "$3" == "$2" ]] || fail "$1" "Expected: $2" "Actual:   $3"; }
+until_field() { # name, wanted
+  for attempt in {1..100}; do [[ $(field "$1") == "$2" ]] && return; sleep .1; done
+  fail "$1 never became $2: $(call status)"
+}
+for attempt in {1..100}; do call status > /dev/null 2>&1 && break; sleep .1; done
+
+until_field lat 35.47
+expect "The home view did not take the configured longitude" -97.52 "$(field lon)"
+expect "A home point should read as a config home" config "$(field homeSource)"
+home=$(field home)
+[[ -n $home ]] || fail "A home point did not pick a home station"
+until_field site "$home"
+expect "A valid home point should not be reported" "" "$(field error)"
+
+# A coordinate out of range is named and leaves the station's own home view.
+printf 'home_lat = 200\nhome_lon = -97.52\n' > "$check_dir/config.toml"
+until_field error 'HOME_LAT = 200: A LATITUDE BETWEEN -90 AND 90'
+[[ $(field lat) != 35.47 ]] || fail "A rejected home point still placed the home view"
+
+# One coordinate alone is not a point either.
+printf 'home_lat = 35.47\n' > "$check_dir/config.toml"
+until_field error 'HOME_LAT AND HOME_LON: THE HOME VIEW NEEDS BOTH'
+
+# Hand the shared daemon back on the fixture station, so a check that runs
+# after this one starts where it would have without it.
+printf 'home_site = "KTLX"\n' > "$check_dir/config.toml"
+until_field site KTLX
+
+echo "MAP_HOME_WINDOW_PASSED"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -38,7 +38,7 @@ export OMASTORM_ARCHIVE="$PWD/data/raw/KTLX20130520_201643_V06.gz"
 # check-picker and check-keys select stations for real, so they run last.
 export XDG_RUNTIME_DIR="$scratch/runtime"
 mkdir -p "$XDG_RUNTIME_DIR"
-for check in check-engine-ui check-engine-install check-map-tiles check-map-sites check-map-network check-theme check-picker check-keys check-popover check-launcher check-bind; do
+for check in check-engine-ui check-engine-install check-map-tiles check-map-sites check-map-network check-map-home check-theme check-picker check-keys check-popover check-launcher check-bind; do
   step "$check" timeout 180 bash "scripts/$check.sh"
 done
 target/debug/omastorm-engine stop > /dev/null 2>&1 || true

--- a/tests/map-home.qml
+++ b/tests/map-home.qml
@@ -1,0 +1,88 @@
+import QtQuick
+import Quickshell
+
+// The home view (docs/protocol.md, configuration). Without a home point the
+// camera sits at the station's own offset, 5 km west and 15 km north of the
+// site; with one it sits on the point itself, and stays there across a pan,
+// a reset, and a hand-off to the home station. Choosing another station by
+// hand still centres that station.
+ShellRoot {
+    Engine { id: engine }
+    FloatingWindow {
+        implicitWidth: 960; implicitHeight: 680; color: "#101820"
+        RadarMap {
+            id: map
+            anchors.fill: parent
+            theme: ({font:"monospace", foreground:"#eeeeee", accent:"#5599ee", background:"#101820"})
+            scan: engine.state ? engine.state.frame : null
+            texture: engine.texture
+            azimuthLut: engine.azimuthLut
+            sites: engine.sites
+            siteId: engine.state ? engine.state.site.id : ""
+        }
+    }
+    function check(ok, message) { if (!ok) throw new Error(message); }
+    function distance(a, b) {
+        var r = Math.PI/180, dp = (a.lat-b.lat)*r, dl = (a.lon-b.lon)*r;
+        var h = Math.sin(dp/2)**2 + Math.cos(a.lat*r)*Math.cos(b.lat*r)*Math.sin(dl/2)**2;
+        return 12742*Math.atan2(Math.sqrt(h), Math.sqrt(1-h));
+    }
+    function centre() { return {lat: map.centerLat, lon: map.centerLon}; }
+    // The station's own home view: 5 km west and 15 km north of the site.
+    // The offset is applied in Mercator units taken at the site's latitude,
+    // so the ground distance drifts a few metres over the 15 km; 100 m of
+    // tolerance still separates it from the home point and from the site.
+    readonly property real stationOffsetKm: Math.sqrt(5*5 + 15*15)
+    function checkStationHome(site, message) {
+        check(Math.abs(distance(centre(), site) - stationOffsetKm) < .1, message + ": wrong distance from the site");
+        check(centre().lat > site.lat && centre().lon < site.lon, message + ": the offset is not north-west of the site");
+    }
+    function checkOnPoint(point, message) {
+        check(Math.abs(centre().lat - point.lat) < 1e-9 && Math.abs(centre().lon - point.lon) < 1e-9, message);
+    }
+    property int stage: 0
+    property var site: null
+    property var point: null
+    Timer {
+        interval: 500; repeat: true; running: true
+        onTriggered: {
+            try {
+                if (!map.scan) return;
+                if (stage === 0) {
+                    site = map.scan.site;
+                    // A point well inside the station's range, the case the
+                    // station offset cannot reach: a home that is not the site.
+                    point = {lat: site.lat + .35, lon: site.lon + .45};
+                    check(map.homePoint === null, "The map starts with no home point");
+                    checkStationHome(site, "No home point");
+                    map.homePoint = point;
+                } else if (stage === 1) {
+                    checkOnPoint(point, "A home point did not take the home view");
+                    check(distance(centre(), site) > 40, "The home view stayed on the station");
+                    map.pan(1, 0); map.pan(0, 1);
+                } else if (stage === 2) {
+                    check(distance(centre(), point) > 1, "The pan did not leave the home point");
+                    map.reset();
+                } else if (stage === 3) {
+                    checkOnPoint(point, "Reset did not return to the home point");
+                    // The hand-off to the home station keeps the point.
+                    map.jumpHome(site.lat, site.lon);
+                } else if (stage === 4) {
+                    checkOnPoint(point, "The home hand-off left the home point");
+                    // A station chosen by hand is still centred on that station.
+                    var other = map.sites.find(s => s.id !== map.siteId && distance(s, site) > 200);
+                    check(!!other, "No second station to choose");
+                    map.jumpTo(other.lat, other.lon);
+                    checkStationHome(other, "Choosing a station ignored its own home view");
+                    map.homePoint = null;
+                    map.reset();
+                } else if (stage === 5) {
+                    checkStationHome(site, "Clearing the home point did not restore the station offset");
+                    console.log("MAP_HOME_PASSED"); Qt.quit();
+                }
+                stage++;
+            } catch (e) { console.error(e); Qt.quit(); }
+        }
+    }
+    Timer { interval: 15000; running: true; onTriggered: Qt.quit() }
+}

--- a/ui/Config.qml
+++ b/ui/Config.qml
@@ -4,10 +4,11 @@ import Quickshell.Io
 import "Toml.js" as Toml
 
 // ~/.config/omastorm/config.toml (docs/protocol.md, configuration): the
-// home station, whether the map centre picks the station, the treatment,
-// the weak-return floor, and the `[keys]` table. Watched like the theme
-// files, so an edit applies to the running window. OMASTORM_CONFIG names
-// another file for checks and captures; a missing file is no config.
+// home station, the home view's own centre, whether the map centre picks
+// the station, the treatment, the weak-return floor, and the `[keys]`
+// table. Watched like the theme files, so an edit applies to the running
+// window. OMASTORM_CONFIG names another file for checks and captures; a
+// missing file is no config.
 //
 // Omarchy's own location (DESIGN.md, site model), the file its weather
 // panel writes, is read beside it for the current-location home. It is
@@ -31,6 +32,12 @@ QtObject {
     readonly property var treatment: values.treatment
     // The raw value; the window judges it: a dBZ number, false, or unset.
     readonly property var weakFloor: values.weak_floor
+    // The raw values; the window judges them as a latitude/longitude pair.
+    // Together they place the home view on a point of the user's choosing
+    // instead of the home station's own offset, and pick the home station
+    // when `home_site` is unset.
+    readonly property var homeLat: values.home_lat
+    readonly property var homeLon: values.home_lon
     // The `[keys]` table as action id -> value, for Keys.resolve.
     readonly property var keys: {
         var table = {};

--- a/ui/Keys.js
+++ b/ui/Keys.js
@@ -110,6 +110,28 @@ function weakFloor(value, errors) {
     errors.push("weak_floor = " + JSON.stringify(value) + ": a dBZ number or false");
     return DEFAULT_FLOOR;
 }
+// The home view's centre (docs/protocol.md, configuration): `home_lat` and
+// `home_lon` in config.toml put the camera on a point of the user's
+// choosing instead of the home station's own offset. Both are needed and
+// each must be in range; returns { lat, lon }, or null when the file names
+// neither. A mistake is reported and leaves the station's own home view.
+function homePoint(lat, lon, errors) {
+    if (lat === undefined && lon === undefined) return null;
+    if (lat === undefined || lon === undefined) {
+        errors.push("home_lat and home_lon: the home view needs both");
+        return null;
+    }
+    if (typeof lat !== "number" || !isFinite(lat) || lat < -90 || lat > 90) {
+        errors.push("home_lat = " + JSON.stringify(lat) + ": a latitude between -90 and 90");
+        return null;
+    }
+    if (typeof lon !== "number" || !isFinite(lon) || lon < -180 || lon > 180) {
+        errors.push("home_lon = " + JSON.stringify(lon) + ": a longitude between -180 and 180");
+        return null;
+    }
+    return { lat: lat, lon: lon };
+}
+
 // OMASTORM_WEAK, set by the capture scripts, outranks the file: "off" or a
 // dBZ number. Empty or unparsable is no override (undefined).
 function envFloor(text) {

--- a/ui/PluginSession.qml
+++ b/ui/PluginSession.qml
@@ -21,12 +21,18 @@ QtObject {
     property var weakFloor: KeyMap.envFloor(Quickshell.env("OMASTORM_WEAK")) !== undefined ? KeyMap.envFloor(Quickshell.env("OMASTORM_WEAK")) : KeyMap.DEFAULT_FLOOR
     property string startupError: ""
     signal homeRequested()
+    // { lat, lon } from config.toml's home_lat/home_lon (docs/protocol.md,
+    // configuration), or null. The popover's map centres on it, and it
+    // picks the home station when `home_site` is unset. The window reports
+    // a value out of range; here a bad pair is simply no point.
+    readonly property var homePoint: KeyMap.homePoint(config.homeLat, config.homeLon, [])
     readonly property string homeSite: {
         if (config.homeSite) return config.homeSite;
-        if (!config.location) return "";
+        var point = homePoint || config.location;
+        if (!point) return "";
         var best = "", distance = Infinity;
         for (var site of engine.sites) {
-            var km = Sites.distanceKm(config.location.lat, config.location.lon, site.lat, site.lon);
+            var km = Sites.distanceKm(point.lat, point.lon, site.lat, site.lon);
             if (km < distance) { best = site.id; distance = km; }
         }
         return best;

--- a/ui/Popover.qml
+++ b/ui/Popover.qml
@@ -111,6 +111,7 @@ FocusScope {
                 theme: card.theme
                 treatment: card.session.treatment
                 weakFloor: card.session.weakFloor
+                homePoint: card.session.homePoint
                 labelSize: 10
                 radarOpacity: card.condition === "unavailable" ? .6 : 1
                 onTilesNeeded: (z, x0, y0, x1, y1) => connection.send({type: "tiles_needed", z: z, x0: x0, y0: y0, x1: x1, y1: y1})

--- a/ui/RadarMap.qml
+++ b/ui/RadarMap.qml
@@ -67,20 +67,25 @@ Item {
     readonly property real kmPerUnit: 2 * Math.PI * 6371 * Math.cos(siteLat * Math.PI / 180)
 
     // Camera. `center` is a longitude/latitude point, or null for the home
-    // view: the site offset by `home` kilometres east and north. `span` is
-    // the ground distance across the shorter viewport side at the scan site,
-    // never under 25 km. The longer side shows at most one world, and the view
+    // view: `homePoint` when config.toml names one, otherwise the site
+    // offset by `home` kilometres east and north. `span` is the ground
+    // distance across the shorter viewport side at the scan site, never
+    // under 25 km. The longer side shows at most one world, and the view
     // stays inside the tile pyramid on both axes; the whole network fits one
     // Mercator world, so nothing wraps at the date line.
     property var center: null
     readonly property point home: Qt.point(-5, 15)
+    // { lat, lon } from config.toml's home_lat/home_lon (docs/protocol.md,
+    // configuration), or null. The home view lands on the point itself,
+    // not offset: the user named the spot they want to look at.
+    property var homePoint: null
     property real span: 210
     readonly property real maxSpan: kmPerUnit * Math.min(width, height) / Math.max(1, width, height)
     readonly property real pixelsPerKm: Math.max(Math.min(width, height) / Math.max(25, span), Math.max(width, height) / kmPerUnit)
     readonly property real worldPixels: pixelsPerKm * kmPerUnit
     readonly property real unitsPerPixel: 1 / worldPixels
-    readonly property real wantedX: center ? mercatorX(center.x) : siteMx + home.x / kmPerUnit
-    readonly property real wantedY: center ? mercatorY(center.y) : siteMy - home.y / kmPerUnit
+    readonly property real wantedX: center ? mercatorX(center.x) : homePoint ? mercatorX(homePoint.lon) : siteMx + home.x / kmPerUnit
+    readonly property real wantedY: center ? mercatorY(center.y) : homePoint ? mercatorY(homePoint.lat) : siteMy - home.y / kmPerUnit
     readonly property real viewCenterX: Math.max(width/2*unitsPerPixel, Math.min(1-width/2*unitsPerPixel, wantedX))
     readonly property real viewCenterY: Math.max(height/2*unitsPerPixel, Math.min(1-height/2*unitsPerPixel, wantedY))
     function reset() { center = null; span = Math.min(210, maxSpan); }
@@ -99,6 +104,13 @@ Item {
     function jumpTo(lat, lon) {
         var k = 2 * Math.PI * 6371 * Math.cos(lat * Math.PI / 180);
         center = Qt.point(longitude(mercatorX(lon) + home.x / k), latitude(mercatorY(lat) - home.y / k));
+    }
+    // The same jump for the home station: a configured home point stands
+    // wherever the station lands, so the camera goes back to the home view
+    // rather than to the station's own offset.
+    function jumpHome(lat, lon) {
+        if (homePoint) center = null;
+        else jumpTo(lat, lon);
     }
     // A hand-off changes the site under a camera the user placed. The span
     // is measured at the site's latitude, so it is rescaled to keep the

--- a/ui/RadarWindow.qml
+++ b/ui/RadarWindow.qml
@@ -133,11 +133,18 @@ Item {
     // again after a reconnect (a rebuilt daemon starts on the archived
     // fixture), with the camera on its home view; the follow setting goes
     // with it. An edit to the file while the window is open applies at once.
-    // Without a home_site the home is the station nearest Omarchy's own
-    // location (DESIGN.md, site model), when that file has one.
+    // Without a home_site the home is the station nearest the home point
+    // config.toml names, or nearest Omarchy's own location (DESIGN.md, site
+    // model) when that file has one.
     Config { id: config }
-    readonly property string homeSource: config.homeSite ? "config" : config.location ? "location" : ""
+    // { lat, lon } from config.toml's home_lat/home_lon, or null. It places
+    // the home view and, without a home_site, picks the home station; a
+    // value out of range is reported like a bad treatment and leaves the
+    // station's own home view standing.
+    readonly property var homePoint: KeyMap.homePoint(config.homeLat, config.homeLon, [])
+    readonly property string homeSource: config.homeSite || homePoint ? "config" : config.location ? "location" : ""
     readonly property string homeSite: config.homeSite ? config.homeSite
+        : homePoint ? nearestTo(homePoint.lat, homePoint.lon)
         : config.location ? nearestTo(config.location.lat, config.location.lon) : ""
     function nearestTo(lat, lon) {
         var best = null, bestKm = Infinity;
@@ -153,7 +160,7 @@ Item {
         configApplied = true;
         if (homeSite) {
             var home = engine.sites.find(s => s.id === homeSite);
-            if (home && (home.id !== siteId || state.source !== "live")) { map.jumpTo(home.lat, home.lon); engine.send({type: "select_site", id: home.id}); }
+            if (home && (home.id !== siteId || state.source !== "live")) { map.jumpHome(home.lat, home.lon); engine.send({type: "select_site", id: home.id}); }
             else if (!home) engine.send({type: "select_site", id: homeSite}); // the engine names the mistake
         }
         if (config.follow !== undefined && config.follow !== state.site.follow) engine.send({type: "follow", enabled: config.follow});
@@ -164,6 +171,8 @@ Item {
         target: config
         function onReadyChanged() { app.applyConfig(); }
         function onFollowChanged() { app.configApplied = false; app.applyConfig(); }
+        function onHomeLatChanged() { app.applySettings(); app.configApplied = false; app.applyConfig(); }
+        function onHomeLonChanged() { app.applySettings(); app.configApplied = false; app.applyConfig(); }
         function onKeysChanged() { app.applySettings(); }
         function onTreatmentChanged() { app.applySettings(); }
         function onWeakFloorChanged() { app.applySettings(); }
@@ -182,6 +191,7 @@ Item {
     function canon(sequence) { probe.sequence = sequence; return probe.portableText; }
     function applySettings() {
         var errors = [], wanted = KeyMap.treatment(config.treatment, errors), floor = KeyMap.weakFloor(config.weakFloor, errors);
+        KeyMap.homePoint(config.homeLat, config.homeLon, errors);
         var resolved = KeyMap.resolve(config.keys, canon);
         bindings = resolved.bindings;
         configErrors = errors.concat(resolved.errors);
@@ -491,6 +501,7 @@ Item {
                     theme: app.theme
                     treatment: app.treatment
                     weakFloor: app.weakFloor
+                    homePoint: app.homePoint
                     radarOpacity: app.condition === "unavailable" ? .6 : 1
                     labelSize: win.compact ? 10 : 12
                     locked: app.locked


### PR DESCRIPTION
Closes #1.

### The problem

The home view is the *station's* home view. `RadarMap` centres it on the site offset by a fixed 5 km west and 15 km north:

```qml
readonly property point home: Qt.point(-5, 15)
readonly property real wantedX: center ? mercatorX(center.x) : siteMx + home.x / kmPerUnit
```

That is where the radar is, not where the user is. `home_site` picks *which* station, and Omarchy's weather location picks the *nearest* station, but nothing says where to look once you get there — so a home well inside the station's range is a pan away on every open, which is exactly what #1 reports.

### The change

`home_lat` and `home_lon` in `config.toml` name that point:

```toml
home_site = "KTLX"   # optional; without it, the station nearest the point
home_lat  = 35.47
home_lon  = -97.52
```

- Given both, the window **and the popover** centre the home view on the point itself — not offset, since the user named the spot they want to look at.
- `Shift+H`, `RESET`, and every later hand-off to the home station return to it. Choosing a station by hand (`n`, the picker) still centres that station, which is what those keys mean.
- Without a `home_site`, the home station is the one nearest the point, so naming a place is enough on its own. The point outranks Omarchy's weather location for that choice, because the user set it deliberately.
- Both keys are required, and each is judged the way `treatment` and `weak_floor` are: one alone, or a coordinate out of range, is named in the status slot and leaves the station's own home view standing. Nothing is silently ignored.

Behaviour with no `home_lat`/`home_lon` in the file is unchanged, including the existing weather-location path.

### Shape

`Config` exposes the raw values, `Keys.js` judges them (`homePoint`), the surfaces bind the result — the same split `treatment` and `weak_floor` already use. The engine is untouched; this is camera state only, so no radar values pass through QML.

### Verification

`tests/map-home.qml` + `scripts/check-map-home.sh`, registered in `scripts/check.sh`. It drives the real `RadarMap` against the archived KTLX scan and asserts the camera through the whole sequence:

- no home point → the station offset (15.81 km, north-west of the site)
- a home point → the camera is on the point to 1e-9°, and >40 km off the site
- a pan leaves it; `reset()` returns to it
- `jumpHome()` keeps it; `jumpTo()` on another station still centres that station
- clearing the point restores the station offset

Happy to reshape any of this — the key names, whether the popover should follow the point too, or whether a bad pair should fall back rather than report.
