### PR TITLE
Add ARM64 engine release packaging and architecture-aware installation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -262,9 +262,14 @@ reviewed with Wes the same day. Everything below is decided.
   `~/.local/share/omastorm/bin`). A dest whose sha256 already matches is
   left alone. Otherwise it copies `OMASTORM_ENGINE_ASSET` or curl-fetches
   the pinned URL (`OMASTORM_ENGINE_URL` overrides), verifies the committed
-  hash, and temp-and-renames. A mismatch is refused. `aarch64` is named
-  and deferred. A missing GitHub asset names the publish step and the
-  checkout build. `ensure` still replaces a stale daemon by self-hash.
+  hash, and temp-and-renames. A mismatch is refused. A missing GitHub asset
+  names the publish step and the checkout build. `ensure` still replaces a
+  stale daemon by self-hash.
+  ARM64 packaging uses the same flow with `omastorm-engine-aarch64-unknown-linux-gnu`
+  and a separate `engine/release-aarch64.pin`. The native release builder
+  selects the host's asset and pin; the installer selects by `uname -m` and
+  refuses a pin for another architecture. Until the ARM64 asset is published
+  and pinned, it gives source-build instructions. No speculative hash ships.
 - `run.sh --ensure` uses `target/debug/omastorm-engine` when that file is
   executable (ordinary development, no fetch). Otherwise it runs the
   installer and execs the installed binary's `ensure`. Ordinary

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ in your Omarchy theme.
 
 Omarchy 4 on x86_64.
 
+ARM64 (`aarch64`) can run a native source build (see below). Prebuilt ARM64
+installation requires a published engine asset pinned in
+`engine/release-aarch64.pin`; until that pin ships, the installer explains
+how to build locally instead of trying to run an x86_64 binary.
+
 ```sh
 omarchy plugin add https://github.com/wesleygrimes/omastorm --enable
 ```
@@ -61,6 +66,20 @@ bash ~/.config/omarchy/plugins/com.omastorm.radar/scripts/install-launcher.sh
 ```
 
 Update with `omarchy plugin update com.omastorm.radar`.
+
+### ARM64 source installation
+
+Install the plugin as above, then, with Rust 1.89+ and a C compiler available:
+
+```sh
+cd ~/.config/omarchy/plugins/com.omastorm.radar
+bash scripts/setup-fixture.sh
+bash scripts/cargo.sh build --locked
+bash run.sh --ensure
+```
+
+The plugin automatically uses this native engine on subsequent launches.
+Repeat the build after updating the plugin to pick up engine changes.
 
 ## Use
 

--- a/engine/README.md
+++ b/engine/README.md
@@ -9,10 +9,25 @@ build --locked`. Run `bash run.sh` thereafter; launch builds offline, ensures a
 shared daemon exists, and starts Quickshell. Rust 1.89+ is required for a
 checkout build. Plugin installs use `scripts/install-engine.sh` and the pin
 in `engine/release.pin` instead of Rust; `bash scripts/build-engine-release.sh`
-produces the x86_64 asset under `target/dist/` and does not publish it
-(the pinned release holds the current file).
+produces a native x86_64 or aarch64 asset under `target/dist/` and does not
+publish it (the pinned release holds the current file).
 `scripts/cargo.sh` uses Cargo on PATH or, if present, an isolated
 `.tools/{cargo,rustup}` toolchain. No Python runs at launch.
+
+### Native engine releases
+
+Run `bash scripts/build-engine-release.sh` on Linux x86_64 or ARM64 after
+fetching the build dependencies and fixture data. It explicitly targets the
+Rust host and emits `omastorm-engine-<host>` plus `SHA256SUMS`. If both native
+assets are collected in `target/dist/`, the checksum manifest covers both.
+Cross-compilation is not configured by this script.
+
+`--write-pin` prepares the host's pin: `engine/release.pin` for x86_64,
+`engine/release-aarch64.pin` for ARM64. It never overwrites the other
+architecture's pin. Publish the exact asset on the named upstream engine
+release before committing its pin. The installer checks both the architecture
+in the asset name and its SHA256. An unpublished ARM64 pin is intentionally
+absent; source builds work while an upstream ARM64 release is being prepared.
 
 The engine embeds `data/fixture.json` and `data/sites.json` and nothing
 archived. `fixture.json` is the frame template (product, palette, bounds,

--- a/scripts/build-engine-release.sh
+++ b/scripts/build-engine-release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Build the x86_64-unknown-linux-gnu GitHub Release asset and SHA256SUMS
-# under target/dist/. Pass --write-pin to copy the hash into engine/release.pin
+# Build the native Linux x86_64 or aarch64 GitHub Release asset and SHA256SUMS
+# under target/dist/. Pass --write-pin to copy the hash into the host's pin
 # after a successful build. Does not publish, tag, or push.
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -15,14 +15,19 @@ if ! command -v rustc >/dev/null && [[ -x .tools/cargo/bin/rustc ]]; then
   export PATH="$CARGO_HOME/bin:$PATH"
 fi
 host=$(rustc -vV | awk '/^host:/{print $2}')
-[[ $host == x86_64-unknown-linux-gnu ]] || die "This script builds the x86_64-unknown-linux-gnu asset (host is $host)."
+case $host in
+  x86_64-unknown-linux-gnu) pin=engine/release.pin ;;
+  aarch64-unknown-linux-gnu) pin=engine/release-aarch64.pin ;;
+  *) die "Unsupported release host: $host (use native Linux x86_64 or aarch64)." ;;
+esac
 
-bash scripts/cargo.sh build --release --locked --offline
-src=target/release/omastorm-engine
+# Explicit target keeps Cargo configuration from selecting another architecture.
+bash scripts/cargo.sh build --release --locked --offline --target "$host"
+src=target/$host/release/omastorm-engine
 [[ -x $src ]] || die "cargo did not produce $src"
 
 mkdir -p target/dist
-asset=omastorm-engine-x86_64-unknown-linux-gnu
+asset=omastorm-engine-$host
 dest=target/dist/$asset
 cp -- "$src" "$dest"
 strip --strip-unneeded -- "$dest"
@@ -30,11 +35,10 @@ chmod 755 -- "$dest"
 
 sum=$(sha256sum -- "$dest" | awk '{print $1}')
 # sha256sum -c format, names as they appear on the Release.
-(cd target/dist && sha256sum -- "$asset" > SHA256SUMS)
+(cd target/dist && sha256sum -- omastorm-engine-*-unknown-linux-gnu > SHA256SUMS)
 printf '%s  %s\n' "$sum" "$dest"
 
 version=$(awk -F'"' '/^version = /{print $2; exit}' engine/Cargo.toml)
-pin=engine/release.pin
 if (( write_pin )); then
   cat > "$pin" <<PIN
 # Pinned GitHub Release for the engine binary (DESIGN.md, distribution).

--- a/scripts/check-engine-install.sh
+++ b/scripts/check-engine-install.sh
@@ -16,12 +16,14 @@ trap 'rm -rf "$scratch"' EXIT
 export XDG_DATA_HOME="$scratch/data" XDG_CACHE_HOME="$scratch/cache" XDG_RUNTIME_DIR="$scratch/runtime"
 mkdir -p "$XDG_RUNTIME_DIR"
 debug=$PWD/target/debug/omastorm-engine
+machine=$(uname -m)
+export OMASTORM_ENGINE_MACHINE=$machine
 sum=$(sha256sum -- "$debug" | awk '{print $1}')
 pin=$scratch/release.pin
 cat > "$pin" <<PIN
 tag=engine-test
 repo=wesleygrimes/omastorm
-asset=omastorm-engine-x86_64-unknown-linux-gnu
+asset=omastorm-engine-$machine-unknown-linux-gnu
 sha256=$sum
 PIN
 export OMASTORM_ENGINE_PIN=$pin
@@ -58,11 +60,36 @@ chmod 755 -- "$dest"
 OMASTORM_ENGINE_ASSET="$debug" bash scripts/install-engine.sh
 [[ $(sha256sum -- "$dest" | awk '{print $1}') == "$sum" ]] || fail 'Stale dest was not replaced'
 
-# aarch64 is named, not fetched.
-if OMASTORM_ENGINE_MACHINE=aarch64 bash scripts/install-engine.sh 2>"$scratch/arch.err"; then
-  fail 'Installer accepted aarch64'
+# Both architectures select and verify their own asset. These are installer
+# fixtures, not cross-compiled executables; only the native debug engine runs.
+for arch in x86_64 aarch64; do
+  arch_pin=$scratch/$arch.pin
+  sed "s/^asset=.*/asset=omastorm-engine-$arch-unknown-linux-gnu/" "$pin" > "$arch_pin"
+  rm -f "$dest"
+  OMASTORM_ENGINE_MACHINE=$arch OMASTORM_ENGINE_PIN=$arch_pin OMASTORM_ENGINE_ASSET=$debug bash scripts/install-engine.sh
+  [[ $(sha256sum -- "$dest" | awk '{print $1}') == "$sum" ]] || fail "$arch install did not match"
+  if OMASTORM_ENGINE_MACHINE=$arch OMASTORM_ENGINE_PIN=$arch_pin OMASTORM_ENGINE_ASSET="$scratch/bogus" bash scripts/install-engine.sh 2>"$scratch/current.err"; then
+    : # Already current: no asset read.
+  else
+    fail "$arch current install was not skipped"
+  fi
+  printf 'stale' > "$dest"
+  if OMASTORM_ENGINE_MACHINE=$arch OMASTORM_ENGINE_PIN=$arch_pin OMASTORM_ENGINE_ASSET="$scratch/bogus" bash scripts/install-engine.sh 2>"$scratch/mismatch.err"; then
+    fail "$arch accepted a substituted asset"
+  fi
+  rg -q 'sha256 mismatch' "$scratch/mismatch.err" || fail "$arch mismatch error unclear"
+  [[ $(cat "$dest") == stale ]] || fail "$arch mismatch replaced existing engine"
+done
+
+# Refuse a pin for the wrong architecture before using even a current dest.
+if OMASTORM_ENGINE_MACHINE=aarch64 OMASTORM_ENGINE_PIN=$scratch/x86_64.pin bash scripts/install-engine.sh 2>"$scratch/arch.err"; then
+  fail 'Installer accepted an x86_64 asset on aarch64'
 fi
-rg -q 'aarch64 is deferred' "$scratch/arch.err" || fail "Arch error was unclear: $(cat "$scratch/arch.err")"
+rg -q 'does not match architecture' "$scratch/arch.err" || fail 'Wrong-architecture error was unclear'
+if OMASTORM_ENGINE_MACHINE=riscv64 bash scripts/install-engine.sh 2>"$scratch/arch.err"; then
+  fail 'Installer accepted an unsupported architecture'
+fi
+rg -q 'Unsupported engine architecture: riscv64' "$scratch/arch.err" || fail "Arch error was unclear: $(cat "$scratch/arch.err")"
 
 # Checkout --ensure uses the debug engine and does not write the data home.
 rm -rf "$XDG_DATA_HOME"
@@ -80,30 +107,47 @@ git archive HEAD | tar -x -C "$clone"
 mkdir -p "$clone/scripts" "$clone/engine"
 cp -- run.sh "$clone/run.sh"
 cp -- scripts/install-engine.sh "$clone/scripts/install-engine.sh"
-install -D -m 644 "$pin" "$clone/engine/release.pin"
+# Exercise default pin selection separately from the explicit pin override.
+install -D -m 644 "$scratch/aarch64.pin" "$clone/engine/release-aarch64.pin"
+install -D -m 644 "$scratch/x86_64.pin" "$clone/engine/release.pin"
+for arch in x86_64 aarch64; do
+  rm -f "$dest"
+  (cd "$clone" && env -u OMASTORM_ENGINE_PIN OMASTORM_ENGINE_MACHINE=$arch OMASTORM_ENGINE_ASSET=$debug bash scripts/install-engine.sh)
+  [[ -x $dest ]] || fail "$arch default pin did not install"
+done
+mv "$clone/engine/release-aarch64.pin" "$clone/engine/release-aarch64.pin.saved"
+if (cd "$clone" && env -u OMASTORM_ENGINE_PIN OMASTORM_ENGINE_MACHINE=aarch64 bash scripts/install-engine.sh) 2>"$scratch/missing.err"; then
+  fail 'Installer accepted a missing ARM64 pin'
+fi
+rg -q 'No pinned aarch64 engine release' "$scratch/missing.err" || fail 'Missing ARM64 pin error was unclear'
+rg -q 'cargo.sh build --locked' "$scratch/missing.err" || fail 'Missing ARM64 pin omitted source-build guidance'
+mv "$clone/engine/release-aarch64.pin.saved" "$clone/engine/release-aarch64.pin"
 rm -rf "$clone/target"
-export OMASTORM_ENGINE_ASSET=$debug OMASTORM_ENGINE_PIN=$clone/engine/release.pin
+export OMASTORM_ENGINE_ASSET=$debug OMASTORM_ENGINE_PIN=$pin
 (cd "$clone" && bash run.sh --ensure)
 [[ -x $dest ]] || fail 'Clone --ensure did not install the engine'
 timeout 2 socat -t0.2 - "UNIX-CONNECT:$XDG_RUNTIME_DIR/omastorm/engine.sock" < /dev/null | rg -q '"type":"hello"' \
   || fail 'Clone --ensure did not produce a hello'
 "$dest" stop >/dev/null
 
-# Committed pin, if present, is well formed; the dist asset must match when it exists.
-if [[ -f engine/release.pin ]]; then
-  committed=$(awk -F= '/^sha256=/{print $2}' engine/release.pin)
-  [[ $committed =~ ^[a-f0-9]{64}$ ]] || fail 'Committed pin sha256 is not 64 lowercase hex digits'
-  dist=target/dist/omastorm-engine-x86_64-unknown-linux-gnu
+# Every committed pin is well formed; its dist asset must match when present.
+for arch in x86_64 aarch64; do
+  committed_pin=engine/release.pin
+  [[ $arch == aarch64 ]] && committed_pin=engine/release-aarch64.pin
+  [[ -f $committed_pin ]] || continue
+  committed=$(awk -F= '/^sha256=/{print $2}' "$committed_pin")
+  [[ $committed =~ ^[a-f0-9]{64}$ ]] || fail "$committed_pin sha256 is not 64 lowercase hex digits"
+  dist=target/dist/omastorm-engine-$arch-unknown-linux-gnu
   if [[ -f $dist ]]; then
     [[ $(sha256sum -- "$dist" | awk '{print $1}') == "$committed" ]] \
-      || fail "$dist does not match engine/release.pin"
+      || fail "$dist does not match $committed_pin"
     unset OMASTORM_ENGINE_PIN
-    export OMASTORM_ENGINE_ASSET=$dist OMASTORM_ENGINE_PIN=$PWD/engine/release.pin
+    export OMASTORM_ENGINE_ASSET=$dist OMASTORM_ENGINE_PIN=$PWD/$committed_pin OMASTORM_ENGINE_MACHINE=$arch
     rm -f "$dest"
     bash scripts/install-engine.sh
     [[ $(sha256sum -- "$dest" | awk '{print $1}') == "$committed" ]] \
       || fail 'Committed-pin install did not match'
   fi
-fi
+done
 
 echo 'Engine install: pin verify, mismatch refuse, dest install, skip current, replace stale, arch, checkout --ensure, clone --ensure PASS'

--- a/scripts/install-engine.sh
+++ b/scripts/install-engine.sh
@@ -8,8 +8,15 @@ cd "$(dirname "$0")/.."
 
 die() { printf '%s\n' "$@" >&2; exit 1; }
 
-pin_file=${OMASTORM_ENGINE_PIN:-engine/release.pin}
-[[ -f $pin_file ]] || die "Omastorm engine pin missing: $pin_file"
+machine=${OMASTORM_ENGINE_MACHINE:-$(uname -m)}
+case $machine in
+  x86_64) default_pin=engine/release.pin ;;
+  aarch64) default_pin=engine/release-aarch64.pin ;;
+  *) die "Unsupported engine architecture: $machine (supported: x86_64, aarch64)." ;;
+esac
+pin_file=${OMASTORM_ENGINE_PIN:-$default_pin}
+[[ -f $pin_file ]] || die "No pinned $machine engine release: $pin_file" \
+  "From this checkout with Rust 1.89+: bash scripts/setup-fixture.sh && bash scripts/cargo.sh build --locked && bash run.sh --ensure"
 tag= repo= asset= sha256=
 while IFS= read -r line || [[ -n $line ]]; do
   [[ $line =~ ^[[:space:]]*(#|$) ]] && continue
@@ -23,8 +30,8 @@ done < "$pin_file"
 [[ -n $tag && -n $repo && -n $asset && -n $sha256 ]] || die "Incomplete pin in $pin_file"
 [[ $sha256 =~ ^[a-f0-9]{64}$ ]] || die "Pin sha256 in $pin_file is not 64 lowercase hex digits"
 
-machine=${OMASTORM_ENGINE_MACHINE:-$(uname -m)}
-[[ $machine == x86_64 ]] || die "No $machine engine asset yet (aarch64 is deferred; see DESIGN.md, distribution)."
+expected_asset=omastorm-engine-$machine-unknown-linux-gnu
+[[ $asset == "$expected_asset" ]] || die "Engine asset $asset does not match architecture $machine (expected $expected_asset)."
 
 data_home=${XDG_DATA_HOME:-$HOME/.local/share}
 dest_dir=$data_home/omastorm/bin


### PR DESCRIPTION
Love the plugin! I'm running on a mac though and so the x86 build does not work for me, I was able to get it working with some help from codex by just targeting arm, figured I'd share the fix with others. Below is the PR.

On an ARM64 Omarchy installation, opening Omastorm reports that the radar engine is unavailable. Bootstrap currently rejects `aarch64` because only the x86_64 release is supported. A native build works on my machine.

This adds native ARM64 release packaging and selects the engine pin by architecture. x86_64 keeps `engine/release.pin`; ARM64 uses `engine/release-aarch64.pin`. The installer rejects an asset named for another architecture and retains checksum verification, skipping an already-current engine, and atomic replacement. The release builder explicitly targets its native Linux host, updates only that host's pin, and includes both assets in `SHA256SUMS` when present.

The README documents the working ARM64 source-install path. Until an ARM64 release is pinned, the installer provides those build commands.

**Release step still needed:** publish `omastorm-engine-aarch64-unknown-linux-gnu` on the upstream engine release, then commit the generated ARM64 pin. This change deliberately does not commit a checksum for an unpublished asset or change the existing x86_64 pin. Automatic ARM64 binary installation becomes available after that step.

Validation on Linux ARM64:

- `bash scripts/check.sh`: all checks passed, including formatting, Clippy, Rust tests, installer/bootstrap checks, and the standard UI checks.
- Built and stripped the native ARM64 release, verified its checksum manifest, and installed the actual binary through a temporary pin and data directory.
- Verified `--write-pin` leaves the x86_64 pin unchanged.
- Installer fixtures cover both architectures, missing ARM64 pins, wrong-architecture pins, unsupported machines, and checksum rejection. A native x86_64 release build was not run.