### PR TITLE
Treat a slow hello as a daemon still starting, not a failed launch

### DIFF
--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -1580,7 +1580,21 @@ fn handshake(dir: &Path) -> io::Result<Option<Handshake>> {
     stream.set_read_timeout(Some(Duration::from_millis(200)))?;
     let mut reader = BufReader::new(stream).take(64 * 1024);
     let mut text = String::new();
-    reader.read_line(&mut text)?;
+    // A daemon that has bound the socket but not yet published its hello is
+    // starting, not broken: the read timeout means "not ready", the same
+    // answer as no socket at all, so `ensure` keeps waiting out its deadline.
+    match reader.read_line(&mut text) {
+        Ok(_) => {}
+        Err(e)
+            if matches!(
+                e.kind(),
+                io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+            ) =>
+        {
+            return Ok(None);
+        }
+        Err(e) => return Err(e),
+    }
     let handshake: Handshake = serde_json::from_str(&text).map_err(io::Error::other)?;
     if handshake.kind != "hello" {
         return Err(io::Error::other(


### PR DESCRIPTION
Found while verifying #5; unrelated to it, and based on `main` so the two are independent.

### Symptom

`omastorm-engine ensure` fails with a bare error while the daemon it just spawned is alive and about to answer:

```
$ target/debug/omastorm-engine ensure
Error: Os { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" }
$ cat $XDG_RUNTIME_DIR/omastorm/engine.log
Archive ready: decoded in 532.34ms, textures encoded by 956.23ms, published by 956.85ms
```

A second `ensure` against the now-warm daemon succeeds, which is the tell: it is a startup race, not a broken daemon.

On a pristine `388af52` checkout this takes four steps of `scripts/check.sh` down on this machine — including `launcher_replaces_a_daemon_of_another_build`, whose `assert!(started.status.success())` at `engine/tests/protocol.rs:354` is asserting exactly this:

```
test                 FAIL
check-engine-ui      FAIL
check-engine-install FAIL
check-popover        FAIL
```

### Cause

`handshake` gives the socket a 200 ms read timeout and propagates the timeout as an error:

```rust
stream.set_read_timeout(Some(Duration::from_millis(200)))?;
let mut reader = BufReader::new(stream).take(64 * 1024);
let mut text = String::new();
reader.read_line(&mut text)?;          // WouldBlock / TimedOut escapes here
```

`serve` binds the socket before it has published the first frame — with `OMASTORM_ARCHIVE` that decode is ~950 ms, well past 200 ms. So `ready` returns `Err`, and the `ready(&dir)?` inside `ensure`'s retry loop aborts the whole launch on the first slow answer, defeating the deadline directly above it:

```rust
// Allow far more than that, so a slow disk or a busy machine gets a slow
// launch rather than a killed daemon.
let deadline = Instant::now() + Duration::from_secs(10);
while Instant::now() < deadline {
    if ready(&dir)? {   // <- one slow hello ends the loop instead of retrying
```

The loop already polls every 20 ms for 10 s; it just never gets the chance.

`run.sh --ensure` is the plugin bootstrap, so on a machine that starts slowly the user gets no engine until the 20 s retry, with that `WouldBlock` line as the last line of `bootstrap.log` — which is what the popover shows while there is no engine.

### Fix

A read timeout now means "not ready", the same answer `handshake` already gives when there is no socket at all, so the caller keeps waiting out its deadline. Real I/O errors still propagate.

### Verification

`bash scripts/check.sh` on this machine, same checkout, only this commit:

| | before | after |
|---|---|---|
| `test` | FAIL | **PASS** (7/7, incl. `launcher_replaces_a_daemon_of_another_build`) |
| `check-engine-ui` | FAIL | **PASS** |
| `check-engine-install` | FAIL | **PASS** |
| `check-popover` | FAIL | **PASS** |

All 15 steps green, `fmt` and `clippy -D warnings` included.

No new test: `launcher_replaces_a_daemon_of_another_build` already covers this and goes red-to-green. It only catches the race on a machine slow enough to lose it, though — happy to add a test that makes it deterministic (a stub daemon that binds the socket and holds the hello past the timeout) if you would like it pinned down.
