### PR TITLE
Prepare native aarch64 engine releases

### DIFF
--- a/.github/workflows/engine-build.yml
+++ b/.github/workflows/engine-build.yml
@@ -1,0 +1,54 @@
+name: Engine release candidates
+
+on:
+  pull_request:
+    paths:
+      - 'engine/**'
+      - 'Cargo.*'
+      - 'data/**'
+      - 'golden/**'
+      - 'scripts/*engine*.sh'
+      - 'scripts/cargo.sh'
+      - 'scripts/setup-fixture.sh'
+      - '.github/workflows/engine-build.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            arch: x86_64
+          - runner: ubuntu-24.04-arm
+            arch: aarch64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup toolchain install stable --profile minimal && rustup default stable
+      - name: Fetch fixtures and dependencies
+        run: |
+          bash scripts/setup-fixture.sh
+          bash scripts/cargo.sh fetch --locked
+      - name: Test the native engine
+        run: bash scripts/cargo.sh test --offline --locked
+      - name: Build release candidate
+        run: bash scripts/build-engine-release.sh
+      - name: Verify native installation and bootstrap
+        env:
+          OMASTORM_ARCHIVE: ${{ github.workspace }}/data/raw/KTLX20130520_201643_V06.gz
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y socat ripgrep
+          bash scripts/check-engine-install.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: engine-${{ matrix.arch }}
+          path: target/dist/
+          if-no-files-found: error

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,9 @@ not start the step after it in the same session.
   of git (see `.gitignore`); README media are assets on the plugin's GitHub
   Release and are linked by URL.
 - The engine binary is a GitHub Release asset (`engine-<version>`) pinned by
-  sha256 in `engine/release.pin`; `scripts/install-engine.sh` fetches and
-  verifies it. Bump the pin only after the release it names exists.
+  sha256 in `engine/release.pin` (x86_64) or `engine/release-aarch64.pin`
+  (ARM, once published); `scripts/install-engine.sh` fetches and verifies it.
+  Bump a pin only after the release and asset it names exist.
 - `manifest.json` `version` is the plugin's version; tag the same commit
   `v<version>`. The engine has its own version in `engine/Cargo.toml` and its
   own `engine-<version>` tag. The two move independently; the pin joins them.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -253,17 +253,20 @@ reviewed with Wes the same day. Everything below is decided.
   source of truth; a `SHA256SUMS` next to the asset is for humans. Pinning,
   not `latest`, because UI and engine share protocol v1.
 - `scripts/build-engine-release.sh` builds `--release --locked --offline`
-  on `x86_64-unknown-linux-gnu`, copies and strips the binary into
-  `target/dist/`, writes `SHA256SUMS`, and with `--write-pin` updates the
-  pin. It does not tag, publish, or push. Release order: publish that
-  exact file as Release `engine-0.1.0`, then the pin may reach origin.
+  for its native x86_64 or aarch64 Linux GNU host, copies and strips the
+  binary into `target/dist/`, and writes `SHA256SUMS` and a candidate pin.
+  It does not update committed pins, tag, publish, or push. Publish and
+  verify the exact asset before promoting its candidate pin into `engine/`.
+  The release-candidate workflow tests/builds both CPUs on native runners.
 - `scripts/install-engine.sh` installs under
   `$XDG_DATA_HOME/omastorm/bin/omastorm-engine` (default
   `~/.local/share/omastorm/bin`). A dest whose sha256 already matches is
   left alone. Otherwise it copies `OMASTORM_ENGINE_ASSET` or curl-fetches
   the pinned URL (`OMASTORM_ENGINE_URL` overrides), verifies the committed
-  hash, and temp-and-renames. A mismatch is refused. `aarch64` is named
-  and deferred. A missing GitHub asset names the publish step and the
+  hash, and temp-and-renames. A mismatch is refused. x86_64 selects
+  `engine/release.pin`; aarch64 selects `engine/release-aarch64.pin`, with
+  the same fields and an independent hash. The pin must name the host CPU.
+  The ARM pin is added only after its asset is published and verified. A missing GitHub asset names the publish step and the
   checkout build. `ensure` still replaces a stale daemon by self-hash.
 - `run.sh --ensure` uses `target/debug/omastorm-engine` when that file is
   executable (ordinary development, no fetch). Otherwise it runs the

--- a/engine/README.md
+++ b/engine/README.md
@@ -9,8 +9,8 @@ build --locked`. Run `bash run.sh` thereafter; launch builds offline, ensures a
 shared daemon exists, and starts Quickshell. Rust 1.89+ is required for a
 checkout build. Plugin installs use `scripts/install-engine.sh` and the pin
 in `engine/release.pin` instead of Rust; `bash scripts/build-engine-release.sh`
-produces the x86_64 asset under `target/dist/` and does not publish it
-(the pinned release holds the current file).
+produces the native x86_64 or aarch64 asset, `SHA256SUMS`, and a candidate
+pin under `target/dist/`. It does not publish or change committed pins.
 `scripts/cargo.sh` uses Cargo on PATH or, if present, an isolated
 `.tools/{cargo,rustup}` toolchain. No Python runs at launch.
 
@@ -334,3 +334,33 @@ The UI check verifies socket metadata, invalid JSON, a rejection that sits
 beside state until the client's next command (including one answered by the
 real daemon), the azimuth lookup and tile path rules, a `tiles_needed` round
 trip, and rejecting an unknown protocol version.
+
+## Publishing an ARM engine
+
+The `Engine release candidates` workflow builds and tests on native GitHub
+x86_64 and ARM Linux runners. Each artifact contains the stripped binary,
+`SHA256SUMS`, and its candidate pin. The native engine tests and installer
+bootstrap run on each CPU; Quickshell/GPU checks still run on the development
+desktop. Locally, fetch dependencies and fixtures as above, then run
+`bash scripts/build-engine-release.sh` on the matching native host.
+
+The installer selects `engine/release.pin` on x86_64 and
+`engine/release-aarch64.pin` on aarch64. Each has its own tag, asset, and
+checksum, so adding ARM does not replace the existing x86_64 binary.
+Unsupported CPUs and pins naming a different CPU fail before downloading.
+
+For the first ARM release, build the engine source matching the existing
+`engine-0.1.1` tag (check `git diff engine-0.1.1 -- engine/src engine/build.rs
+engine/data Cargo.toml Cargo.lock engine/Cargo.toml data/SHA256SUMS`). If the
+engine source changes, bump the engine version and publish a new engine tag.
+Download the ARM workflow artifact and verify it with `sha256sum -c
+SHA256SUMS` in its directory. Publish the ARM binary on the release named by
+the candidate pin, keeping the existing x86_64 asset. Download that published
+binary again and verify its checksum before copying `release-aarch64.pin`
+into `engine/`. Never pin an unpublished candidate or replace an existing
+release binary with different bytes.
+
+Before merging ARM support, commit that verified pin, change README's install
+platforms to “Omarchy 4 on x86_64 or aarch64,” and run `bash scripts/check.sh`.
+Until then, ARM bootstrap reports that its published pin is missing. An Asahi
+Omarchy install/popover/window check remains the final desktop validation.

--- a/scripts/build-engine-release.sh
+++ b/scripts/build-engine-release.sh
@@ -1,42 +1,42 @@
 #!/usr/bin/env bash
-# Build the x86_64-unknown-linux-gnu GitHub Release asset and SHA256SUMS
-# under target/dist/. Pass --write-pin to copy the hash into engine/release.pin
-# after a successful build. Does not publish, tag, or push.
+# Build a native Linux release asset, SHA256SUMS, and a candidate pin under
+# target/dist/. Publish the asset before copying the candidate into engine/.
+# Does not modify committed pins, tag, publish, or push.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
 die() { printf '%s\n' "$@" >&2; exit 1; }
-
-write_pin=0
-[[ ${1:-} == --write-pin ]] && write_pin=1
+[[ $# == 0 ]] || die 'Usage: bash scripts/build-engine-release.sh (pins are promoted only after publication)'
 
 if ! command -v rustc >/dev/null && [[ -x .tools/cargo/bin/rustc ]]; then
   export RUSTUP_HOME="$PWD/.tools/rustup" CARGO_HOME="$PWD/.tools/cargo"
   export PATH="$CARGO_HOME/bin:$PATH"
 fi
 host=$(rustc -vV | awk '/^host:/{print $2}')
-[[ $host == x86_64-unknown-linux-gnu ]] || die "This script builds the x86_64-unknown-linux-gnu asset (host is $host)."
+case $host in
+  x86_64-unknown-linux-gnu) pin_name=release.pin ;;
+  aarch64-unknown-linux-gnu) pin_name=release-aarch64.pin ;;
+  *) die "Unsupported release host: $host (use native x86_64 or aarch64 Linux GNU)." ;;
+esac
 
-bash scripts/cargo.sh build --release --locked --offline
-src=target/release/omastorm-engine
+# Explicit target keeps a Cargo target override from packaging the wrong CPU.
+bash scripts/cargo.sh build --release --locked --offline --target "$host" --target-dir target
+src=target/$host/release/omastorm-engine
 [[ -x $src ]] || die "cargo did not produce $src"
 
 mkdir -p target/dist
-asset=omastorm-engine-x86_64-unknown-linux-gnu
+asset=omastorm-engine-$host
 dest=target/dist/$asset
 cp -- "$src" "$dest"
 strip --strip-unneeded -- "$dest"
 chmod 755 -- "$dest"
 
 sum=$(sha256sum -- "$dest" | awk '{print $1}')
-# sha256sum -c format, names as they appear on the Release.
-(cd target/dist && sha256sum -- "$asset" > SHA256SUMS)
+# Include both assets if native builds have been collected in this directory.
+(cd target/dist && sha256sum -- omastorm-engine-*-unknown-linux-gnu > SHA256SUMS)
 printf '%s  %s\n' "$sum" "$dest"
-
 version=$(awk -F'"' '/^version = /{print $2; exit}' engine/Cargo.toml)
-pin=engine/release.pin
-if (( write_pin )); then
-  cat > "$pin" <<PIN
+cat > "target/dist/$pin_name" <<PIN
 # Pinned GitHub Release for the engine binary (DESIGN.md, distribution).
 # Bump only after the named release exists on wesleygrimes/omastorm.
 tag=engine-$version
@@ -44,10 +44,4 @@ repo=wesleygrimes/omastorm
 asset=$asset
 sha256=$sum
 PIN
-fi
-
-if [[ -f $pin ]]; then
-  expected=$(awk -F= '/^sha256=/{print $2}' "$pin")
-  [[ $sum == "$expected" ]] || die "Built $dest ($sum) does not match $pin ($expected)." \
-    "Re-run with --write-pin only when preparing a new engine release."
-fi
+printf 'Candidate pin: target/dist/%s; publish and verify the asset before copying to engine/%s.\n' "$pin_name" "$pin_name"

--- a/scripts/check-engine-install.sh
+++ b/scripts/check-engine-install.sh
@@ -3,8 +3,8 @@
 # mismatch, install under a scratch XDG_DATA_HOME, skip a current dest,
 # reject an unsupported machine, keep ordinary launch and a checkout
 # --ensure off the installer. Uses a scratch pin and the debug engine so
-# check.sh does not need a release rebuild. When target/dist matches the
-# committed pin, that asset is installed too.
+# check.sh does not need a release rebuild. A native candidate in target/dist
+# is also installed and bootstrapped when present.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -21,7 +21,7 @@ pin=$scratch/release.pin
 cat > "$pin" <<PIN
 tag=engine-test
 repo=wesleygrimes/omastorm
-asset=omastorm-engine-x86_64-unknown-linux-gnu
+asset=omastorm-engine-$(uname -m)-unknown-linux-gnu
 sha256=$sum
 PIN
 export OMASTORM_ENGINE_PIN=$pin
@@ -58,11 +58,43 @@ chmod 755 -- "$dest"
 OMASTORM_ENGINE_ASSET="$debug" bash scripts/install-engine.sh
 [[ $(sha256sum -- "$dest" | awk '{print $1}') == "$sum" ]] || fail 'Stale dest was not replaced'
 
-# aarch64 is named, not fetched.
-if OMASTORM_ENGINE_MACHINE=aarch64 bash scripts/install-engine.sh 2>"$scratch/arch.err"; then
-  fail 'Installer accepted aarch64'
+# Both architectures select their own default pin and reject the other asset.
+# Synthetic payloads test selection/hashing; native bootstrap is tested below.
+selector=$scratch/selector
+mkdir -p "$selector/scripts" "$selector/engine"
+cp scripts/install-engine.sh "$selector/scripts/"
+for machine in x86_64 aarch64; do
+  pin_name=release.pin
+  [[ $machine == aarch64 ]] && pin_name=release-aarch64.pin
+  printf 'payload for %s\n' "$machine" > "$scratch/$machine"
+  arch_sum=$(sha256sum "$scratch/$machine" | awk '{print $1}')
+  cat > "$selector/engine/$pin_name" <<PIN
+tag=engine-test
+repo=wesleygrimes/omastorm
+asset=omastorm-engine-$machine-unknown-linux-gnu
+sha256=$arch_sum
+PIN
+  env -u OMASTORM_ENGINE_PIN OMASTORM_ENGINE_MACHINE=$machine \
+    OMASTORM_ENGINE_ASSET="$scratch/$machine" bash "$selector/scripts/install-engine.sh"
+  [[ $(sha256sum "$dest" | awk '{print $1}') == "$arch_sum" ]] || fail "Wrong $machine pin selected"
+  other=x86_64
+  [[ $machine == x86_64 ]] && other=aarch64
+  if OMASTORM_ENGINE_MACHINE=$other OMASTORM_ENGINE_PIN="$selector/engine/$pin_name" \
+    bash scripts/install-engine.sh 2>"$scratch/arch.err"; then
+    fail 'Installer accepted a pin for the wrong architecture'
+  fi
+  rg -q 'does not match architecture' "$scratch/arch.err" || fail 'Wrong-arch error unclear'
+done
+rm "$selector/engine/release-aarch64.pin"
+if env -u OMASTORM_ENGINE_PIN OMASTORM_ENGINE_MACHINE=aarch64 \
+  bash "$selector/scripts/install-engine.sh" 2>"$scratch/arch.err"; then
+  fail 'Installer accepted missing ARM pin'
 fi
-rg -q 'aarch64 is deferred' "$scratch/arch.err" || fail "Arch error was unclear: $(cat "$scratch/arch.err")"
+rg -q 'No published aarch64 engine pin' "$scratch/arch.err" || fail 'Missing ARM pin error unclear'
+if OMASTORM_ENGINE_MACHINE=riscv64 bash scripts/install-engine.sh 2>"$scratch/arch.err"; then
+  fail 'Installer accepted unsupported architecture'
+fi
+rg -q 'Unsupported engine architecture' "$scratch/arch.err" || fail 'Unsupported arch error unclear'
 
 # Checkout --ensure uses the debug engine and does not write the data home.
 rm -rf "$XDG_DATA_HOME"
@@ -89,21 +121,32 @@ timeout 2 socat -t0.2 - "UNIX-CONNECT:$XDG_RUNTIME_DIR/omastorm/engine.sock" < /
   || fail 'Clone --ensure did not produce a hello'
 "$dest" stop >/dev/null
 
-# Committed pin, if present, is well formed; the dist asset must match when it exists.
-if [[ -f engine/release.pin ]]; then
-  committed=$(awk -F= '/^sha256=/{print $2}' engine/release.pin)
-  [[ $committed =~ ^[a-f0-9]{64}$ ]] || fail 'Committed pin sha256 is not 64 lowercase hex digits'
-  dist=target/dist/omastorm-engine-x86_64-unknown-linux-gnu
-  if [[ -f $dist ]]; then
-    [[ $(sha256sum -- "$dist" | awk '{print $1}') == "$committed" ]] \
-      || fail "$dist does not match engine/release.pin"
-    unset OMASTORM_ENGINE_PIN
-    export OMASTORM_ENGINE_ASSET=$dist OMASTORM_ENGINE_PIN=$PWD/engine/release.pin
-    rm -f "$dest"
-    bash scripts/install-engine.sh
-    [[ $(sha256sum -- "$dest" | awk '{print $1}') == "$committed" ]] \
-      || fail 'Committed-pin install did not match'
-  fi
+# Every committed pin is well formed and agrees with its architecture.
+for machine in x86_64 aarch64; do
+  pin_name=release.pin
+  [[ $machine == aarch64 ]] && pin_name=release-aarch64.pin
+  committed_pin=$PWD/engine/$pin_name
+  [[ -f $committed_pin ]] || continue
+  committed=$(awk -F= '/^sha256=/{print $2}' "$committed_pin")
+  [[ $committed =~ ^[a-f0-9]{64}$ ]] || fail "Invalid checksum in $committed_pin"
+  [[ $(awk -F= '/^asset=/{print $2}' "$committed_pin") == "omastorm-engine-$machine-unknown-linux-gnu" ]] \
+    || fail "Wrong architecture in $committed_pin"
+done
+
+# Exercise the actual native release candidate when available, including hello.
+case $(uname -m) in
+  x86_64) candidate=target/dist/release.pin ;;
+  aarch64) candidate=target/dist/release-aarch64.pin ;;
+esac
+if [[ -f $candidate ]]; then
+  export OMASTORM_ENGINE_PIN=$PWD/$candidate
+  export OMASTORM_ENGINE_ASSET=$PWD/target/dist/omastorm-engine-$(uname -m)-unknown-linux-gnu
+  rm -f "$dest"
+  bash scripts/install-engine.sh
+  "$dest" ensure >/dev/null
+  timeout 2 socat -t0.2 - "UNIX-CONNECT:$XDG_RUNTIME_DIR/omastorm/engine.sock" < /dev/null | rg -q '"type":"hello"' \
+    || fail 'Release candidate did not produce a hello'
+  "$dest" stop >/dev/null
 fi
 
-echo 'Engine install: pin verify, mismatch refuse, dest install, skip current, replace stale, arch, checkout --ensure, clone --ensure PASS'
+echo 'Engine install: pin verify, mismatch refuse, dest install, skip current, replace stale, both architectures, checkout --ensure, clone --ensure PASS'

--- a/scripts/install-engine.sh
+++ b/scripts/install-engine.sh
@@ -8,8 +8,15 @@ cd "$(dirname "$0")/.."
 
 die() { printf '%s\n' "$@" >&2; exit 1; }
 
-pin_file=${OMASTORM_ENGINE_PIN:-engine/release.pin}
-[[ -f $pin_file ]] || die "Omastorm engine pin missing: $pin_file"
+machine=${OMASTORM_ENGINE_MACHINE:-$(uname -m)}
+case $machine in
+  x86_64) default_pin=engine/release.pin ;;
+  aarch64) default_pin=engine/release-aarch64.pin ;;
+  *) die "Unsupported engine architecture: $machine (supported: x86_64, aarch64)." ;;
+esac
+pin_file=${OMASTORM_ENGINE_PIN:-$default_pin}
+[[ -f $pin_file ]] || die "No published $machine engine pin yet: $pin_file" \
+  "From a checkout with Rust: bash scripts/cargo.sh build --locked && bash run.sh"
 tag= repo= asset= sha256=
 while IFS= read -r line || [[ -n $line ]]; do
   [[ $line =~ ^[[:space:]]*(#|$) ]] && continue
@@ -23,8 +30,8 @@ done < "$pin_file"
 [[ -n $tag && -n $repo && -n $asset && -n $sha256 ]] || die "Incomplete pin in $pin_file"
 [[ $sha256 =~ ^[a-f0-9]{64}$ ]] || die "Pin sha256 in $pin_file is not 64 lowercase hex digits"
 
-machine=${OMASTORM_ENGINE_MACHINE:-$(uname -m)}
-[[ $machine == x86_64 ]] || die "No $machine engine asset yet (aarch64 is deferred; see DESIGN.md, distribution)."
+[[ $asset == "omastorm-engine-$machine-unknown-linux-gnu" ]] \
+  || die "Pin asset $asset does not match architecture $machine"
 
 data_home=${XDG_DATA_HOME:-$HOME/.local/share}
 dest_dir=$data_home/omastorm/bin


### PR DESCRIPTION
ARM Omarchy currently clones the plugin but cannot start its engine because installation is restricted to x86_64. This adds native aarch64 release packaging and installer selection for an independently pinned ARM asset.

- Select `release.pin` on x86_64 and `release-aarch64.pin` on ARM; reject mismatched CPU assets before downloading.
- Build native release assets, checksums, and candidate pins without modifying committed pins before publication.
- Add GitHub Actions builds on native x86_64 and ARM runners, with Rust tests and installation/bootstrap checks for the actual binaries.
- Cover both pin selections, missing ARM pins, unsupported CPUs, and wrong-architecture pins locally.

Draft for #4: the ARM asset must be published and downloaded back for checksum verification before adding its real pin and advertising ARM in the README. Engine sources match `engine-0.1.1`; publication can add the ARM asset to that release without replacing x86_64. An Asahi desktop check remains outstanding. The workflow uploads candidates only and has read-only repository permissions.

Validation: `bash scripts/check.sh` passed all checks, including the packaged x86_64 release candidate install/hello/stop path. `bash scripts/build-engine-release.sh`, candidate SHA256 verification, shell syntax checks, and `git diff --check` passed. Native ARM validation runs in this PR workflow. No shader, sampling, camera, or UI changes; GPU rendering/captures were not needed.
