### PR TITLE
Hand the view on screen to HookEcho

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -374,6 +374,33 @@ reviewed with Wes the same day. Everything below is decided.
   camera path per theme on the archived fixture, stills at home for the
   treatment table (`scripts/capture-demo.sh`, `scripts/capture-readme.sh`).
 
+### HookEcho hand-off as built (2026-09-08)
+
+- Omastorm stays the quick native radar view and hands a view to a fuller
+  viewer rather than growing into one. `Shift+O` and a HOOKECHO control in
+  the controls row build HookEcho's documented deep link,
+  `hookecho://goto/SITE,lon,lat,zoom[,time]` (`docs/technical-reference.md`
+  in `d4vid87/hookecho`; `parse_goto` in `crates/hookecho/src/app.rs`), from
+  the station on screen, the map centre to four decimals, and the zoom as
+  `log2(worldPixels / 256)`, HookEcho's camera being `1 / (256 · 2^zoom)`
+  world units per pixel. The scan time travels only when the frame shown is
+  not the live head (archived, or stepped back), because HookEcho seeks to
+  a named instant and goes live without one. No product or tilt travels:
+  reflectivity is both sides' default, and an absent field leaves the
+  recipient's own setting alone by HookEcho's contract.
+- Launch is a short `sh -c`: `hookecho` on PATH first (HookEcho hands a
+  link to its running instance itself), else `xdg-open` when
+  `xdg-mime query default x-scheme-handler/hookecho` names a handler, else
+  exit 127 and `HOOKECHO NOT FOUND · PUT hookecho ON PATH` in the status
+  slot. `setsid -f` detaches the viewer from the window's process. Omarchy
+  is Arch and HookEcho has no AUR package (checked 2026-09-08), so the
+  README names the AppImage-on-PATH route. No config key: a PATH entry or
+  the scheme registration is the whole setup.
+- `scripts/check-keys.sh` puts a stand-in `hookecho` on PATH that records
+  its argument, asserts the link's shape and centre from the `hookecho`
+  status field, runs the action, and expects the stand-in to receive that
+  link and the slot to confirm.
+
 ## Technical foundation (decided 2026-09-05)
 
 **Architecture.** A headless engine does fetching, decoding, caching, and

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ feed cannot be reached, with cached frames kept.
 | `n` | Nearest site |
 | `Shift+L` | Lock the station |
 | `Shift+H` | Save the station as home |
+| `Shift+O` | Open this view in HookEcho |
 | `Space` | Loop the frames |
 | `[` `]` | Step a frame |
 | `Home` `End` | Oldest or newest frame |
@@ -94,6 +95,13 @@ feed cannot be reached, with cached frames kept.
 
 Measured returns under 5 dBZ (insects, birds, ground clutter on a clear day)
 are hidden by default and the legend says so; `w` shows them.
+
+`Shift+O`, or the HOOKECHO control, opens the station, map centre, and zoom
+on screen in [HookEcho](https://github.com/d4vid87/hookecho) through its
+`hookecho://goto/` link; a stepped-back or archived frame opens on that scan,
+a live view opens live. Omastorm runs `hookecho` from your PATH (an AppImage
+renamed or symlinked to `~/.local/bin/hookecho` works), or the desktop's
+registered `hookecho://` handler. Without either the status slot says so.
 
 ## Configuration
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -357,7 +357,8 @@ zoom_in = "+ ="
   `OMASTORM_WEAK` (`off` or a number), set by the capture scripts, outranks
   it. Anything else is reported like a bad `treatment` and leaves the default.
 - `[keys]`: one entry per action, laid over the defaults in `ui/Keys.js`:
-  `search` (`/ s`), `nearest` (`n`), `lock` (`Shift+L`), `home` (`Shift+H`), `pan_left`
+  `search` (`/ s`), `nearest` (`n`), `lock` (`Shift+L`), `home` (`Shift+H`),
+  `hookecho` (`Shift+O`), `pan_left`
   `pan_down` `pan_up` `pan_right` (`h j k l` and the arrows), `zoom_in`
   (`+ =`), `zoom_out` (`-`), `reset` (`0`), `previous_frame` (`[`),
   `next_frame` (`]`), `play` (`Space`), `oldest` (`Home`), `newest` (`End`),

--- a/scripts/check-keys.sh
+++ b/scripts/check-keys.sh
@@ -24,8 +24,14 @@ nearest = "s"
 bogus = "x"
 reset = 0
 TOML
+# A stand-in `hookecho` on PATH records the link the hand-off gives it, so
+# the check exercises the real launch without opening a viewer.
+mkdir -p "$check_dir/bin"
+printf '#!/bin/sh\nprintf %%s "$1" > "%s/link"\n' "$check_dir" > "$check_dir/bin/hookecho"
+chmod +x "$check_dir/bin/hookecho"
+rm -f "$check_dir/link"
 export QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME=basic QT_QUICK_BACKEND=rhi QSG_RHI_BACKEND=opengl
-OMASTORM_CONFIG="$check_dir/config.toml" OMASTORM_LOCATION="$check_dir/weather.json" bash run.sh > "$check_dir/log" 2>&1 &
+PATH="$check_dir/bin:$PATH" OMASTORM_CONFIG="$check_dir/config.toml" OMASTORM_LOCATION="$check_dir/weather.json" bash run.sh > "$check_dir/log" 2>&1 &
 pid=$!
 trap 'kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true' EXIT
 call() { quickshell ipc --pid "$pid" call keys "$@"; }
@@ -72,6 +78,16 @@ less "$(field span)" "$span" || fail "zoom_in did not narrow the span: $span -> 
 call run reset
 expect 'reset returns the span' "$span" "$(field span)"
 expect 'reset returns the centre' "$lat $lon" "$(field lat) $(field lon)"
+# Shift+O hands the view to HookEcho: the link names the station, the map
+# centre, and HookEcho's zoom, and the stand-in on PATH receives exactly it.
+link=$(field hookecho)
+[[ $link =~ ^hookecho://goto/KFCX,(-?[0-9]+\.[0-9]{4}),(-?[0-9]+\.[0-9]{4}),[0-9]+\.[0-9]$ ]] || fail "The HookEcho link has the wrong shape: $link"
+near() { awk -v a="$1" -v b="$2" 'BEGIN { d = a - b; exit !(d < .0011 && d > -.0011) }'; }
+near "${BASH_REMATCH[2]}" "$lat" && near "${BASH_REMATCH[1]}" "$lon" || fail "The link does not carry the map centre $lat $lon: $link"
+call run hookecho
+for attempt in {1..50}; do [[ -f "$check_dir/link" ]] && break; sleep .1; done
+expect 'The stand-in received the link' "$link" "$(cat "$check_dir/link")"
+expect 'The status slot says so' 'HOOKECHO · OPENING KFCX' "$(field notice)"
 call run pixels
 expect '1 picks Pixels' PIXELS "$(field treatment)"
 call run weak

--- a/ui/Keys.js
+++ b/ui/Keys.js
@@ -6,13 +6,16 @@
 // sequence parses (an empty string means it does not).
 
 // Bindings are Qt key sequences separated by spaces: "h Left" binds both.
-// Shift+L is the lock because lowercase l pans; the digit keys pick a
-// treatment; `w` toggles the weak-return floor; `?` opens the sheet; Escape with nothing open closes the window.
+// Shift+L is the lock because lowercase l pans; Shift+H and Shift+O act
+// outside the window (the config file, another application); the digit
+// keys pick a treatment; `w` toggles the weak-return floor; `?` opens the
+// sheet; Escape with nothing open closes the window.
 var ACTIONS = [
     { id: "search", keys: "/ s" },
     { id: "nearest", keys: "n" },
     { id: "lock", keys: "Shift+L" },
     { id: "home", keys: "Shift+H" },
+    { id: "hookecho", keys: "Shift+O" },
     { id: "pan_left", keys: "h Left" },
     { id: "pan_down", keys: "j Down" },
     { id: "pan_up", keys: "k Up" },
@@ -41,7 +44,8 @@ var ROWS = [
      { label: "save site as home", actions: ["home"] },
      { label: "pan", actions: ["pan_left", "pan_down", "pan_up", "pan_right"] },
      { label: "zoom", actions: ["zoom_in", "zoom_out"] },
-     { label: "reset to home view", actions: ["reset"] }],
+     { label: "reset to home view", actions: ["reset"] },
+     { label: "open this view in HookEcho", actions: ["hookecho"] }],
     [{ label: "previous frame", actions: ["previous_frame"] },
      { label: "next frame", actions: ["next_frame"] },
      { label: "play / pause", actions: ["play"] },

--- a/ui/RadarWindow.qml
+++ b/ui/RadarWindow.qml
@@ -196,6 +196,7 @@ Item {
         case "nearest": nearest(); break;
         case "lock": toggleLock(); break;
         case "home": setHome(); break;
+        case "hookecho": openHookEcho(); break;
         case "pan_left": map.pan(-1, 0); break;
         case "pan_right": map.pan(1, 0); break;
         case "pan_up": map.pan(0, -1); break;
@@ -226,7 +227,7 @@ Item {
         function status(): string {
             return JSON.stringify({sheet: sheet.open, menu: treatmentMenu.opened, treatment: app.treatment, weakFloor: app.weakFloor === null ? "off" : app.weakFloor, error: app.configError,
                                    span: Math.round(map.span * 10) / 10, lat: Math.round(map.centerLat * 1000) / 1000, lon: Math.round(map.centerLon * 1000) / 1000,
-                                   home: app.homeSite, homeSource: app.homeSource, site: app.siteId, locked: app.locked});
+                                   home: app.homeSite, homeSource: app.homeSource, site: app.siteId, locked: app.locked, hookecho: app.hookechoLink, notice: app.notice});
         }
     }
     // Site navigation (DESIGN.md, markers): the lock pins the station against
@@ -245,6 +246,34 @@ Item {
         config.setHome(siteId);
         notice = "HOME · " + siteId + " SAVED TO CONFIG.TOML";
         noticeTimer.restart();
+    }
+    // Shift+O or the HOOKECHO control hands this view to HookEcho through
+    // its documented deep link (DESIGN.md, HookEcho hand-off as built):
+    // `hookecho://goto/SITE,lon,lat,zoom[,time]`. The centre is the map's;
+    // HookEcho's zoom is log2 of the world's width in 256 px tiles, so the
+    // span converts through the map's worldPixels. The scan time travels
+    // only when the frame on screen is not the live head, so a live view
+    // opens live and an archived or stepped-back one opens on that scan.
+    readonly property string hookechoLink: !scan ? ""
+        : "hookecho://goto/" + siteId + "," + map.centerLon.toFixed(4) + "," + map.centerLat.toFixed(4) + "," + Math.log2(map.worldPixels / 256).toFixed(1)
+          + (scan.scanTime && !(state.source === "live" && newestShown) ? "," + scan.scanTime : "")
+    function openHookEcho() {
+        if (!hookechoLink || hookecho.running) return;
+        hookecho.command = ["sh", "-c",
+            'command -v hookecho >/dev/null 2>&1 && exec setsid -f hookecho "$1"; ' +
+            '[ -n "$(xdg-mime query default x-scheme-handler/hookecho 2>/dev/null)" ] && exec setsid -f xdg-open "$1"; exit 127',
+            "omastorm", hookechoLink];
+        hookecho.running = true;
+    }
+    // The launch is a short shell: HookEcho on PATH, else the desktop's
+    // registered hookecho:// handler, else 127. setsid detaches the viewer
+    // so it outlives this window; only the shell's exit is awaited.
+    Process {
+        id: hookecho
+        onExited: code => {
+            app.notice = code === 0 ? "HOOKECHO · OPENING " + (app.siteId || "THIS VIEW") : "HOOKECHO NOT FOUND · PUT hookecho ON PATH";
+            noticeTimer.restart();
+        }
     }
     function nearest() {
         var s = map.nearest();
@@ -706,6 +735,7 @@ Item {
                 GlyphButton { glyph: app.locked ? "lock" : "follow"; selected: app.locked; enabled: !!app.state; onClicked: app.toggleLock() }
                 // Save the station on screen as home; away once it is the home.
                 Control { text: win.compact ? "⌂" : "⌂ HOME"; visible: !!app.state && app.siteId !== "" && app.siteId !== app.homeSite; onClicked: app.setHome() }
+                Control { text: win.compact ? "↗" : "↗ HOOKECHO"; visible: !!app.scan; onClicked: app.run("hookecho") }
                 Item { Layout.fillWidth: true }
                 // The treatment chip (DESIGN.md, treatment control): one
                 // low-emphasis control naming the treatment; click opens the


### PR DESCRIPTION
Omastorm stays the quick native radar view; this adds one action that hands
the view on screen to a fuller viewer instead of growing one here.

`Shift+O`, or a HOOKECHO control after HOME in the controls row, builds
HookEcho's documented deep link and opens it:

    hookecho://goto/SITE,lon,lat,zoom[,time]

- `SITE` is the station on screen (empty before one is selected; HookEcho
  accepts that and just flies to the view).
- `lon,lat` is the map centre to four decimals.
- `zoom` is `log2(worldPixels / 256)`: HookEcho's camera is
  `1 / (256 · 2^zoom)` world units per pixel, so the ground scale carries
  over.
- `time` (RFC 3339, the frame's `scanTime`) travels only when the frame on
  screen is not the live head. HookEcho seeks to a named instant and goes
  live without one, so a live view opens live and an archived or
  stepped-back frame opens on that scan.

No product or tilt travels: reflectivity is both sides' default, and an
absent field leaves the recipient's own setting alone by HookEcho's
contract (`parse_goto` in `crates/hookecho/src/app.rs`,
`docs/technical-reference.md`, checked against `d4vid87/hookecho` at
b06bbb0).

Launch is a short `sh -c`: `hookecho` on PATH first (HookEcho hands a link
to its running instance itself), else `xdg-open` when
`xdg-mime query default x-scheme-handler/hookecho` names a handler, else
exit 127 and `HOOKECHO NOT FOUND · PUT hookecho ON PATH` in the status
slot. `setsid -f` detaches the viewer from the window. No config key: a
PATH entry or the scheme registration is the whole setup, and the README
names the AppImage-on-PATH route since Omarchy is Arch and HookEcho has no
AUR package.

`scripts/check-keys.sh` puts a stand-in `hookecho` on PATH that records
its argument, asserts the link's shape and centre from the new `hookecho`
status field, runs the action, and expects the stand-in to receive that
link and the slot to confirm. `docs/protocol.md` lists the `hookecho`
action for `[keys]`; DESIGN.md has the as-built note.

Verified on Omarchy (esper, Arch): `scripts/check.sh` all 15 steps green
on the branch. With HookEcho v0.12.0-beta.2 (AppImage, sha256-verified
against the release, symlinked as `hookecho` on PATH): a live view opened
live (`opening link hookecho://goto/KFWS,-97.3565,32.7078,8.2`, `live
stream started for KFWS`), a stepped-back frame opened on its scan
(`opening link …8.2,2026-09-08T14:16:35Z`, no live-stream line), and with
`hookecho` off PATH and no scheme handler the status slot read
`HOOKECHO NOT FOUND · PUT hookecho ON PATH`.

Context: this is step 0 of https://github.com/joshuaswarren/omarchy-chase,
which keeps chase-specific glue (install, GPS, session, status) out of
Omastorm and out of the viewers.
