### PR TITLE
Manage prerequisites and jobs with mise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ data/derived/
 # Site media, cut from docs/media by the commands in site/README.md
 site/take.mp4
 site/take-poster.png
+
+# mise per-machine overrides
+mise.local.toml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,26 +33,32 @@ not start the step after it in the same session.
 
 ## Run and verify
 
+`mise.toml` declares the tools (Rust, shellcheck, jq, ripgrep, gh) and the
+jobs. `mise install` once, then `mise run` lists them:
+
 ```sh
-bash scripts/setup-fixture.sh                # once per fresh checkout: geography to embed, archived volume for tests
-bash run.sh                                  # launch (needs GPU Quickshell); starts lean, goes live on the home station
-OMASTORM_ARCHIVE=data/raw/KTLX20130520_201643_V06.gz bash run.sh   # start on the archived scan instead (offline)
-OMASTORM_STYLE=STIPPLE bash run.sh           # PIXELS | GLYPHS | STIPPLE
-target/debug/omastorm-engine stop            # end the shared daemon by hand (a launch replaces a stale build itself)
-bash scripts/check.sh                        # the regression suite against a scratch daemon (~1 min); --gpu adds the rendering test
-bash scripts/cargo.sh test --offline --locked -- --ignored rendering   # GPU pixel check on its own
+mise run setup                               # once per fresh checkout: desktop package check, fixture download, cargo fetch, debug build
+mise run run                                 # launch (needs GPU Quickshell); starts lean, goes live on the home station
+OMASTORM_ARCHIVE=data/raw/KTLX20130520_201643_V06.gz mise run run   # start on the archived scan instead (offline)
+OMASTORM_STYLE=STIPPLE mise run run          # PIXELS | GLYPHS | STIPPLE
+mise run stop                                # end the shared daemon by hand (a launch replaces a stale build itself)
+mise run lint                                # rustfmt check, clippy, shellcheck
+mise run test                                # Rust unit and socket tests
+mise run check                               # the integration suite against a scratch daemon (~1 min); --gpu adds the rendering test
+mise run release                             # native release binary under target/dist/; never publishes
 bash scripts/capture-review.sh               # offscreen captures to review/ (ImageMagick; ignored output)
 omarchy plugin validate .                    # the manifest check the shell and the marketplace apply
 ```
 
-Install and launch need Rust and Quickshell only.
+Install and launch for users need Quickshell only; the engine arrives as a
+pinned release asset. Only a checkout needs mise.
 
 The rendering test and the captures need a working desktop OpenGL
 context (offscreen platform, RHI OpenGL). A sandbox without a GPU cannot run
 them; say so in the handoff rather than skipping silently. The software Qt
 Quick backend is unsupported by design.
 
-Run `bash scripts/check.sh` before every commit; it never touches the shared
+Run `mise run check` before every commit; it never touches the shared
 daemon. After any shader, sampling, or camera change, add `--gpu` for the
 ignored rendering test (`engine/tests/rendering.rs`, described in
 `engine/README.md`) and run the capture review; the test replays the shader's
@@ -64,9 +70,10 @@ with `bash scripts/build-shader.sh` whenever `ui/shaders/radar.frag` or
 
 - Arch Linux with Omarchy. Quickshell 0.3.1. Nothing in install, launch, or
   the checks uses Python.
-- Rust is a checkout-local toolchain under `.tools/` (ignored), not a system
-  install. Always go through `bash scripts/cargo.sh ...`; bare `cargo` is not on
-  PATH.
+- Rust comes from mise (`mise.toml` pins the version), not a system install.
+  Bare `cargo` is on PATH only inside `mise run` or `mise exec`; the scripts
+  go through `bash scripts/cargo.sh ...`, which finds it either way. An older
+  checkout-local toolchain under `.tools/` (ignored) is no longer used.
 - Go is installed but is not used by this project.
 - Omarchy theme files: `~/.local/state/omarchy/current/theme/{colors,shell}.toml`
   (a real directory, not a symlink). Theme-change hooks run from

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ mise lint                                    # rustfmt check, clippy, shellcheck
 mise test                                    # Rust unit and socket tests
 mise check                                   # the integration suite against a scratch daemon (~1 min); --gpu adds the rendering test
 mise build-release                           # optimized, stripped engine under target/dist/ as a release candidate; publishes nothing
-mise release                                 # from a clean main: publish engine-<version> as an immutable GitHub Release and write the pin (--dry-run first)
+mise release                                 # publish engine-<version> from a clean main and write the pin; steps in engine/README.md, "Cutting an engine release"
 bash scripts/capture-review.sh               # offscreen captures to review/ (ImageMagick; ignored output)
 omarchy plugin validate .                    # the manifest check the shell and the marketplace apply
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,18 +34,19 @@ not start the step after it in the same session.
 ## Run and verify
 
 `mise.toml` declares the tools (Rust, shellcheck, jq, ripgrep, gh) and the
-jobs. `mise install` once, then `mise run` lists them:
+jobs. `mise install` once, then `mise tasks` lists them; each runs as
+`mise <job>`:
 
 ```sh
-mise run setup                               # once per fresh checkout: desktop package check, fixture download, cargo fetch, debug build
-mise run run                                 # launch (needs GPU Quickshell); starts lean, goes live on the home station
-OMASTORM_ARCHIVE=data/raw/KTLX20130520_201643_V06.gz mise run run   # start on the archived scan instead (offline)
-OMASTORM_STYLE=STIPPLE mise run run          # PIXELS | GLYPHS | STIPPLE
-mise run stop                                # end the shared daemon by hand (a launch replaces a stale build itself)
-mise run lint                                # rustfmt check, clippy, shellcheck
-mise run test                                # Rust unit and socket tests
-mise run check                               # the integration suite against a scratch daemon (~1 min); --gpu adds the rendering test
-mise run release                             # native release binary under target/dist/; never publishes
+mise setup                                   # once per fresh checkout: desktop package check, fixture download, cargo fetch, debug build
+mise start                                   # launch (needs GPU Quickshell); starts lean, goes live on the home station
+OMASTORM_ARCHIVE=data/raw/KTLX20130520_201643_V06.gz mise start   # start on the archived scan instead (offline)
+OMASTORM_STYLE=STIPPLE mise start            # PIXELS | GLYPHS | STIPPLE
+mise stop                                    # end the shared daemon by hand (a launch replaces a stale build itself)
+mise lint                                    # rustfmt check, clippy, shellcheck
+mise test                                    # Rust unit and socket tests
+mise check                                   # the integration suite against a scratch daemon (~1 min); --gpu adds the rendering test
+mise release                                 # native release binary under target/dist/; never publishes
 bash scripts/capture-review.sh               # offscreen captures to review/ (ImageMagick; ignored output)
 omarchy plugin validate .                    # the manifest check the shell and the marketplace apply
 ```
@@ -58,7 +59,7 @@ context (offscreen platform, RHI OpenGL). A sandbox without a GPU cannot run
 them; say so in the handoff rather than skipping silently. The software Qt
 Quick backend is unsupported by design.
 
-Run `mise run check` before every commit; it never touches the shared
+Run `mise check` before every commit; it never touches the shared
 daemon. After any shader, sampling, or camera change, add `--gpu` for the
 ignored rendering test (`engine/tests/rendering.rs`, described in
 `engine/README.md`) and run the capture review; the test replays the shader's
@@ -71,7 +72,7 @@ with `bash scripts/build-shader.sh` whenever `ui/shaders/radar.frag` or
 - Arch Linux with Omarchy. Quickshell 0.3.1. Nothing in install, launch, or
   the checks uses Python.
 - Rust comes from mise (`mise.toml` pins the version), not a system install.
-  Bare `cargo` is on PATH only inside `mise run` or `mise exec`; the scripts
+  Bare `cargo` is on PATH only inside `mise <job>` or `mise exec`; the scripts
   go through `bash scripts/cargo.sh ...`, which finds it either way. An older
   checkout-local toolchain under `.tools/` (ignored) is no longer used.
 - Go is installed but is not used by this project.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ mise lint                                    # rustfmt check, clippy, shellcheck
 mise test                                    # Rust unit and socket tests
 mise check                                   # the integration suite against a scratch daemon (~1 min); --gpu adds the rendering test
 mise build-release                           # optimized, stripped engine under target/dist/ as a release candidate; publishes nothing
+mise release                                 # from a clean main: publish engine-<version> as an immutable GitHub Release and write the pin (--dry-run first)
 bash scripts/capture-review.sh               # offscreen captures to review/ (ImageMagick; ignored output)
 omarchy plugin validate .                    # the manifest check the shell and the marketplace apply
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ mise stop                                    # end the shared daemon by hand (a 
 mise lint                                    # rustfmt check, clippy, shellcheck
 mise test                                    # Rust unit and socket tests
 mise check                                   # the integration suite against a scratch daemon (~1 min); --gpu adds the rendering test
-mise release                                 # native release binary under target/dist/; never publishes
+mise build-release                           # optimized, stripped engine under target/dist/ as a release candidate; publishes nothing
 bash scripts/capture-review.sh               # offscreen captures to review/ (ImageMagick; ignored output)
 omarchy plugin validate .                    # the manifest check the shell and the marketplace apply
 ```

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -255,8 +255,12 @@ reviewed with Wes the same day. Everything below is decided.
 - `scripts/build-engine-release.sh` builds `--release --locked --offline`
   on `x86_64-unknown-linux-gnu`, copies and strips the binary into
   `target/dist/`, writes `SHA256SUMS`, and with `--write-pin` updates the
-  pin. It does not tag, publish, or push. Release order: publish that
-  exact file as Release `engine-0.1.0`, then the pin may reach origin.
+  pin. It does not tag, publish, or push. Releases on the repo are immutable
+  (enabled 2026-09-08): assets and tag lock at publish, cannot be changed or
+  deleted, and a botched release burns its version. Release order: create
+  `engine-<version>` as a draft with that exact file and `SHA256SUMS`, publish
+  it, run `mise check` so the pinned-asset step verifies what was actually
+  published, then the pin may reach origin.
 - `scripts/install-engine.sh` installs under
   `$XDG_DATA_HOME/omastorm/bin/omastorm-engine` (default
   `~/.local/share/omastorm/bin`). A dest whose sha256 already matches is

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -257,10 +257,12 @@ reviewed with Wes the same day. Everything below is decided.
   `target/dist/`, writes `SHA256SUMS`, and with `--write-pin` updates the
   pin. It does not tag, publish, or push. Releases on the repo are immutable
   (enabled 2026-09-08): assets and tag lock at publish, cannot be changed or
-  deleted, and a botched release burns its version. Release order: create
-  `engine-<version>` as a draft with that exact file and `SHA256SUMS`, publish
-  it, run `mise check` so the pinned-asset step verifies what was actually
-  published, then the pin may reach origin.
+  deleted, and a botched release burns its version. Release order, done by
+  `mise release` (`scripts/release-engine.sh`) from a clean `main` even with
+  origin: build the candidate, require its hello to name this version and the
+  UI's protocol, create `engine-<version>` as a draft with that exact file
+  and `SHA256SUMS`, publish, fetch the published asset back and require it to
+  hash to the candidate, write the pin. Then `mise check` and the pin commit.
 - `scripts/install-engine.sh` installs under
   `$XDG_DATA_HOME/omastorm/bin/omastorm-engine` (default
   `~/.local/share/omastorm/bin`). A dest whose sha256 already matches is

--- a/README.md
+++ b/README.md
@@ -146,6 +146,6 @@ and [data/README.md](data/README.md).
 
 ```sh
 mise install
-mise run setup
-mise run run
+mise setup
+mise start
 ```

--- a/README.md
+++ b/README.md
@@ -140,12 +140,12 @@ Code: MIT, see [LICENSE](LICENSE).
 
 ## Developing
 
-A checkout needs Rust 1.89+ and Quickshell with OpenGL. See
-[AGENTS.md](AGENTS.md), [engine/README.md](engine/README.md), and
-[data/README.md](data/README.md).
+A checkout needs [mise](https://mise.jdx.dev) for the toolchain and Quickshell
+with OpenGL. See [AGENTS.md](AGENTS.md), [engine/README.md](engine/README.md),
+and [data/README.md](data/README.md).
 
 ```sh
-bash scripts/setup-fixture.sh
-bash scripts/cargo.sh build --locked
-bash run.sh
+mise install
+mise run setup
+mise run run
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ in your Omarchy theme.
   the antenna turns. Stale data says it is stale.
 - **Every site.** Pan the map and it follows the nearest station, or search by
   id, city, or state.
-- **Timeline.** The last 60 scans per station, cached locally. Play, step, scrub.
+- **Timeline.** Up to 60 scans per station, cached locally. Play, step, scrub.
 - **Three treatments.** Glyphs, Pixels, and Stipple sample the same gate and
   paint the cell differently.
 - **Native.** Colors, font, and spacing come from the active Omarchy theme and
@@ -71,9 +71,10 @@ frame. Closing the window returns to home.
 
 In the window, drag to pan and scroll to zoom. The map follows the nearest
 station as you pan unless you lock it. A station you arrive at fetches its last
-dozen scans, so there is a loop to play within a few seconds. The status slot shows the age of the
-frame on screen: LIVE, STALE after ten minutes, UNAVAILABLE or OFFLINE when the
-feed cannot be reached, with cached frames kept.
+dozen scans, so there is a loop to play within a few seconds; the cache then
+grows to 60 as new scans arrive. The status slot shows the age of the frame on
+screen: LIVE, STALE after ten minutes, UNAVAILABLE or OFFLINE when the feed
+cannot be reached, with cached frames kept.
 
 | Key | Action |
 | --- | --- |
@@ -98,8 +99,8 @@ are hidden by default and the legend says so; `w` shows them.
 ## Configuration
 
 `~/.config/omastorm/config.toml` is optional. Without `home_site` the home is
-the station nearest Omarchy's weather location. `Shift+H`, or the HOME
-button, saves the station on screen as `home_site`.
+the station nearest the location Omarchy's weather panel is set to. `Shift+H`,
+or the HOME button, saves the station on screen as `home_site`.
 
 ```toml
 home_site = "KTLX"   # a station id; omit to use Omarchy's weather location
@@ -113,7 +114,23 @@ zoom_in = "+ ="
 ```
 
 A bad value is named in the status slot and that setting stays on its default.
-The action names and key syntax are in [docs/protocol.md](docs/protocol.md).
+Every action name, the key syntax, and what each setting does are in
+[docs/configuration.md](docs/configuration.md).
+
+## Troubleshooting
+
+The engine runs as one shared daemon per login. Its log is
+`$XDG_RUNTIME_DIR/omastorm/engine.log` (usually `/run/user/<uid>/omastorm/`).
+If the popover says the engine could not be installed, the download or its
+sha256 check failed; the reason is in `bootstrap.log` in the same directory,
+and opening the popover again retries. To restart the engine by hand:
+
+```sh
+~/.local/share/omastorm/bin/omastorm-engine stop
+```
+
+The next popover or window starts it again. Please attach both logs to a
+[bug report](https://github.com/wesleygrimes/omastorm/issues).
 
 ## Remove
 
@@ -121,6 +138,7 @@ The action names and key syntax are in [docs/protocol.md](docs/protocol.md).
 omarchy plugin remove com.omastorm.radar
 ~/.local/share/omastorm/bin/omastorm-engine stop
 rm -rf ~/.local/share/omastorm ~/.cache/omastorm
+rm -rf ~/.config/omastorm                            # your config.toml; keep it to reinstall later
 rm -f ~/.local/share/applications/omastorm.desktop   # if you added the launcher entry
 ```
 
@@ -140,12 +158,15 @@ Code: MIT, see [LICENSE](LICENSE).
 
 ## Developing
 
-A checkout needs [mise](https://mise.jdx.dev) for the toolchain and Quickshell
-with OpenGL. See [AGENTS.md](AGENTS.md), [engine/README.md](engine/README.md),
-and [data/README.md](data/README.md).
+A checkout needs [mise](https://mise.jdx.dev) for the toolchain, plus the
+desktop packages `quickshell` (with OpenGL), `qt6-shadertools`, and `socat`;
+`mise setup` names any that are missing. See [AGENTS.md](AGENTS.md) for the
+jobs and conventions, [engine/README.md](engine/README.md) for the engine, and
+[data/README.md](data/README.md) for the fixture data.
 
 ```sh
-mise install
-mise setup
-mise start
+mise install    # the pinned toolchain
+mise setup      # fixture download, cargo fetch, debug build
+mise start      # launch the window
+mise check      # the regression suite; run before every commit
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,59 @@
+# Configuration
+
+The UI reads and watches `~/.config/omastorm/config.toml` for the home
+station, follow flag, treatment, weak-return floor, and key map. Home and
+follow settings become engine commands described in [protocol.md](protocol.md);
+treatment and the weak-return floor stay in the UI. The
+[README](../README.md#configuration) has the short version.
+
+`OMASTORM_CONFIG` names another file for checks and captures; a missing file
+is no configuration.
+
+```toml
+home_site = "KJAX"   # a station id from hello.sites
+follow = true        # the map centre picks the station; omit to leave the shared flag alone
+treatment = "GLYPHS" # PIXELS, GLYPHS, or STIPPLE at launch; Glyphs when omitted
+weak_floor = 5       # dBZ; measured returns under it draw nothing; false draws them all; 5 when omitted
+
+[keys]               # Qt key sequences, several separated by spaces; "" unbinds
+pan_left = "h Left"
+zoom_in = "+ ="
+```
+
+- `home_site`: when the engine's state first arrives (and again after a
+  reconnect, since a restarted daemon starts with no station) the
+  window puts the camera on this station's home view and sends
+  `select_site`; an id outside the table shows the engine's rejection in the
+  status slot. Without it, the home is the station nearest Omarchy's own
+  location when `~/.local/state/omarchy/settings/weather.json` (`name`,
+  `latitude`, `longitude`, written by the shell's weather panel) has one,
+  selected the same way; the header says `HOME · NEAR <name>` or
+  `HOME · CONFIG.TOML` while the home station is shown. With neither, the
+  window shows whatever the daemon is on, the whole network with no station
+  at first, until a pan hands off or a station is chosen. `OMASTORM_LOCATION` names
+  another location file; when `OMASTORM_CONFIG` is set the machine's own
+  location file is not read unless `OMASTORM_LOCATION` names one, so a check
+  or capture with its own config is isolated from the desktop's settings.
+- `follow`: sent as the `follow` command at the same moments when it differs
+  from the state. An edit to the file applies to the open window at once.
+- `treatment`: the treatment at launch and whenever the file changes; the
+  keys and the chip change it afterwards without writing the file.
+  `OMASTORM_STYLE`, set by the capture scripts, outranks it.
+- `weak_floor`: the weak-return floor (DESIGN.md, weak-return floor) at
+  launch and whenever the file changes: a number in the product's units, or
+  `false` to draw every measured return; 5 when omitted. The `weak` key
+  toggles between off and this floor afterwards without writing the file.
+  `OMASTORM_WEAK` (`off` or a number), set by the capture scripts, outranks
+  it. Anything else is reported like a bad `treatment` and leaves the default.
+- `[keys]`: one entry per action, laid over the defaults in `ui/Keys.js`:
+  `search` (`/ s`), `nearest` (`n`), `lock` (`Shift+L`), `home` (`Shift+H`), `pan_left`
+  `pan_down` `pan_up` `pan_right` (`h j k l` and the arrows), `zoom_in`
+  (`+ =`), `zoom_out` (`-`), `reset` (`0`), `previous_frame` (`[`),
+  `next_frame` (`]`), `play` (`Space`), `oldest` (`Home`), `newest` (`End`),
+  `pixels` `glyphs` `stipple` (`1 2 3`), `weak` (`w`), `help` (`?`), `close`
+  (`Escape`).
+  A value that is not a quoted string, a sequence Qt cannot parse, an
+  unknown action, or a key another action already holds leaves that action
+  on its default and is named in the status slot (`[KEYS] ZOOM_IN = "FOO":
+  FOO IS NOT A KEY`, with a count of any further mistakes) until the file is
+  fixed; a bad `treatment` or `weak_floor` is reported the same way.

--- a/docs/media/README.md
+++ b/docs/media/README.md
@@ -24,7 +24,10 @@ time and is not a latency measurement.
 - `window-live.png`, `popover.png`: live KTLX with the actual scan time.
 
 Publish with `gh release upload v0.1.0 --clobber docs/media/*` and keep the
-README URLs pointing at that tag.
+README URLs pointing at that tag. `v0.1.0` predates the repo's immutable
+releases setting (2026-09-08), so its assets still accept a re-upload; a
+release made after that locks its assets at publish, so media for a new tag
+has to be uploaded while the release is still a draft.
 
 Radar: NOAA NEXRAD. Map: © OpenStreetMap contributors
 ([ODbL](https://opendatacommons.org/licenses/odbl/1-0/)); Natural Earth, public

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -19,7 +19,7 @@ travel over this protocol; they go to the GPU as texture files.
 `hello` is sent once on connect, followed immediately by a full `state`.
 
 ```json
-{"type":"hello","v":1,"engine":"0.1.0",
+{"type":"hello","v":1,"engine":"0.1.1",
  "sites":[{"id":"KTLX","name":"Oklahoma City","state":"OK",
            "lat":35.33306,"lon":-97.27748,"altM":388.0}]}
 ```
@@ -314,62 +314,14 @@ catalogued frame while the poller replays the current volume's lowest cut
 from the bucket, so a picture arrives within seconds and the next volume
 paints live.
 
-## Configuration (phase 4)
+## Configuration
 
-`~/.config/omastorm/config.toml`, read and watched by the UI (`ui/Config.qml`);
-the engine receives the relevant values as commands. `OMASTORM_CONFIG` names
-another file for checks and captures; a missing file is no configuration.
+`~/.config/omastorm/config.toml` is read and watched by the UI, never by the
+engine. Home and follow settings become `select_site` and `follow` commands;
+treatment and the weak-return floor stay in the UI. Keys, values, and error
+reporting are in [configuration.md](configuration.md).
 
-```toml
-home_site = "KJAX"   # a station id from hello.sites
-follow = true        # the map centre picks the station; omit to leave the shared flag alone
-treatment = "GLYPHS" # PIXELS, GLYPHS, or STIPPLE at launch; Glyphs when omitted
-weak_floor = 5       # dBZ; measured returns under it draw nothing; false draws them all; 5 when omitted
-
-[keys]               # Qt key sequences, several separated by spaces; "" unbinds
-pan_left = "h Left"
-zoom_in = "+ ="
-```
-
-- `home_site`: when the engine's state first arrives (and again after a
-  reconnect, since a restarted daemon starts with no station) the
-  window puts the camera on this station's home view and sends
-  `select_site`; an id outside the table shows the engine's rejection in the
-  status slot. Without it, the home is the station nearest Omarchy's own
-  location when `~/.local/state/omarchy/settings/weather.json` (`name`,
-  `latitude`, `longitude`, written by the shell's weather panel) has one,
-  selected the same way; the header says `HOME · NEAR <name>` or
-  `HOME · CONFIG.TOML` while the home station is shown. With neither, the
-  window shows whatever the daemon is on, the whole network with no station
-  at first, until a pan hands off or a station is chosen. `OMASTORM_LOCATION` names
-  another location file; when `OMASTORM_CONFIG` is set the machine's own
-  location file is not read unless `OMASTORM_LOCATION` names one, so a check
-  or capture with its own config is isolated from the desktop's settings.
-- `follow`: sent as the `follow` command at the same moments when it differs
-  from the state. An edit to the file applies to the open window at once.
-- `treatment`: the treatment at launch and whenever the file changes; the
-  keys and the chip change it afterwards without writing the file.
-  `OMASTORM_STYLE`, set by the capture scripts, outranks it.
-- `weak_floor`: the weak-return floor (DESIGN.md, weak-return floor) at
-  launch and whenever the file changes: a number in the product's units, or
-  `false` to draw every measured return; 5 when omitted. The `weak` key
-  toggles between off and this floor afterwards without writing the file.
-  `OMASTORM_WEAK` (`off` or a number), set by the capture scripts, outranks
-  it. Anything else is reported like a bad `treatment` and leaves the default.
-- `[keys]`: one entry per action, laid over the defaults in `ui/Keys.js`:
-  `search` (`/ s`), `nearest` (`n`), `lock` (`Shift+L`), `home` (`Shift+H`), `pan_left`
-  `pan_down` `pan_up` `pan_right` (`h j k l` and the arrows), `zoom_in`
-  (`+ =`), `zoom_out` (`-`), `reset` (`0`), `previous_frame` (`[`),
-  `next_frame` (`]`), `play` (`Space`), `oldest` (`Home`), `newest` (`End`),
-  `pixels` `glyphs` `stipple` (`1 2 3`), `weak` (`w`), `help` (`?`), `close`
-  (`Escape`).
-  A value that is not a quoted string, a sequence Qt cannot parse, an
-  unknown action, or a key another action already holds leaves that action
-  on its default and is named in the status slot (`[KEYS] ZOOM_IN = "FOO":
-  FOO IS NOT A KEY`, with a count of any further mistakes) until the file is
-  fixed; a bad `treatment` or `weak_floor` is reported the same way.
-
-## Phase 1b implementation notes
+## Implementation notes
 
 Plugin clients (phase 5): wire protocol v1 is unchanged. The shell session
 keeps a status connection; each visible popover and expanded window has its
@@ -390,5 +342,5 @@ can be selected live, and its catalogued frames are the timeline; an unsupported
 with an `error` event while retaining the frame. Follow/lock flags are
 shared, and `view_center` hands off under them. `ageSeconds` is actual age at
 snapshot time, re-judged once a second while live.
-On disconnect the phase 1 UI hides radar and retries; on an unknown version it
+On disconnect the UI hides radar and retries; on an unknown version it
 hides radar and latches the error until relaunch.

--- a/engine/README.md
+++ b/engine/README.md
@@ -8,7 +8,7 @@ when one is missing), fetches crates, and builds the debug engine. Run
 `mise start` thereafter; launch builds offline, ensures a shared daemon
 exists, and starts Quickshell. Rust 1.89 is the minimum; `mise.toml` pins the
 version a checkout uses. Plugin installs use `scripts/install-engine.sh` and
-the pin in `engine/release.pin` instead of Rust; `mise release` produces
+the pin in `engine/release.pin` instead of Rust; `mise build-release` produces
 the x86_64 asset under `target/dist/` and does not publish it (the pinned
 release holds the current file). `scripts/cargo.sh` uses Cargo on PATH, which
 mise provides. No Python runs at launch.

--- a/engine/README.md
+++ b/engine/README.md
@@ -1,18 +1,17 @@
 # Engine
 
-From a fresh checkout, run `bash scripts/setup-fixture.sh` once to download
-the Natural Earth files the binary embeds and the archived Level II volume the
-tests and `OMASTORM_ARCHIVE` read (`data/raw/`
-is ignored; `build.rs` stops with a message naming the script when one is
-missing), then explicitly fetch/build dependencies with `bash scripts/cargo.sh
-build --locked`. Run `bash run.sh` thereafter; launch builds offline, ensures a
-shared daemon exists, and starts Quickshell. Rust 1.89+ is required for a
-checkout build. Plugin installs use `scripts/install-engine.sh` and the pin
-in `engine/release.pin` instead of Rust; `bash scripts/build-engine-release.sh`
-produces the x86_64 asset under `target/dist/` and does not publish it
-(the pinned release holds the current file).
-`scripts/cargo.sh` uses Cargo on PATH or, if present, an isolated
-`.tools/{cargo,rustup}` toolchain. No Python runs at launch.
+From a fresh checkout, `mise install` gets the pinned Rust toolchain and
+`mise run setup` downloads the Natural Earth files the binary embeds and the
+archived Level II volume the tests and `OMASTORM_ARCHIVE` read (`data/raw/`
+is ignored; `build.rs` stops with a message naming `scripts/setup-fixture.sh`
+when one is missing), fetches crates, and builds the debug engine. Run
+`mise run run` thereafter; launch builds offline, ensures a shared daemon
+exists, and starts Quickshell. Rust 1.89 is the minimum; `mise.toml` pins the
+version a checkout uses. Plugin installs use `scripts/install-engine.sh` and
+the pin in `engine/release.pin` instead of Rust; `mise run release` produces
+the x86_64 asset under `target/dist/` and does not publish it (the pinned
+release holds the current file). `scripts/cargo.sh` uses Cargo on PATH, which
+mise provides. No Python runs at launch.
 
 The engine embeds `data/fixture.json` and `data/sites.json` and nothing
 archived. `fixture.json` is the frame template (product, palette, bounds,
@@ -219,10 +218,10 @@ Source URL, date, and caveats are embedded and exposed with hello.
 Checks (socket and GPU checks need desktop access outside the sandbox):
 
 ```sh
-bash scripts/cargo.sh test --offline --locked
+mise run test                                # unit and socket tests
+mise run lint                                # rustfmt check, clippy, shellcheck
+mise run check                               # everything below plus the other UI checks, against a scratch daemon
 bash scripts/cargo.sh test --offline --locked -- --ignored rendering   # GPU, needs Quickshell
-bash scripts/cargo.sh clippy --offline --locked --all-targets -- -D warnings
-bash scripts/cargo.sh fmt --check
 bash scripts/check-engine-ui.sh
 bash scripts/check-map-tiles.sh              # delayed zoom tiles and ranked labels
 bash scripts/check-map-sites.sh              # site overlay geometry, layout, and pan

--- a/engine/README.md
+++ b/engine/README.md
@@ -333,3 +333,35 @@ The UI check verifies socket metadata, invalid JSON, a rejection that sits
 beside state until the client's next command (including one answered by the
 real daemon), the azimuth lookup and tile path rules, a `tiles_needed` round
 trip, and rejecting an unknown protocol version.
+
+## Cutting an engine release
+
+Releases on the repository are immutable: once published, the tag and the
+assets cannot be changed or deleted, and a mistake burns that version number.
+`mise release` does every step below except the version bump and the final
+commit, and refuses to start unless the preconditions hold.
+
+1. Bump `version` in `engine/Cargo.toml`. Run `mise build` so `Cargo.lock`
+   follows, then commit both and push to `main`. The release names the commit
+   everyone has, so `main` must be clean and even with `origin/main`.
+2. `mise release --dry-run`. This builds the optimized, stripped candidate
+   under `target/dist/`, starts it under a scratch runtime, and requires its
+   hello to report the new version and the protocol version `ui/Engine.qml`
+   accepts. It prints the tag, the sha256, and the release notes (the commits
+   since the pinned release that touch `engine/src`, `build.rs`, `tests`,
+   `engine/Cargo.toml`, or `Cargo.lock`), then stops.
+3. `mise release`. Same checks, then it asks. On yes it creates
+   `engine-<version>` as a draft with the binary and `SHA256SUMS`, publishes
+   it, fetches the published asset back from GitHub, and requires it to hash
+   to the candidate. Only then does it write `engine/release.pin`. `--yes`
+   skips the prompt.
+4. `mise check`. The install step installs from the new pin for real and
+   checks the published binary's hash, protocol, and version.
+5. Commit the pin bump (`engine/release.pin` is the only change) and push.
+   Users receive the new engine on their next `omarchy plugin update`.
+
+If the script refuses, the message names the precondition: wrong branch,
+dirty tree, behind or ahead of origin, a version already pinned, tagged, or
+released, or a lock file that disagrees with `Cargo.toml`. If the published
+asset does not hash to the candidate, the pin is not written; bump the version
+and publish again rather than trying to repair the release.

--- a/engine/README.md
+++ b/engine/README.md
@@ -1,14 +1,14 @@
 # Engine
 
 From a fresh checkout, `mise install` gets the pinned Rust toolchain and
-`mise run setup` downloads the Natural Earth files the binary embeds and the
+`mise setup` downloads the Natural Earth files the binary embeds and the
 archived Level II volume the tests and `OMASTORM_ARCHIVE` read (`data/raw/`
 is ignored; `build.rs` stops with a message naming `scripts/setup-fixture.sh`
 when one is missing), fetches crates, and builds the debug engine. Run
-`mise run run` thereafter; launch builds offline, ensures a shared daemon
+`mise start` thereafter; launch builds offline, ensures a shared daemon
 exists, and starts Quickshell. Rust 1.89 is the minimum; `mise.toml` pins the
 version a checkout uses. Plugin installs use `scripts/install-engine.sh` and
-the pin in `engine/release.pin` instead of Rust; `mise run release` produces
+the pin in `engine/release.pin` instead of Rust; `mise release` produces
 the x86_64 asset under `target/dist/` and does not publish it (the pinned
 release holds the current file). `scripts/cargo.sh` uses Cargo on PATH, which
 mise provides. No Python runs at launch.
@@ -218,9 +218,9 @@ Source URL, date, and caveats are embedded and exposed with hello.
 Checks (socket and GPU checks need desktop access outside the sandbox):
 
 ```sh
-mise run test                                # unit and socket tests
-mise run lint                                # rustfmt check, clippy, shellcheck
-mise run check                               # everything below plus the other UI checks, against a scratch daemon
+mise test                                    # unit and socket tests
+mise lint                                    # rustfmt check, clippy, shellcheck
+mise check                                   # everything below plus the other UI checks, against a scratch daemon
 bash scripts/cargo.sh test --offline --locked -- --ignored rendering   # GPU, needs Quickshell
 bash scripts/check-engine-ui.sh
 bash scripts/check-map-tiles.sh              # delayed zoom tiles and ranked labels

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,7 @@
-# Repo prerequisites and the jobs. `mise install` gets the tools; `mise run`
-# lists the jobs. Quickshell, Qt Shader Tools, socat, ImageMagick, and ffmpeg
-# are desktop packages outside mise; `mise run setup` checks for them.
+# Repo prerequisites and the jobs. `mise install` gets the tools; `mise tasks`
+# lists the jobs and each runs as `mise <job>`. Quickshell, Qt Shader Tools,
+# socat, ImageMagick, and ffmpeg are desktop packages outside mise; `mise setup`
+# checks for them.
 
 [tools]
 rust = { version = "1.98", profile = "minimal", components = "rustfmt,clippy" }
@@ -29,7 +30,7 @@ run = [
   "shellcheck -x run.sh scripts/*.sh",
 ]
 
-[tasks.run]
+[tasks.start]
 description = "Launch the window against the shared debug daemon (needs GPU Quickshell)"
 run = "bash run.sh"
 

--- a/mise.toml
+++ b/mise.toml
@@ -46,8 +46,8 @@ run = "cargo test --offline --locked"
 description = "Integration suite against a scratch daemon; run before every commit (--gpu adds the rendering test)"
 run = "bash scripts/check.sh"
 
-[tasks.release]
-description = "Native release binary and SHA256SUMS under target/dist/; never publishes (--write-pin updates engine/release.pin)"
+[tasks.build-release]
+description = "Optimized, stripped engine and SHA256SUMS under target/dist/ as a release candidate; publishes nothing (--write-pin updates engine/release.pin)"
 run = "bash scripts/build-engine-release.sh"
 
 [tasks.clean]

--- a/mise.toml
+++ b/mise.toml
@@ -50,6 +50,10 @@ run = "bash scripts/check.sh"
 description = "Optimized, stripped engine and SHA256SUMS under target/dist/ as a release candidate; publishes nothing (--write-pin updates engine/release.pin)"
 run = "bash scripts/build-engine-release.sh"
 
+[tasks.release]
+description = "Publish engine-<version> from main: candidate, draft release, publish, verify the published asset, write the pin (--dry-run, --yes)"
+run = "bash scripts/release-engine.sh"
+
 [tasks.clean]
 description = "Remove Cargo output and scratch runtime dirs"
 run = [

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,57 @@
+# Repo prerequisites and the jobs. `mise install` gets the tools; `mise run`
+# lists the jobs. Quickshell, Qt Shader Tools, socat, ImageMagick, and ffmpeg
+# are desktop packages outside mise; `mise run setup` checks for them.
+
+[tools]
+rust = { version = "1.98", profile = "minimal", components = "rustfmt,clippy" }
+shellcheck = "0.11"
+jq = "1.8"
+ripgrep = "15"
+gh = "2"
+
+[tasks.setup]
+description = "Desktop package check, fixture download, cargo fetch, debug build"
+run = "bash scripts/setup.sh"
+
+[tasks.build]
+description = "Debug engine"
+run = "cargo build --offline --locked"
+
+[tasks.format]
+description = "rustfmt, writing"
+run = "cargo fmt"
+
+[tasks.lint]
+description = "rustfmt check, clippy with warnings denied, shellcheck"
+run = [
+  "cargo fmt --check",
+  "cargo clippy --offline --locked --all-targets -- -D warnings",
+  "shellcheck -x run.sh scripts/*.sh",
+]
+
+[tasks.run]
+description = "Launch the window against the shared debug daemon (needs GPU Quickshell)"
+run = "bash run.sh"
+
+[tasks.stop]
+description = "End the shared debug daemon"
+run = "target/debug/omastorm-engine stop"
+
+[tasks.test]
+description = "Rust unit and socket tests"
+run = "cargo test --offline --locked"
+
+[tasks.check]
+description = "Integration suite against a scratch daemon; run before every commit (--gpu adds the rendering test)"
+run = "bash scripts/check.sh"
+
+[tasks.release]
+description = "Native release binary and SHA256SUMS under target/dist/; never publishes (--write-pin updates engine/release.pin)"
+run = "bash scripts/build-engine-release.sh"
+
+[tasks.clean]
+description = "Remove Cargo output and scratch runtime dirs"
+run = [
+  "cargo clean",
+  "rm -rf /tmp/omastorm-check.* /tmp/omastorm-theme.*",
+]

--- a/scripts/build-engine-release.sh
+++ b/scripts/build-engine-release.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Build the x86_64-unknown-linux-gnu GitHub Release asset and SHA256SUMS
-# under target/dist/. Pass --write-pin to copy the hash into engine/release.pin
+# under target/dist/ as a release candidate. It is not compared to the current
+# pin; a candidate is expected to differ from the published binary. Pass
+# --write-pin to copy its hash into engine/release.pin
 # after a successful build. Does not publish, tag, or push.
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -44,10 +46,4 @@ repo=wesleygrimes/omastorm
 asset=$asset
 sha256=$sum
 PIN
-fi
-
-if [[ -f $pin ]]; then
-  expected=$(awk -F= '/^sha256=/{print $2}' "$pin")
-  [[ $sum == "$expected" ]] || die "Built $dest ($sum) does not match $pin ($expected)." \
-    "Re-run with --write-pin only when preparing a new engine release."
 fi

--- a/scripts/capture-keys.sh
+++ b/scripts/capture-keys.sh
@@ -28,10 +28,13 @@ capture() { # name, delay ms, config, location, ipc steps...
   OMASTORM_CONFIG="$config" OMASTORM_LOCATION="$location" OMASTORM_WIDTH=960 OMASTORM_HEIGHT=680 \
     OMASTORM_CAPTURE_DELAY="$delay" OMASTORM_CAPTURE="$review/keys-$name.png" bash run.sh > /dev/null 2>&1 &
   pid=$!
-  for attempt in {1..100}; do quickshell ipc --pid "$pid" call keys status > /dev/null 2>&1 && break; sleep .1; done
+  for _ in {1..100}; do quickshell ipc --pid "$pid" call keys status > /dev/null 2>&1 && break; sleep .1; done
   sleep 4 # tiles and the replayed cut
-  local step
-  for step in "$@"; do quickshell ipc --pid "$pid" call keys $step; done
+  local step words
+  for step in "$@"; do
+    read -ra words <<< "$step"
+    quickshell ipc --pid "$pid" call keys "${words[@]}"
+  done
   wait "$pid"
   [[ -s "$review/keys-$name.png" ]] || { echo "No capture for $name" >&2; exit 1; }
   echo "captured $name · engine on $(timeout 2 socat -t0.2 - "UNIX-CONNECT:$sock" < /dev/null | sed -n 2p | grep -o '"site":{"id"[^}]*}')"

--- a/scripts/capture-loading.sh
+++ b/scripts/capture-loading.sh
@@ -31,14 +31,14 @@ capture() { # name, delay ms, env...
 # the real cache; ensure in run.sh finds it by build under XDG_RUNTIME_DIR.
 scratch=$(mktemp -d /tmp/omastorm-loading.XXXXXX)
 mkdir -p "$scratch/runtime" "$scratch/cache"
-XDG_RUNTIME_DIR="$scratch/runtime" XDG_CACHE_HOME="$scratch/cache" OMASTORM_ARCHIVE= target/debug/omastorm-engine serve > "$scratch/engine.log" 2>&1 &
+XDG_RUNTIME_DIR="$scratch/runtime" XDG_CACHE_HOME="$scratch/cache" OMASTORM_ARCHIVE='' target/debug/omastorm-engine serve > "$scratch/engine.log" 2>&1 &
 for _ in $(seq 100); do [[ -S "$scratch/runtime/omastorm/engine.sock" ]] && break; sleep .1; done
 [[ -S "$scratch/runtime/omastorm/engine.sock" ]] || { echo "Scratch daemon did not start" >&2; cat "$scratch/engine.log" >&2; exit 1; }
 capture none 2500 XDG_RUNTIME_DIR="$scratch/runtime" XDG_CACHE_HOME="$scratch/cache" OMASTORM_CONFIG="$none"
 capture before 1500 XDG_RUNTIME_DIR="$scratch/runtime" XDG_CACHE_HOME="$scratch/cache" OMASTORM_CONFIG="$config"
 capture after 20000 XDG_RUNTIME_DIR="$scratch/runtime" XDG_CACHE_HOME="$scratch/cache" OMASTORM_CONFIG="$config"
 grep -h "^Live\|^Ready" "$scratch/engine.log" | sed 's/^/  engine: /' | head -4
-kill $(jobs -p) 2>/dev/null || true
+jobs -p | xargs -r kill 2>/dev/null || true
 
 cd "$review"
 magick montage -label '%t' loading-none.png loading-before.png loading-after.png \

--- a/scripts/capture-picker.sh
+++ b/scripts/capture-picker.sh
@@ -25,10 +25,13 @@ capture() { # name, delay ms, ipc steps...
   OMASTORM_CONFIG="$scratch/home.toml" OMASTORM_WIDTH=960 OMASTORM_HEIGHT=680 \
     OMASTORM_CAPTURE_DELAY="$delay" OMASTORM_CAPTURE="$review/picker-$name.png" bash run.sh > /dev/null 2>&1 &
   pid=$!
-  for attempt in {1..100}; do quickshell ipc --pid "$pid" call picker status > /dev/null 2>&1 && break; sleep .1; done
+  for _ in {1..100}; do quickshell ipc --pid "$pid" call picker status > /dev/null 2>&1 && break; sleep .1; done
   sleep 4 # tiles and the replayed cut
-  local step
-  for step in "$@"; do quickshell ipc --pid "$pid" call picker $step; done
+  local step words
+  for step in "$@"; do
+    read -ra words <<< "$step"
+    quickshell ipc --pid "$pid" call picker "${words[@]}"
+  done
   wait "$pid"
   [[ -s "$review/picker-$name.png" ]] || { echo "No capture for $name" >&2; exit 1; }
   echo "captured $name · engine on $(timeout 2 socat -t0.2 - "UNIX-CONNECT:$sock" < /dev/null | sed -n 2p | grep -o '"site":{"id"[^}]*}')"

--- a/scripts/capture-popover.sh
+++ b/scripts/capture-popover.sh
@@ -19,7 +19,7 @@ quickshell -p ui/PopoverHarness.qml > "$scratch/ui.log" 2>&1 &
 pid=$!
 call() { quickshell ipc --pid "$pid" call popover "$@"; }
 ready=0
-for attempt in {1..120}; do
+for _ in {1..120}; do
   if call status 2>/dev/null | jq -e '.site == "KTLX" and .condition == "ok" and (.frame | contains("loading") | not)' >/dev/null 2>&1; then ready=1; break; fi
   sleep .5
 done
@@ -31,7 +31,7 @@ for treatment in GLYPHS PIXELS STIPPLE; do
   path="$PWD/review/popover-${treatment,,}.png"
   rm -f "$path"
   call capture "$path"
-  for attempt in {1..50}; do [[ -s $path ]] && break; sleep .1; done
+  for _ in {1..50}; do [[ -s $path ]] && break; sleep .1; done
   [[ -s $path ]] || exit 1
 done
 call status > review/popover-state.json

--- a/scripts/capture-states.sh
+++ b/scripts/capture-states.sh
@@ -57,7 +57,7 @@ daemon "$scratch/silent" env
 capture silent 75000 XDG_RUNTIME_DIR="$scratch/silent" XDG_CACHE_HOME="$scratch/cache" OMASTORM_CONFIG="$(config_for "$silent_site")"
 grep -h "^Live" "$scratch/offline/engine.log" "$scratch/silent/engine.log" | sed 's/^/  engine: /' | head -4
 pkill -f "^target/debug/omastorm-engine serve" -P $$ 2>/dev/null || true
-kill $(jobs -p) 2>/dev/null || true
+jobs -p | xargs -r kill 2>/dev/null || true
 
 # The harness shell (scripts/capture-harness.sh): the real UI files with
 # OMASTORM_STATE_OVERRIDE laid over every state.

--- a/scripts/check-bind.sh
+++ b/scripts/check-bind.sh
@@ -10,6 +10,7 @@ fail() { printf '%s\n' "$@" >&2; exit 1; }
 bind='o.bind("SUPER + SHIFT + R", "Omastorm", "omarchy shell shell toggle com.omastorm.radar '"'"'{}'"'"'")'
 rg -F -- "$bind" README.md >/dev/null \
   || fail "README.md does not name the documented o.bind line"
+# shellcheck disable=SC2088 # the literal path as the README prints it
 rg -F -- '~/.config/hypr/bindings.lua' README.md >/dev/null \
   || fail 'README.md does not name ~/.config/hypr/bindings.lua'
 rg -F -- 'omarchy plugin add https://github.com/wesleygrimes/omastorm --enable' README.md >/dev/null \

--- a/scripts/check-engine-install.sh
+++ b/scripts/check-engine-install.sh
@@ -3,8 +3,9 @@
 # mismatch, install under a scratch XDG_DATA_HOME, skip a current dest,
 # reject an unsupported machine, keep ordinary launch and a checkout
 # --ensure off the installer. Uses a scratch pin and the debug engine so
-# check.sh does not need a release rebuild. When target/dist matches the
-# committed pin, that asset is installed too.
+# check.sh does not need a release rebuild. The committed pin is then installed
+# for real and its asset must hash to the pin, speak the protocol the UI
+# accepts, and report the version its tag names.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -76,7 +77,8 @@ target/debug/omastorm-engine stop >/dev/null
 clone=$scratch/clone
 mkdir -p "$clone"
 git archive HEAD | tar -x -C "$clone"
-# Working tree: this check runs before the packaging commit is on HEAD.
+# The launcher and installer come from the working tree so the check covers
+# uncommitted changes to them; everything else is HEAD, as a clone would be.
 mkdir -p "$clone/scripts" "$clone/engine"
 cp -- run.sh "$clone/run.sh"
 cp -- scripts/install-engine.sh "$clone/scripts/install-engine.sh"
@@ -89,21 +91,41 @@ timeout 2 socat -t0.2 - "UNIX-CONNECT:$XDG_RUNTIME_DIR/omastorm/engine.sock" < /
   || fail 'Clone --ensure did not produce a hello'
 "$dest" stop >/dev/null
 
-# Committed pin, if present, is well formed; the dist asset must match when it exists.
-if [[ -f engine/release.pin ]]; then
-  committed=$(awk -F= '/^sha256=/{print $2}' engine/release.pin)
-  [[ $committed =~ ^[a-f0-9]{64}$ ]] || fail 'Committed pin sha256 is not 64 lowercase hex digits'
-  dist=target/dist/omastorm-engine-x86_64-unknown-linux-gnu
-  if [[ -f $dist ]]; then
-    [[ $(sha256sum -- "$dist" | awk '{print $1}') == "$committed" ]] \
-      || fail "$dist does not match engine/release.pin"
-    unset OMASTORM_ENGINE_PIN
-    export OMASTORM_ENGINE_ASSET=$dist OMASTORM_ENGINE_PIN=$PWD/engine/release.pin
-    rm -f "$dest"
-    bash scripts/install-engine.sh
-    [[ $(sha256sum -- "$dest" | awk '{print $1}') == "$committed" ]] \
-      || fail 'Committed-pin install did not match'
-  fi
+# The committed pin names what users get. Install from it for real: the
+# asset the pin names must exist on GitHub, hash to the pin, speak the
+# protocol version the UI accepts, and report the version its tag names.
+# The asset is fetched once into target/pinned/<sha256> and reused. When
+# GitHub is unreachable the step says so and passes; a checkout is correct
+# without the network, and the fetch is retried on the next run.
+committed=$(awk -F= '/^sha256=/{print $2}' engine/release.pin)
+tag=$(awk -F= '/^tag=/{print $2}' engine/release.pin)
+[[ $committed =~ ^[a-f0-9]{64}$ ]] || fail 'Committed pin sha256 is not 64 lowercase hex digits'
+[[ $tag =~ ^engine-([0-9]+\.[0-9]+\.[0-9]+)$ ]] || fail "Committed pin tag is not engine-<version>: $tag"
+pinned_version=${BASH_REMATCH[1]}
+ui_protocol=$(rg -o 'message\.v !== ([0-9]+)' -r '$1' ui/Engine.qml)
+[[ -n $ui_protocol ]] || fail 'Could not read the protocol version ui/Engine.qml accepts'
+cache=target/pinned/$committed
+unset OMASTORM_ENGINE_ASSET
+export OMASTORM_ENGINE_PIN=$PWD/engine/release.pin
+rm -f "$dest"
+if [[ -f $cache ]]; then
+  OMASTORM_ENGINE_ASSET=$cache bash scripts/install-engine.sh
+elif curl -fsI --max-time 5 https://github.com > /dev/null 2>&1; then
+  bash scripts/install-engine.sh
+  install -D -m 755 "$dest" "$cache"
+else
+  echo 'Committed pin: GitHub unreachable, the published asset was not verified this run.' >&2
+fi
+if [[ -x $dest ]]; then
+  [[ $(sha256sum -- "$dest" | awk '{print $1}') == "$committed" ]] || fail 'Pinned asset install did not match the pin'
+  "$dest" ensure
+  hello=$(timeout 2 socat -t0.2 - "UNIX-CONNECT:$XDG_RUNTIME_DIR/omastorm/engine.sock" < /dev/null | head -n1 || true)
+  "$dest" stop >/dev/null
+  rg -q '"type":"hello"' <<< "$hello" || fail 'Pinned asset did not produce a hello'
+  [[ $(jq -r .v <<< "$hello") == "$ui_protocol" ]] \
+    || fail "Pinned asset speaks protocol v$(jq -r .v <<< "$hello"); ui/Engine.qml accepts v$ui_protocol"
+  [[ $(jq -r .engine <<< "$hello") == "$pinned_version" ]] \
+    || fail "Pinned asset reports engine $(jq -r .engine <<< "$hello"); the pin names $tag"
 fi
 
-echo 'Engine install: pin verify, mismatch refuse, dest install, skip current, replace stale, arch, checkout --ensure, clone --ensure PASS'
+echo 'Engine install: pin verify, mismatch refuse, dest install, skip current, replace stale, arch, checkout --ensure, clone --ensure, pinned asset PASS'

--- a/scripts/check-keys.sh
+++ b/scripts/check-keys.sh
@@ -34,10 +34,10 @@ fail() { printf '%s\n' "$@" >&2; cat "$check_dir/log" >&2; exit 1; }
 expect() { [[ "$3" == "$2" ]] || fail "$1" "Expected: $2" "Actual:   $3"; }
 less() { awk -v a="$1" -v b="$2" 'BEGIN { exit !(a + 0 < b + 0) }'; }
 until_field() { # name, wanted
-  for attempt in {1..100}; do [[ $(field "$1") == "$2" ]] && return; sleep .1; done
+  for _ in {1..100}; do [[ $(field "$1") == "$2" ]] && return; sleep .1; done
   fail "$1 never became $2: $(call status)"
 }
-for attempt in {1..100}; do call status > /dev/null 2>&1 && break; sleep .1; done
+for _ in {1..100}; do call status > /dev/null 2>&1 && break; sleep .1; done
 call status > /dev/null || fail "The window's keys IPC never answered"
 
 # The table over the defaults: the good line applies, every mistake is
@@ -95,7 +95,7 @@ quickshell ipc --pid "$pid" call picker close
 # and the header follows the file through the watch.
 shown=$(field site)
 call run home
-for attempt in {1..50}; do grep -q "^home_site = \"$shown\"$" "$check_dir/config.toml" && break; sleep .1; done
+for _ in {1..50}; do grep -q "^home_site = \"$shown\"$" "$check_dir/config.toml" && break; sleep .1; done
 grep -q "^home_site = \"$shown\"$" "$check_dir/config.toml" || fail "Shift+H did not save home_site = \"$shown\"" "$(cat "$check_dir/config.toml")"
 [[ $(grep -n "^home_site\|^\[keys\]" "$check_dir/config.toml" | head -1) == *home_site* ]] || fail "home_site landed inside a table"
 until_field homeSource config

--- a/scripts/check-picker.sh
+++ b/scripts/check-picker.sh
@@ -17,10 +17,10 @@ trap 'kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true' EXIT
 call() { quickshell ipc --pid "$pid" call picker "$@"; }
 fail() { printf '%s\n' "$@" >&2; cat "$check_dir/log" >&2; exit 1; }
 expect() { [[ "$3" == "$2" ]] || fail "$1" "Expected: $2" "Actual:   $3"; }
-for attempt in {1..100}; do call status > /dev/null 2>&1 && break; sleep .1; done
+for _ in {1..100}; do call status > /dev/null 2>&1 && break; sleep .1; done
 call status > /dev/null || fail "The window's picker IPC never answered"
 call open ""
-for attempt in {1..50}; do [[ $(call matches) != '[]' ]] && break; sleep .1; done
+for _ in {1..50}; do [[ $(call matches) != '[]' ]] && break; sleep .1; done
 # The fixture's home view centres north-west of KTLX: KTLX first, the Norman pair next.
 m=$(call matches)
 [[ $m == '["KTLX","K'* && $m == *KOUN* && $m == *KCRI* ]] || fail "Empty query did not list the nearest stations first: $m"
@@ -51,7 +51,7 @@ expect 'Enter closes the picker' 'false' "$(call status | grep -o '"open":[a-z]*
 # The field must let go of the keyboard, or the next `/` types into it instead of reopening.
 expect 'Enter hands the keyboard back' 'false' "$(call status | grep -o '"focused":[a-z]*' | cut -d: -f2)"
 sock="$XDG_RUNTIME_DIR/omastorm/engine.sock"
-for attempt in {1..50}; do
+for _ in {1..50}; do
   site=$(timeout 2 socat -t0.2 - "UNIX-CONNECT:$sock" < /dev/null | sed -n 2p | grep -o '"site":{[^}]*}' || true)
   [[ $site == *"\"id\":\"$first\""* && $site == *'"locked":true'* ]] && break
   sleep .1

--- a/scripts/check-popover.sh
+++ b/scripts/check-popover.sh
@@ -23,7 +23,7 @@ status() { call status; }
 fail() { echo "$*" >&2; cat "$scratch/ui.log" >&2; exit 1; }
 until_status() {
   local filter=$1
-  for attempt in {1..100}; do
+  for _ in {1..100}; do
     status 2>/dev/null | jq -e "$filter" >/dev/null 2>&1 && return 0
     sleep .1
   done
@@ -46,7 +46,7 @@ until_status '.condition == "archived" and .text == "ARCHIVED"'
 call closeWindow
 call reopen
 call capture "$PWD/review/popover-archived.png"
-for attempt in {1..50}; do [[ -s review/popover-archived.png ]] && break; sleep .1; done
+for _ in {1..50}; do [[ -s review/popover-archived.png ]] && break; sleep .1; done
 sock="$XDG_RUNTIME_DIR/omastorm/engine.sock"
 tell() { printf '%s\n' "$@" | socat -t0.2 - "UNIX-CONNECT:$sock" >/dev/null; }
 # Two deterministic complete frames, using the archived fixture's metadata

--- a/scripts/check-theme.sh
+++ b/scripts/check-theme.sh
@@ -28,7 +28,7 @@ quickshell -p "$tmp/ui/shell.qml" > "$tmp/log" 2>&1 &
 pid=$!
 expect() {
     local actual=""
-    for attempt in {1..50}; do
+    for _ in {1..50}; do
         actual=$(quickshell ipc --pid "$pid" call check snapshot 2>/dev/null) || true
         if [[ "$actual" == "$1" ]]; then return; fi
         sleep .1

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -8,7 +8,7 @@
 # sampling, or camera change). The capture scripts are not here: run the
 # one whose picture the session changed.
 set -uo pipefail
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0")/.." || exit 1
 gpu=0
 [[ ${1:-} == --gpu ]] && gpu=1
 scratch=$(mktemp -d /tmp/omastorm-check.XXXXXX)

--- a/scripts/install-engine.sh
+++ b/scripts/install-engine.sh
@@ -10,7 +10,7 @@ die() { printf '%s\n' "$@" >&2; exit 1; }
 
 pin_file=${OMASTORM_ENGINE_PIN:-engine/release.pin}
 [[ -f $pin_file ]] || die "Omastorm engine pin missing: $pin_file"
-tag= repo= asset= sha256=
+tag='' repo='' asset='' sha256=''
 while IFS= read -r line || [[ -n $line ]]; do
   [[ $line =~ ^[[:space:]]*(#|$) ]] && continue
   key=${line%%=*}

--- a/scripts/release-engine.sh
+++ b/scripts/release-engine.sh
@@ -73,8 +73,8 @@ hello=$(timeout 2 socat -t0.2 - "UNIX-CONNECT:$XDG_RUNTIME_DIR/omastorm/engine.s
 [[ $(jq -r .engine <<< "$hello") == "$version" ]] \
   || die "The candidate reports engine $(jq -r .engine <<< "$hello"), not $version."
 
-# Notes: engine commits since the pinned release.
-notes=$(git log --no-merges --format='- %s' "$pinned..HEAD" -- engine Cargo.toml Cargo.lock)
+# Notes: commits since the pinned release that change the binary.
+notes=$(git log --no-merges --format='- %s' "$pinned..HEAD" -- engine/src engine/build.rs engine/tests engine/Cargo.toml Cargo.lock)
 [[ -n $notes ]] || notes='- No engine source changes since the previous release.'
 
 printf '\n%s at %s\n%s  %s\n\n%s\n\n' "$tag" "$(git rev-parse --short HEAD)" "$sum" "$asset" "$notes"

--- a/scripts/release-engine.sh
+++ b/scripts/release-engine.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Publish an engine release from main (DESIGN.md, distribution). Run it as
+# `mise release`. Refuses unless on main, clean, and even with origin/main,
+# and unless engine/Cargo.toml names a version with no tag or release yet.
+# Builds the candidate, requires it to answer hello with that version and the
+# protocol ui/Engine.qml accepts, creates the GitHub Release as a draft with
+# the binary and SHA256SUMS, asks, and publishes. Releases are immutable, so
+# publishing is the point of no return. It then fetches the published asset
+# back, requires it to hash to the candidate, and writes engine/release.pin.
+# It does not commit: run `mise check`, then commit the pin bump.
+#   --dry-run  stop after the candidate checks; create nothing
+#   --yes      publish without the prompt
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+die() { printf '%s\n' "$@" >&2; exit 1; }
+
+dry_run=0
+yes=0
+for arg in "$@"; do
+  case $arg in
+    --dry-run) dry_run=1 ;;
+    --yes) yes=1 ;;
+    *) die "Unknown option: $arg (use --dry-run or --yes)" ;;
+  esac
+done
+
+repo=wesleygrimes/omastorm
+asset=omastorm-engine-x86_64-unknown-linux-gnu
+
+for tool in gh git curl jq rg socat sha256sum strip; do
+  command -v "$tool" > /dev/null 2>&1 || die "Need $tool on PATH; run this as mise release."
+done
+gh auth status > /dev/null 2>&1 || die 'gh is not logged in (gh auth login).'
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+[[ $branch == main ]] || die "On $branch; engine releases are cut from main."
+[[ -z $(git status --porcelain) ]] || die 'The working tree is not clean.'
+git fetch -q origin main
+[[ $(git rev-parse HEAD) == $(git rev-parse origin/main) ]] \
+  || die 'main is not even with origin/main; push or pull first so the release names a commit everyone has.'
+
+version=$(awk -F'"' '/^version = /{print $2; exit}' engine/Cargo.toml)
+lock_version=$(awk '/^name = "omastorm-engine"$/{getline; print}' Cargo.lock | awk -F'"' '{print $2}')
+[[ $version == "$lock_version" ]] \
+  || die "engine/Cargo.toml says $version but Cargo.lock says $lock_version; build with --locked and commit the lock."
+tag=engine-$version
+pinned=$(awk -F= '/^tag=/{print $2}' engine/release.pin)
+[[ $tag != "$pinned" ]] || die "$tag is already the pinned release; bump version in engine/Cargo.toml first."
+! git rev-parse -q --verify "refs/tags/$tag" > /dev/null || die "Tag $tag already exists locally."
+! git ls-remote --exit-code --tags origin "refs/tags/$tag" > /dev/null 2>&1 || die "Tag $tag already exists on origin."
+! gh release view "$tag" -R "$repo" > /dev/null 2>&1 \
+  || die "Release $tag already exists. Releases are immutable; bump the version instead of replacing it."
+
+# The candidate: optimized, stripped, with SHA256SUMS beside it.
+bash scripts/build-engine-release.sh
+dist=target/dist/$asset
+sum=$(sha256sum -- "$dist" | awk '{print $1}')
+
+# It must answer hello with this version and the protocol the UI accepts.
+ui_protocol=$(rg -o 'message\.v !== ([0-9]+)' -r '$1' ui/Engine.qml)
+[[ -n $ui_protocol ]] || die 'Could not read the protocol version ui/Engine.qml accepts.'
+scratch=$(mktemp -d /tmp/omastorm-release.XXXXXX)
+trap 'rm -rf "$scratch"' EXIT
+mkdir -p "$scratch/runtime"
+export XDG_RUNTIME_DIR=$scratch/runtime XDG_CACHE_HOME=$scratch/cache XDG_DATA_HOME=$scratch/data
+"$dist" ensure
+hello=$(timeout 2 socat -t0.2 - "UNIX-CONNECT:$XDG_RUNTIME_DIR/omastorm/engine.sock" < /dev/null | head -n1 || true)
+"$dist" stop > /dev/null
+[[ $(jq -r .type <<< "$hello") == hello ]] || die 'The candidate did not answer hello.'
+[[ $(jq -r .v <<< "$hello") == "$ui_protocol" ]] \
+  || die "The candidate speaks protocol v$(jq -r .v <<< "$hello"); ui/Engine.qml accepts v$ui_protocol."
+[[ $(jq -r .engine <<< "$hello") == "$version" ]] \
+  || die "The candidate reports engine $(jq -r .engine <<< "$hello"), not $version."
+
+# Notes: engine commits since the pinned release.
+notes=$(git log --no-merges --format='- %s' "$pinned..HEAD" -- engine Cargo.toml Cargo.lock)
+[[ -n $notes ]] || notes='- No engine source changes since the previous release.'
+
+printf '\n%s at %s\n%s  %s\n\n%s\n\n' "$tag" "$(git rev-parse --short HEAD)" "$sum" "$asset" "$notes"
+if (( dry_run )); then
+  echo 'Dry run: the candidate passed; nothing was created.'
+  exit 0
+fi
+if (( ! yes )); then
+  read -r -p "Publish $tag? It cannot be edited or deleted afterwards. [y/N] " answer
+  [[ $answer == y || $answer == Y ]] || die 'Not published.'
+fi
+
+# Draft first: assets lock at publish and cannot be added afterwards.
+gh release create "$tag" -R "$repo" --draft --target "$(git rev-parse HEAD)" \
+  --title "Engine $version" --notes "$notes" "$dist" target/dist/SHA256SUMS
+gh release edit "$tag" -R "$repo" --draft=false
+echo "Published https://github.com/$repo/releases/tag/$tag"
+
+# Pin what was published, not what was uploaded.
+url=https://github.com/$repo/releases/download/$tag/$asset
+curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors -o "$scratch/published" -- "$url" \
+  || die "Could not fetch the published asset from $url; the pin was not written."
+got=$(sha256sum -- "$scratch/published" | awk '{print $1}')
+[[ $got == "$sum" ]] \
+  || die "The published $asset hashes to $got; the candidate was $sum." 'Do not pin this release. Bump the version and publish again.'
+
+cat > engine/release.pin <<PIN
+# Pinned GitHub Release for the engine binary (DESIGN.md, distribution).
+# Bump only after the named release exists on wesleygrimes/omastorm.
+tag=$tag
+repo=$repo
+asset=$asset
+sha256=$sum
+PIN
+echo "Wrote engine/release.pin for $tag."
+echo "Next: mise check, then commit the pin bump and push."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Fresh-checkout setup, run through `mise run setup` so the mise tools are on
+# PATH. Checks the desktop packages mise does not manage, downloads the
+# fixture and geography, fetches crates, and builds the debug engine. Launch
+# never calls this; it is the one step that touches the network on purpose.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+missing=()
+need() { # command, package
+  command -v "$1" > /dev/null 2>&1 || missing+=("$2")
+}
+need quickshell quickshell
+need socat socat
+[[ -x ${QSB:-/usr/lib/qt6/bin/qsb} ]] || missing+=(qt6-shadertools)
+if (( ${#missing[@]} )); then
+  printf 'Missing desktop packages: %s\n' "${missing[*]}" >&2
+  printf 'Install them, for example: sudo pacman -S --needed %s\n' "${missing[*]}" >&2
+  exit 1
+fi
+command -v magick > /dev/null 2>&1 || echo 'Optional: imagemagick (captures) is not installed.' >&2
+command -v ffmpeg > /dev/null 2>&1 || echo 'Optional: ffmpeg (demo video) is not installed.' >&2
+
+bash scripts/setup-fixture.sh
+cargo fetch --locked
+cargo build --offline --locked
+echo 'Setup complete. Next: mise run run'

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Fresh-checkout setup, run through `mise run setup` so the mise tools are on
+# Fresh-checkout setup, run through `mise setup` so the mise tools are on
 # PATH. Checks the desktop packages mise does not manage, downloads the
 # fixture and geography, fetches crates, and builds the debug engine. Launch
 # never calls this; it is the one step that touches the network on purpose.
@@ -24,4 +24,4 @@ command -v ffmpeg > /dev/null 2>&1 || echo 'Optional: ffmpeg (demo video) is not
 bash scripts/setup-fixture.sh
 cargo fetch --locked
 cargo build --offline --locked
-echo 'Setup complete. Next: mise run run'
+echo 'Setup complete. Next: mise start'


### PR DESCRIPTION
A checkout now has pinned development tools and a consistent set of commands through `mise.toml`. This replaces the unpinned checkout-local Rust toolchain and documents setup, daily development, release candidates, and engine publishing in one workflow.

## Development workflow

```sh
mise install       # install the pinned tools
mise setup         # check desktop packages, fetch fixtures/dependencies, build
mise start         # launch the window
mise stop          # stop the shared daemon
mise lint          # rustfmt, clippy, shellcheck
mise test          # Rust unit and socket tests
mise check         # integration suite against a scratch daemon
mise build-release # build an optimized candidate; publishes nothing
mise release       # publish an engine release from clean, synchronized main
mise tasks         # list all jobs
```

The toolchain pins Rust 1.98 with rustfmt and clippy, shellcheck, jq, ripgrep, and gh. Existing scripts remain the implementation. `scripts/cargo.sh` uses the cargo supplied by mise; the old `.tools/` toolchain is no longer used. Setup checks desktop dependencies and reports missing packages. Shellcheck findings in the existing scripts are fixed.

## Engine releases

`mise build-release` produces the stripped engine and SHA256SUMS without requiring the candidate to match the last published binary.

`mise release` requires clean `main` synchronized with `origin/main`, matching manifest/lockfile versions, and an unused engine version. It builds the candidate, verifies the version and protocol in its hello response, asks before publishing, creates a draft with both assets, and publishes it. It then downloads the published binary, verifies its hash against the candidate, and writes `engine/release.pin`. The pin is committed separately after `mise check` passes. `--dry-run` stops after candidate verification; `--yes` skips the confirmation prompt. Release notes include commits affecting engine source, tests, the manifest, or lockfile.

The installation check now verifies the pinned release asset's hash, protocol compatibility, and reported engine version instead of comparing an unrelated local candidate with the pin. Downloads are cached by hash. If GitHub is unreachable and no cached asset exists, the check reports that published-asset verification was skipped.

## Documentation

The README clarifies the scan cache, home-location fallback, desktop prerequisites, troubleshooting logs, restart command, and optional configuration removal. A dedicated `docs/configuration.md` contains settings, key bindings, environment overrides, and error reporting. The protocol document links to it and clarifies that treatment and the weak-return floor remain UI settings. The engine README documents the release procedure.

## Validation

- `MISE_AUTO_INSTALL=false mise check` passed all 14 steps after the final documentation changes. The suite ran outside the sandbox because its scratch daemons require local sockets; automatic installs were disabled to avoid an unrelated global mise tool update.
- `git diff --check` passed.
- Previously verified: `mise lint`, `mise build`, `mise test`, and a release dry run in a scratch clone with version 0.1.2. The actual publishing path has not been run because it would create a real release.

CI workflows and build provenance attestations remain follow-up work.
