### PR TITLE
Remember the camera and onboard with a location picker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,10 @@ Use the contribution workflow and its required checks for every commit.
   `$XDG_DATA_HOME/omastorm/`, `$XDG_STATE_HOME/omastorm/` (or
   `~/.local/state/omastorm/`), or `~/.config/omastorm/`. Only an explicit run of
   `scripts/install-launcher.sh` may write
-  `$XDG_DATA_HOME/applications/omastorm.desktop`.
+  `$XDG_DATA_HOME/applications/omastorm.desktop`. Only an explicit run of
+  `scripts/link-plugin.sh` may replace
+  `~/.config/omarchy/plugins/com.omastorm.radar` with a symlink to the
+  checkout (and restore the kept clone).
 - Ordinary `run.sh` never downloads. Network access belongs in the engine's
   live mode or explicit setup/install scripts. Plugin `--ensure` may install
   the pinned engine when no checkout debug engine exists. No archived radar

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,8 @@ Use the contribution workflow and its required checks for every commit.
   compiled `.qsb` shaders are required exceptions. See `.gitignore`.
 - Never modify Omarchy or system configuration. Writes belong only in the
   repo, `$XDG_RUNTIME_DIR/omastorm/`, `$XDG_CACHE_HOME/omastorm/`,
-  `$XDG_DATA_HOME/omastorm/`, or `~/.config/omastorm/`. Only an explicit run of
+  `$XDG_DATA_HOME/omastorm/`, `$XDG_STATE_HOME/omastorm/` (or
+  `~/.local/state/omastorm/`), or `~/.config/omastorm/`. Only an explicit run of
   `scripts/install-launcher.sh` may write
   `$XDG_DATA_HOME/applications/omastorm.desktop`.
 - Ordinary `run.sh` never downloads. Network access belongs in the engine's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,12 +34,26 @@ open clients reconnect. Use `mise stop` to end it, never `kill`. Close only
 Quickshell instances you launched; a windowless process left after closing is
 a leak to investigate.
 
-`mise start` loads this checkout's `ui/`, not the installed plugin under
-`~/.config/omarchy/plugins/com.omastorm.radar` (the bar still uses that
-copy). A tty launch prints the qml path, live vs archive, and which
-config/state/place files apply. `mise restart` stops the daemon first so a
-check or capture leftover is not reused. `mise onboard` starts with no
-weather file and no remembered view, so the location picker shows.
+`mise start` loads this checkout's `ui/` in a window. The bar still uses the
+installed plugin under `~/.config/omarchy/plugins/com.omastorm.radar` unless
+you point it here:
+
+```sh
+mise plugin-link
+```
+
+That replaces the install directory with a symlink to this checkout (the
+previous clone is kept beside it), restarts the Omarchy shell, and
+enables the bar widget.
+After that, `mise start`, `mise restart`, and `mise onboard` also restart the
+shell so the popover matches this tree (a symlink skips the plugin file
+watcher, and `rescanPlugins` keeps the old QML). `mise onboard`'s empty weather
+and state files apply only to the window; the popover keeps its usual place
+files. `mise plugin-unlink` restores the clone. A tty launch prints the qml path,
+live vs archive, whether the bar is linked, and which config/state/place
+files apply. `mise restart` stops the daemon first so a check or capture
+leftover is not reused. `mise onboard` starts the window with no weather file
+and no remembered view, so the location picker shows.
 
 ## Verify and submit
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,13 @@ open clients reconnect. Use `mise stop` to end it, never `kill`. Close only
 Quickshell instances you launched; a windowless process left after closing is
 a leak to investigate.
 
+`mise start` loads this checkout's `ui/`, not the installed plugin under
+`~/.config/omarchy/plugins/com.omastorm.radar` (the bar still uses that
+copy). A tty launch prints the qml path, live vs archive, and which
+config/state/place files apply. `mise restart` stops the daemon first so a
+check or capture leftover is not reused. `mise onboard` starts with no
+weather file and no remembered view, so the location picker shows.
+
 ## Verify and submit
 
 Keep each change scoped to one issue. Run `mise check` before every commit;

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -40,10 +40,14 @@ map center in this order:
 Only show onboarding when none of the first three sources supplies a valid
 center. The popover offers "Choose a location", opening the expanded
 window's picker. Offer place search and "Enter coordinates", which reveals
-labeled latitude and longitude fields with validation. "Show radar" accepts
-the location. No separate setup wizard or settings window is required. Keep
-"Choose location…" available after onboarding. Coordinate entry chooses a
-view; it does not create a permanent config override or lock a radar.
+labeled latitude and longitude fields with validation. Place search is an
+engine `search_places` reply over GeoNames cities with population ≥ 5000
+in the network envelope (state/region and country so two Jacksonvilles are
+distinct); map labels stay Natural Earth. "Show radar" accepts the location.
+No separate setup wizard or settings window is required. Keep the picker
+reachable after onboarding (`Shift+H` and LOCATION). Coordinate entry
+chooses a view; it does not create a permanent config override or lock a
+radar. Choosing a location writes `state.json`, never `config.toml`.
 
 Reuse Omarchy's location when available without requiring its weather plugin.
 Read weather settings only; never write them. Location search is an explicit
@@ -88,8 +92,9 @@ resolves preferences and remembered state, then sends commands.
 New settings are optional, omit means default, and a bad value is named in
 the status slot. Keep deliberate settings in `config.toml` and session restore in `state.json`.
 The app never rewrites config because the user pans, zooms, or changes a lock.
-See [configuration](docs/configuration.md) for file ownership and precedence.
-Do not write Omarchy, Hyprland, or system configuration.
+Write `state.json` atomically. See [configuration](docs/configuration.md) for
+file ownership and precedence. Do not write Omarchy, Hyprland, or system
+configuration.
 
 A product is a texture, legend, units, timestamp, and source from the engine.
 Level II is what is drawn.

--- a/README.md
+++ b/README.md
@@ -73,13 +73,16 @@ Update with `omarchy plugin update com.omastorm.radar`.
 
 ## Use
 
-Click the mark in the bar for the popover: the selected station, LIVE or the
-connection condition, the actual scan time, step and play, and EXPAND. Click
-the radar or press Enter for the window; it opens on the same station and
-frame and map view. Closing preserves your view for the next launch.
+Click the mark in the bar for the popover: the map at your location, LIVE or
+the connection condition, the actual scan time, step and play, and EXPAND.
+If no location is known, the popover offers “Choose a location,” which opens
+the picker in the window. Click the radar or press Enter for the window; it
+opens on the same station, frame, and camera. Closing preserves your view
+for the next launch.
 
 In the window, drag to pan and scroll to zoom. The map follows the nearest
-station as you pan unless you lock it. A station you arrive at fetches its last
+station as you pan unless you lock it; a locked radar stays put even when
+the camera leaves its coverage. A station you arrive at fetches its last
 dozen scans, so there is a loop to play within a few seconds; the cache then
 grows to 60 as new scans arrive. The status slot shows the age of the frame on
 screen: LIVE, STALE after ten minutes, UNAVAILABLE or OFFLINE when the feed
@@ -89,10 +92,11 @@ cannot be reached, with cached frames kept.
 | --- | --- |
 | `h` `j` `k` `l` or arrows | Pan |
 | `+` `-` | Zoom |
-| `0` | Reset view |
+| `0` | Reset to the configured or weather location |
 | `/` or `s` | Search sites |
 | `n` | Nearest site |
 | `Shift+L` | Lock the station |
+| `Shift+H` | Choose a location |
 | `Space` | Loop the frames |
 | `[` `]` | Step a frame |
 | `Home` `End` | Oldest or newest frame |
@@ -108,8 +112,9 @@ are hidden by default and the legend says so; `w` shows them.
 
 `~/.config/omastorm/config.toml` holds deliberate preferences. The app saves
 last map center, zoom, and UI radar lock separately in
-`$XDG_DATA_HOME/omastorm/state.json` (default
-`~/.local/share/omastorm/state.json`). Navigation never rewrites your config.
+`$XDG_STATE_HOME/omastorm/state.json` (default
+`~/.local/state/omastorm/state.json`). Navigation never rewrites your config.
+`Shift+H`, or LOCATION, opens the location picker; it writes state, not config.
 
 Explicit center coordinates win on every launch. Without them, Omastorm
 restores your last view, then falls back to the weather location or location
@@ -171,6 +176,8 @@ This is a beta. Bugs, rough edges, and ideas go to
 Radar: NOAA NEXRAD Level II via the NOAA Open Data program on AWS. Basemap: ©
 OpenStreetMap contributors, [ODbL](https://opendatacommons.org/licenses/odbl/1-0/),
 tiles by [OpenFreeMap](https://openfreemap.org); Natural Earth, public domain.
+Location search: [GeoNames](https://www.geonames.org/),
+[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 Code: MIT, see [LICENSE](LICENSE).
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The next popover or window starts it again. Please attach both logs to a
 ```sh
 omarchy plugin remove com.omastorm.radar
 ~/.local/share/omastorm/bin/omastorm-engine stop
-rm -rf ~/.local/share/omastorm ~/.cache/omastorm
+rm -rf ~/.local/share/omastorm ~/.cache/omastorm ~/.local/state/omastorm
 rm -rf ~/.config/omastorm                            # your config.toml; keep it to reinstall later
 rm -f ~/.local/share/applications/omastorm.desktop   # if you added the launcher entry
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,10 +10,10 @@ engine. The UI sends the commands described in [protocol.md](protocol.md).
 | File | Owner and purpose | Contents |
 | --- | --- | --- |
 | `~/.config/omastorm/config.toml` | User-managed, deliberate preferences | Optional fixed launch center, radar override, treatment, weak-return floor, keybindings |
-| `$XDG_DATA_HOME/omastorm/state.json` | App-managed, remembered session | Last map center, zoom, and optional radar lock chosen in the UI |
+| `$XDG_STATE_HOME/omastorm/state.json` | App-managed, remembered session | Last map center, zoom, and optional radar lock chosen in the UI |
 
-When `XDG_DATA_HOME` is unset, state lives at
-`~/.local/share/omastorm/state.json`. Onboarding, panning, zooming, and UI lock
+When `XDG_STATE_HOME` is unset, state lives at
+`~/.local/state/omastorm/state.json`. Onboarding, panning, zooming, and UI lock
 changes write state, not config. Deleting state resets the remembered session
 without removing deliberate preferences. Missing or invalid state falls back
 to the remaining location sources; it must not prevent startup. Keep state
@@ -35,7 +35,7 @@ A missing location opens a "Choose a location" prompt in the popover; its
 button opens the expanded window's picker. Accepting a location saves the
 view in state. Weather-derived initial coordinates are also saved in state.
 Neither route adds coordinate overrides to config. The picker remains
-available through "Choose location…" after onboarding.
+available through `Shift+H` and LOCATION after onboarding.
 
 Resolve the radar independently: configured `locked_radar`, then a remembered
 UI lock, then the nearest station to the resolved center. A configured radar
@@ -85,16 +85,18 @@ A Jacksonville map center with `locked_radar = "KFCX"` is valid. Honor both
 settings even when the sweep is outside the view. Show the selected station
 and lock, with "Use nearest radar" and "Go to selected radar" available when
 coverage is outside the view. Never relocate the camera or discard the lock
-silently.
+silently. The chrome says `LOCKED · OUTSIDE COVERAGE` when the camera sits
+outside that radar's rings.
 
 For agent-assisted installation, write coordinate overrides only when the
 user requests a fixed launch location. Ordinary installation leaves them
 unset so weather location or onboarding establishes a remembered view.
 
 `OMASTORM_CONFIG` names another config file for checks and captures; a missing
-file is no configuration. `OMASTORM_LOCATION` names another weather file.
-When using an isolated config, checks and captures must also isolate remembered
-state and must not read the desktop's weather location unless explicitly named.
+file is no configuration. `OMASTORM_STATE` names another state file;
+`OMASTORM_LOCATION` names another weather file. When `OMASTORM_CONFIG` is set,
+the machine's own state and weather files are not read unless
+`OMASTORM_STATE` or `OMASTORM_LOCATION` names one.
 
 ## Display and keyboard preferences
 
@@ -108,9 +110,10 @@ state and must not read the desktop's weather location unless explicitly named.
   `OMASTORM_WEAK` (`off` or a number), set by the capture scripts, outranks
   it. Anything else is reported like a bad `treatment` and leaves the default.
 - `[keys]`: one entry per action, laid over the defaults in `ui/Keys.js`:
-  `search` (`/ s`), `nearest` (`n`), `lock` (`Shift+L`), `pan_left`
+  `search` (`/ s`), `nearest` (`n`), `lock` (`Shift+L`), `home` (`Shift+H`,
+  the location picker), `pan_left`
   `pan_down` `pan_up` `pan_right` (`h j k l` and the arrows), `zoom_in`
-  (`+ =`), `zoom_out` (`-`), `reset` (`0`), `previous_frame` (`[`),
+  (`+ =`), `zoom_out` (`-`), `reset` (`0`, the resolved location), `previous_frame` (`[`),
   `next_frame` (`]`), `play` (`Space`), `oldest` (`Home`), `newest` (`End`),
   `pixels` `glyphs` `stipple` (`1 2 3`), `weak` (`w`), `help` (`?`), `close`
   (`Escape`).
@@ -118,4 +121,21 @@ state and must not read the desktop's weather location unless explicitly named.
   unknown action, or a key another action already holds leaves that action
   on its default and is named in the status slot (`[KEYS] ZOOM_IN = "FOO":
   FOO IS NOT A KEY`, with a count of any further mistakes) until the file is
-  fixed; a bad `treatment` or `weak_floor` is reported the same way.
+  fixed; a bad `treatment`, `weak_floor`, centre, or `locked_radar` is
+  reported the same way. `home_site` and `follow` are unused and named if
+  present.
+
+## Remembered state
+
+`~/.local/state/omastorm/state.json` is written atomically (a temporary file
+renamed into place). It holds the last map centre, span in kilometres, and
+the UI radar lock when one is set:
+
+```json
+{"lat":30.332,"lon":-81.656,"span":210,"lock":"KJAX","name":"Jacksonville"}
+```
+
+Invalid fields are dropped. A missing file is no remembered view.
+`OMASTORM_LOCATION` names another weather.json (`name`, `latitude`,
+`longitude`, written by the shell's weather panel) for checks; coordinates
+outside ±90/±180 are ignored.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -334,7 +334,7 @@ paints live.
 ## Configuration
 
 `~/.config/omastorm/config.toml` and
-`$XDG_DATA_HOME/omastorm/state.json` are read by the UI, never by the engine.
+`$XDG_STATE_HOME/omastorm/state.json` are read by the UI, never by the engine.
 Explicit preferences override remembered view state. The UI resolves the map
 center and radar lock independently, then sends `select_site`, `lock`,
 `follow`, and settled `view_center` commands as needed. Unlocked navigation
@@ -353,6 +353,8 @@ remembered-view writes so surfaces do not overwrite one another's state.
 On launch, the UI applies explicit config over remembered state. Reconnecting
 to the engine restores the necessary selection and flags without resetting
 the active camera. A change of frame or station never re-centers the map.
+Location picks write state.json. With no location, the popover offers the
+picker instead of inventing a centre.
 
 `hello` additionally includes `pid`, `build` (an opaque fingerprint),
 `sitesSource`, `sitesRetrieved`, and `sitesNotes`. These allow the launcher to

--- a/engine/tests/rendering.rs
+++ b/engine/tests/rendering.rs
@@ -569,11 +569,9 @@ fn install_harness(dir: &Path) {
     let shader = |name: &str| json!(format!("{ROOT}/ui/shaders/{name}.frag.qsb")).to_string();
     assert!(component.contains("\"shaders/radar.frag.qsb\"") && component.contains("id: map\n"));
     assert!(component.contains("\"shaders/tile.frag.qsb\""));
-    assert!(component.contains("\"shaders/sweep.frag.qsb\""));
     let component = component
         .replace("\"shaders/radar.frag.qsb\"", &shader("radar"))
         .replace("\"shaders/tile.frag.qsb\"", &shader("tile"))
-        .replace("\"shaders/sweep.frag.qsb\"", &shader("sweep"))
         .replacen(
             "id: map\n",
             "id: map\n    property alias shaderItem: radarEffect\n",

--- a/mise.toml
+++ b/mise.toml
@@ -32,15 +32,23 @@ run = [
 
 [tasks.start]
 description = "Launch the window against the shared debug daemon (needs GPU Quickshell)"
-run = "bash run.sh"
+run = "OMASTORM_RESCAN_PLUGIN=1 bash run.sh"
 
 [tasks.restart]
 description = "Stop the shared debug daemon, then launch this checkout's window"
-run = "bash -c 'test -x target/debug/omastorm-engine && target/debug/omastorm-engine stop || true; exec bash run.sh'"
+run = "bash -c 'test -x target/debug/omastorm-engine && target/debug/omastorm-engine stop || true; exec env OMASTORM_RESCAN_PLUGIN=1 bash run.sh'"
 
 [tasks.onboard]
 description = "Launch this checkout with no weather or remembered view (location picker)"
-run = "mkdir -p target && : > target/onboard-state.json && OMASTORM_LOCATION=/dev/null OMASTORM_STATE=$PWD/target/onboard-state.json bash run.sh"
+run = "mkdir -p target && : > target/onboard-state.json && OMASTORM_LOCATION=/dev/null OMASTORM_STATE=$PWD/target/onboard-state.json OMASTORM_RESCAN_PLUGIN=1 bash run.sh"
+
+[tasks.plugin-link]
+description = "Point the Omarchy bar plugin at this checkout and enable it"
+run = "bash scripts/link-plugin.sh"
+
+[tasks.plugin-unlink]
+description = "Restore the installed Omarchy plugin clone"
+run = "bash scripts/link-plugin.sh --unlink"
 
 [tasks.stop]
 description = "End the shared debug daemon"

--- a/mise.toml
+++ b/mise.toml
@@ -34,6 +34,14 @@ run = [
 description = "Launch the window against the shared debug daemon (needs GPU Quickshell)"
 run = "bash run.sh"
 
+[tasks.restart]
+description = "Stop the shared debug daemon, then launch this checkout's window"
+run = "bash -c 'test -x target/debug/omastorm-engine && target/debug/omastorm-engine stop || true; exec bash run.sh'"
+
+[tasks.onboard]
+description = "Launch this checkout with no weather or remembered view (location picker)"
+run = "mkdir -p target && : > target/onboard-state.json && OMASTORM_LOCATION=/dev/null OMASTORM_STATE=$PWD/target/onboard-state.json bash run.sh"
+
 [tasks.stop]
 description = "End the shared debug daemon"
 run = "target/debug/omastorm-engine stop"

--- a/run.sh
+++ b/run.sh
@@ -25,4 +25,27 @@ fi
 # Launch is strictly offline. Fetch build dependencies explicitly during setup.
 bash scripts/cargo.sh build --offline --locked --quiet
 target/debug/omastorm-engine ensure
+# A tty launch names this checkout and which files apply, so a leftover
+# archive daemon or the installed plugin is obvious. Captures are not a tty.
+if [[ -t 1 ]]; then
+  mode=live
+  [[ -n ${OMASTORM_ARCHIVE:-} ]] && mode="archive $OMASTORM_ARCHIVE"
+  config=${OMASTORM_CONFIG:-$HOME/.config/omastorm/config.toml}
+  if [[ -n ${OMASTORM_STATE:-} ]]; then
+    state=$OMASTORM_STATE
+  elif [[ -n ${OMASTORM_CONFIG:-} ]]; then
+    state="(not read; OMASTORM_CONFIG is set)"
+  else
+    state=${XDG_STATE_HOME:-$HOME/.local/state}/omastorm/state.json
+  fi
+  if [[ -n ${OMASTORM_LOCATION:-} ]]; then
+    location=$OMASTORM_LOCATION
+  elif [[ -n ${OMASTORM_CONFIG:-} ]]; then
+    location="(not read; OMASTORM_CONFIG is set)"
+  else
+    location=$HOME/.local/state/omarchy/settings/weather.json
+  fi
+  printf 'Omastorm %s\n  qml    %s\n  engine %s\n  config %s\n  state  %s\n  place  %s\n' \
+    "$PWD" "${OMASTORM_QML:-ui/shell.qml}" "$mode" "$config" "$state" "$location"
+fi
 exec quickshell -p "${OMASTORM_QML:-ui/shell.qml}" "$@"

--- a/run.sh
+++ b/run.sh
@@ -45,7 +45,13 @@ if [[ -t 1 ]]; then
   else
     location=$HOME/.local/state/omarchy/settings/weather.json
   fi
-  printf 'Omastorm %s\n  qml    %s\n  engine %s\n  config %s\n  state  %s\n  place  %s\n' \
-    "$PWD" "${OMASTORM_QML:-ui/shell.qml}" "$mode" "$config" "$state" "$location"
+  bar=$(bash scripts/link-plugin.sh --status)
+  printf 'Omastorm %s\n  qml    %s\n  engine %s\n  bar    %s\n  config %s\n  state  %s\n  place  %s\n' \
+    "$PWD" "${OMASTORM_QML:-ui/shell.qml}" "$mode" "$bar" "$config" "$state" "$location"
+fi
+# mise start / restart / onboard restart the Omarchy shell when this checkout
+# is linked, so the bar popover matches. Captures and checks leave it alone.
+if [[ -n ${OMASTORM_RESCAN_PLUGIN:-} ]]; then
+  bash scripts/link-plugin.sh --rescan
 fi
 exec quickshell -p "${OMASTORM_QML:-ui/shell.qml}" "$@"

--- a/scripts/capture-demo.sh
+++ b/scripts/capture-demo.sh
@@ -21,10 +21,10 @@ export OMASTORM_CONFIG="$demo_dir/config.toml"
 unset OMASTORM_ARCHIVE
 rm -rf "$demo_dir"
 mkdir -p "$XDG_RUNTIME_DIR" "$XDG_CACHE_HOME" "$demo_dir/shaders" "$demo_dir/frames"
-printf 'home_site = "%s"\n' "$site" > "$OMASTORM_CONFIG"
+jq -r --arg id "$site" '.sites[] | select(.id==$id) | "center_lat = \(.lat)\ncenter_lon = \(.lon)\nlocked_radar = \"\(.id)\""' engine/data/sites.json > "$OMASTORM_CONFIG"
 cleanup() { target/debug/omastorm-engine stop >/dev/null 2>&1 || true; }
 trap cleanup EXIT
-cp ui/Theme.qml ui/Engine.qml ui/RadarMark.qml ui/RadarMap.qml ui/SitePicker.qml ui/Sites.js ui/KeysSheet.qml ui/Keys.js ui/Timeline.js ui/Config.qml ui/Toml.js "$demo_dir/"
+cp ui/Theme.qml ui/Engine.qml ui/RadarMark.qml ui/RadarMap.qml ui/SitePicker.qml ui/Sites.js ui/KeysSheet.qml ui/Keys.js ui/Timeline.js ui/Config.qml ui/Toml.js ui/Location.js ui/LocationPicker.qml ui/Remembered.qml ui/PluginSession.qml ui/qmldir "$demo_dir/"
 cp ui/shaders/*.qsb "$demo_dir/shaders/"
 ruby - "$demo_dir" <<'RUBY'
 dir = ARGV.fetch(0)
@@ -33,7 +33,7 @@ harness = <<'QML'
     // Start once the station is live and the backfill has given it a loop.
     Timer { interval: 500; running: true; repeat: true
         onTriggered: if (app.scan && app.scan.scanTime && app.frames.filter(f => f.status === "complete").length >= 8) { running = false; waitTiles.start(); } }
-    Timer { id: waitTiles; interval: 5000; onTriggered: { map.reset(); demo.homeSpan = map.span; demo.advance(); } }
+    Timer { id: waitTiles; interval: 5000; onTriggered: { app.resetView(); demo.homeSpan = map.span; demo.advance(); } }
     QtObject {
         id: demo
         property int frame: 0

--- a/scripts/capture-harness.sh
+++ b/scripts/capture-harness.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 harness="$PWD/target/capture-harness"
 mkdir -p "$harness"
-cp ui/shell.qml ui/RadarWindow.qml ui/RadarMark.qml ui/RadarMap.qml ui/SitePicker.qml ui/Sites.js ui/KeysSheet.qml ui/Keys.js ui/Timeline.js ui/Theme.qml ui/Config.qml ui/Toml.js "$harness/"
+cp ui/shell.qml ui/RadarWindow.qml ui/RadarMark.qml ui/RadarMap.qml ui/SitePicker.qml ui/Sites.js ui/KeysSheet.qml ui/Keys.js ui/Timeline.js ui/Theme.qml ui/Config.qml ui/Toml.js ui/Location.js ui/LocationPicker.qml ui/Remembered.qml ui/PluginSession.qml ui/qmldir "$harness/"
 ln -sfn "$PWD/ui/shaders" "$harness/shaders"
 perl -pe 's/^(\s+)state = message;$/$1var override = JSON.parse(Quickshell.env("OMASTORM_STATE_OVERRIDE") || "{}");\n$1for (var key in override) message[key] = override[key] && typeof override[key] === "object" && !Array.isArray(override[key]) && message[key] ? Object.assign(message[key], override[key]) : override[key];\n$1state = message;/' ui/Engine.qml > "$harness/Engine.qml"
 grep -q OMASTORM_STATE_OVERRIDE "$harness/Engine.qml"

--- a/scripts/capture-keys.sh
+++ b/scripts/capture-keys.sh
@@ -13,7 +13,7 @@ export QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME=basic QT_QUICK_BACKEND=rhi
 review="$PWD/review"
 rm -f "$review"/keys-*.png
 scratch=$(mktemp -d /tmp/omastorm-keys.XXXXXX)
-printf 'home_site = "KTLX"\n' > "$scratch/home.toml"
+jq -r '.sites[] | select(.id=="KTLX") | "center_lat = \(.lat)\ncenter_lon = \(.lon)\nlocked_radar = \"KTLX\""' engine/data/sites.json > "$scratch/home.toml"
 : > "$scratch/none.toml"
 printf '{\n  "name": "Stokesdale",\n  "latitude": 36.23708,\n  "longitude": -79.97948\n}\n' > "$scratch/weather.json"
 bash scripts/cargo.sh build --offline --locked --quiet
@@ -25,7 +25,7 @@ tell '{"type":"select_site","id":"KTLX"}' '{"type":"lock","enabled":false}'
 capture() { # name, delay ms, config, location, ipc steps...
   local name=$1 delay=$2 config=$3 location=$4 pid
   shift 4
-  OMASTORM_CONFIG="$config" OMASTORM_LOCATION="$location" OMASTORM_WIDTH=960 OMASTORM_HEIGHT=680 \
+  OMASTORM_CONFIG="$config" OMASTORM_LOCATION="$location" OMASTORM_STATE="$scratch/state-$name.json" OMASTORM_WIDTH=960 OMASTORM_HEIGHT=680 \
     OMASTORM_CAPTURE_DELAY="$delay" OMASTORM_CAPTURE="$review/keys-$name.png" bash run.sh > /dev/null 2>&1 &
   pid=$!
   for _ in {1..100}; do quickshell ipc --pid "$pid" call keys status > /dev/null 2>&1 && break; sleep .1; done

--- a/scripts/capture-loading.sh
+++ b/scripts/capture-loading.sh
@@ -4,9 +4,7 @@
 # it goes live on SITE (default KJAX), the map without radar under LOADING;
 # review/loading-after.png is the same daemon once the current volume's
 # lowest cut has been replayed from the bucket. review/loading-none.png is a
-# lean daemon opened with no home at all: the window settles on the network's
-# middle and following hands off to the nearest station at once, so the
-# NO STATION state lasts a frame and the picture is that station loading.
+# lean daemon with no configured centre: the first-run location picker.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 mkdir -p review
@@ -15,7 +13,7 @@ site="${SITE:-KJAX}"
 review="$PWD/review"
 rm -f "$review"/loading-*.png
 config=$(mktemp /tmp/omastorm-loading-config.XXXXXX)
-printf 'home_site = "%s"\n' "$site" > "$config"
+jq -r --arg id "$site" '.sites[] | select(.id==$id) | "center_lat = \(.lat)\ncenter_lon = \(.lon)\nlocked_radar = \"\(.id)\""' engine/data/sites.json > "$config"
 none=$(mktemp /tmp/omastorm-loading-none.XXXXXX)
 : > "$none"
 

--- a/scripts/capture-location.sh
+++ b/scripts/capture-location.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Location, remembered view, and a locked radar with the camera outside
+# coverage (DESIGN.md, location): review/location-*.png and
+# review/location-sheet.png.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+mkdir -p review
+export OMASTORM_ARCHIVE=${OMASTORM_ARCHIVE:-$PWD/data/raw/KTLX20130520_201643_V06.gz}
+export QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME=basic QT_QUICK_BACKEND=rhi QSG_RHI_BACKEND=opengl
+review="$PWD/review"
+rm -f "$review"/location-*.png
+scratch=$(mktemp -d /tmp/omastorm-location.XXXXXX)
+export XDG_RUNTIME_DIR="$scratch/runtime" XDG_CACHE_HOME="$scratch/cache"
+mkdir -p "$XDG_RUNTIME_DIR" "$XDG_CACHE_HOME"
+printf '{\n  "name": "Stokesdale",\n  "latitude": 36.23708,\n  "longitude": -79.97948\n}\n' > "$scratch/weather.json"
+: > "$scratch/none.toml"
+printf 'center_lat = 30.332\ncenter_lon = -81.656\nlocked_radar = "KTLX"\n' > "$scratch/locked.toml"
+bash scripts/cargo.sh build --offline --locked --quiet
+target/debug/omastorm-engine ensure
+trap 'target/debug/omastorm-engine stop >/dev/null 2>&1 || true' EXIT
+
+capture() { # name, delay ms, env..., then ipc steps
+  local name=$1 delay=$2 pid
+  shift 2
+  local env_args=() steps=()
+  while [[ $# -gt 0 ]]; do
+    if [[ $1 == -- ]]; then shift; steps=("$@"); break; fi
+    env_args+=("$1"); shift
+  done
+  env "${env_args[@]}" OMASTORM_WIDTH=960 OMASTORM_HEIGHT=680 \
+    OMASTORM_CAPTURE_DELAY="$delay" OMASTORM_CAPTURE="$review/location-$name.png" bash run.sh > /dev/null 2>&1 &
+  pid=$!
+  for _ in {1..100}; do quickshell ipc --pid "$pid" call keys status > /dev/null 2>&1 && break; sleep .1; done
+  sleep 4
+  local step words
+  for step in "${steps[@]+"${steps[@]}"}"; do
+    read -ra words <<< "$step"
+    quickshell ipc --pid "$pid" call "${words[@]}"
+  done
+  wait "$pid"
+  [[ -s "$review/location-$name.png" ]] || { echo "No capture for $name" >&2; exit 1; }
+  echo "captured $name"
+}
+
+capture weather 7000 OMASTORM_CONFIG="$scratch/none.toml" OMASTORM_LOCATION="$scratch/weather.json" OMASTORM_STATE="$scratch/state-weather.json"
+capture picker 8000 OMASTORM_CONFIG="$scratch/none.toml" OMASTORM_LOCATION="$scratch/missing.json" OMASTORM_STATE="$scratch/state-picker.json" -- 'location open oklahoma'
+capture coords 8000 OMASTORM_CONFIG="$scratch/none.toml" OMASTORM_LOCATION="$scratch/missing.json" OMASTORM_STATE="$scratch/state-coords.json" -- 'location open zzzq' 'location setLat 35.4' 'location setLon -97.5'
+capture locked 8000 OMASTORM_CONFIG="$scratch/locked.toml" OMASTORM_LOCATION="$scratch/missing.json" OMASTORM_STATE="$scratch/state-locked.json"
+
+cd "$review"
+magick montage -label '%t' location-weather.png location-picker.png location-coords.png location-locked.png \
+  -tile 2x -geometry 640x453+8+12 -background '#181414' -fill '#e6d9db' -pointsize 18 location-sheet.png
+echo "review/location-sheet.png"

--- a/scripts/capture-picker.sh
+++ b/scripts/capture-picker.sh
@@ -12,7 +12,7 @@ export QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME=basic QT_QUICK_BACKEND=rhi
 review="$PWD/review"
 rm -f "$review"/picker-*.png
 scratch=$(mktemp -d /tmp/omastorm-picker.XXXXXX)
-printf 'home_site = "KTLX"\n' > "$scratch/home.toml"
+jq -r '.sites[] | select(.id=="KTLX") | "center_lat = \(.lat)\ncenter_lon = \(.lon)\nlocked_radar = \"KTLX\""' engine/data/sites.json > "$scratch/home.toml"
 bash scripts/cargo.sh build --offline --locked --quiet
 target/debug/omastorm-engine ensure
 sock="$XDG_RUNTIME_DIR/omastorm/engine.sock"

--- a/scripts/capture-popover.sh
+++ b/scripts/capture-popover.sh
@@ -8,7 +8,7 @@ export XDG_RUNTIME_DIR="$scratch/runtime" XDG_CACHE_HOME="$scratch/cache"
 export OMASTORM_ROOT="$PWD" OMASTORM_CONFIG="$scratch/config.toml"
 export QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME=basic QT_QUICK_BACKEND=rhi QSG_RHI_BACKEND=opengl
 mkdir -p "$XDG_RUNTIME_DIR" review
-printf 'home_site = "KTLX"\n' > "$OMASTORM_CONFIG"
+jq -r '.sites[] | select(.id=="KTLX") | "center_lat = \(.lat)\ncenter_lon = \(.lon)\nlocked_radar = \"KTLX\""' engine/data/sites.json > "$OMASTORM_CONFIG"
 pid=
 cleanup() {
   [[ -z $pid ]] || kill "$pid" 2>/dev/null || true

--- a/scripts/capture-readme.sh
+++ b/scripts/capture-readme.sh
@@ -9,7 +9,7 @@ export OMASTORM_ROOT="$PWD" OMASTORM_CONFIG="$scratch/config.toml"
 export QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME=basic
 export QT_QUICK_BACKEND=rhi QSG_RHI_BACKEND=opengl
 mkdir -p "$XDG_RUNTIME_DIR" docs/media
-printf 'home_site = "KTLX"\n' > "$OMASTORM_CONFIG"
+jq -r '.sites[] | select(.id=="KTLX") | "center_lat = \(.lat)\ncenter_lon = \(.lon)\nlocked_radar = \"KTLX\""' engine/data/sites.json > "$OMASTORM_CONFIG"
 cleanup() { target/debug/omastorm-engine stop >/dev/null 2>&1 || true; }
 trap cleanup EXIT
 

--- a/scripts/capture-review.sh
+++ b/scripts/capture-review.sh
@@ -5,6 +5,10 @@ mkdir -p review
 export OMASTORM_ARCHIVE=${OMASTORM_ARCHIVE:-$PWD/data/raw/KTLX20130520_201643_V06.gz} # the archived scan the checks assume
 export QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME=basic
 export QT_QUICK_BACKEND=rhi QSG_RHI_BACKEND=opengl
+scratch=$(mktemp -d /tmp/omastorm-review.XXXXXX)
+export XDG_RUNTIME_DIR="$scratch/runtime" XDG_CACHE_HOME="$scratch/cache"
+mkdir -p "$XDG_RUNTIME_DIR" "$XDG_CACHE_HOME"
+trap 'target/debug/omastorm-engine stop >/dev/null 2>&1 || true' EXIT
 for spec in 'minimum 360 360 PIXELS' 'compact 400 420 PIXELS' 'quarter 960 680 PIXELS' 'half 960 1200 PIXELS' 'full 1920 1200 PIXELS' 'glyphs 960 680 GLYPHS' 'stipple 960 680 STIPPLE'; do
   read -r name width height treatment <<< "$spec"
   OMASTORM_WIDTH="$width" OMASTORM_HEIGHT="$height" OMASTORM_STYLE="$treatment" OMASTORM_CAPTURE="$PWD/review/$name.png" bash run.sh

--- a/scripts/capture-states.sh
+++ b/scripts/capture-states.sh
@@ -26,9 +26,13 @@ rm -f "$review"/states-*.png
 # The windows read a scratch config.toml naming the station, or none.
 scratch=$(mktemp -d /tmp/omastorm-states.XXXXXX)
 mkdir -p "$scratch/offline" "$scratch/silent" "$scratch/cache"
-config_for() { # station id, or nothing for no home station
+config_for() { # station id, or nothing for no configured radar
   local file="$scratch/config-${1:-none}.toml"
-  if [[ -n ${1:-} ]]; then printf 'home_site = "%s"\n' "$1" > "$file"; else : > "$file"; fi
+  if [[ -n ${1:-} ]]; then
+    jq -r --arg id "$1" '.sites[] | select(.id==$id) | "center_lat = \(.lat)\ncenter_lon = \(.lon)\nlocked_radar = \"\(.id)\""' engine/data/sites.json > "$file"
+  else
+    : > "$file"
+  fi
   echo "$file"
 }
 

--- a/scripts/check-keys.sh
+++ b/scripts/check-keys.sh
@@ -12,7 +12,9 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 check_dir="$PWD/target/check-keys"
 mkdir -p "$check_dir"
-# Stokesdale, NC, as Omarchy's weather panel writes it: KFCX (Roanoke) is nearest.
+rm -f "$check_dir/state.json"
+# Stokesdale, NC, as Omarchy's weather panel writes it: the camera sits on
+# the place; KFCX (Roanoke) is the nearest radar.
 printf '{\n  "name": "Stokesdale",\n  "latitude": 36.23708,\n  "longitude": -79.97948\n}\n' > "$check_dir/weather.json"
 cat > "$check_dir/config.toml" <<'TOML'
 treatment = "neon"
@@ -25,7 +27,7 @@ bogus = "x"
 reset = 0
 TOML
 export QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME=basic QT_QUICK_BACKEND=rhi QSG_RHI_BACKEND=opengl
-OMASTORM_CONFIG="$check_dir/config.toml" OMASTORM_LOCATION="$check_dir/weather.json" bash run.sh > "$check_dir/log" 2>&1 &
+OMASTORM_CONFIG="$check_dir/config.toml" OMASTORM_LOCATION="$check_dir/weather.json" OMASTORM_STATE="$check_dir/state.json" bash run.sh > "$check_dir/log" 2>&1 &
 pid=$!
 trap 'kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true' EXIT
 call() { quickshell ipc --pid "$pid" call keys "$@"; }
@@ -43,7 +45,7 @@ call status > /dev/null || fail "The window's keys IPC never answered"
 # The table over the defaults: the good line applies, every mistake is
 # reported once and leaves its default in place, a key bound twice stays
 # with the first action.
-until_field home KFCX
+until_field site KFCX
 b=$(call bindings)
 [[ $b == *'"pan_left":["A","Left"]'* ]] || fail "pan_left was not rebound: $b"
 [[ $b == *'"zoom_in":["+","="]'* ]] || fail "A bad zoom_in did not keep its default: $b"
@@ -57,7 +59,7 @@ expect 'Six mistakes' 6 "$(grep -o '\[keys\]\|treatment =\|weak_floor =' <<< "$e
 expect 'The status slot names the first and counts the rest' 'TREATMENT = "NEON": NOT PIXELS, GLYPHS, OR STIPPLE (+5 MORE)' "$(field error)"
 expect 'A bad treatment leaves Glyphs' GLYPHS "$(field treatment)"
 expect 'A bad weak_floor leaves the default floor' 5 "$(field weakFloor)"
-expect 'The header names the location home' location "$(field homeSource)"
+expect 'The header names the weather location' weather "$(field locationSource)"
 
 # Each action's effect, through the same function the shortcuts call.
 until_field site KFCX
@@ -91,20 +93,22 @@ call run search
 expect 'The search key opens the picker' true "$(quickshell ipc --pid "$pid" call picker status | grep -o '"open":[a-z]*' | cut -d: -f2)"
 quickshell ipc --pid "$pid" call picker close
 
-# Shift+H saves the station on screen as home_site, above the [keys] table,
-# and the header follows the file through the watch.
-shown=$(field site)
+# Shift+H opens the location picker; a chosen point writes state, never config.
 call run home
-for _ in {1..50}; do grep -q "^home_site = \"$shown\"$" "$check_dir/config.toml" && break; sleep .1; done
-grep -q "^home_site = \"$shown\"$" "$check_dir/config.toml" || fail "Shift+H did not save home_site = \"$shown\"" "$(cat "$check_dir/config.toml")"
-[[ $(grep -n "^home_site\|^\[keys\]" "$check_dir/config.toml" | head -1) == *home_site* ]] || fail "home_site landed inside a table"
-until_field homeSource config
-expect 'The saved home is the station on screen' "$shown" "$(field home)"
+for _ in {1..50}; do [[ $(quickshell ipc --pid "$pid" call location status | grep -o '"open":[a-z]*' | cut -d: -f2) == true ]] && break; sleep .1; done
+expect 'Shift+H opens the location picker' true "$(quickshell ipc --pid "$pid" call location status | grep -o '"open":[a-z]*' | cut -d: -f2)"
+quickshell ipc --pid "$pid" call location go 35.4 -97.5 "Moore"
+until_field lat 35.4
+until_field lon -97.5
+until_field locationSource state
+grep -q '"lat":35.4' "$check_dir/state.json" || fail "Shift+H location did not write state.json" "$(cat "$check_dir/state.json")"
+grep -q home_site "$check_dir/config.toml" && fail "Shift+H wrote home_site into config.toml"
 
 # The fix applies through the file watch: no report, the new key in force,
-# and a configured home_site outranking the location.
+# and an explicit centre outranking the weather location.
 cat > "$check_dir/config.toml" <<'TOML'
-home_site = "KTLX"
+center_lat = 35.333
+center_lon = -97.277
 treatment = "pixels"
 weak_floor = 10
 [keys]
@@ -117,7 +121,8 @@ b=$(call bindings)
 [[ $b == *'"zoom_in":["Z"]'* && $b == *'"search":[]'* ]] || fail "The fixed table did not apply: $b"
 expect 'The treatment setting applies' PIXELS "$(field treatment)"
 expect 'The weak_floor setting applies' 10 "$(field weakFloor)"
-until_field homeSource config
-until_field site KTLX
+until_field locationSource config
+until_field lat 35.333
+until_field lon -97.277
 if rg -q 'TypeError|ReferenceError|Unable to assign|Failed to create.*context|is not a function' "$check_dir/log"; then fail "QML errors in the log"; fi
 echo "KEYS_PASSED"

--- a/scripts/check-link-plugin.sh
+++ b/scripts/check-link-plugin.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Opt-in bar-plugin symlink (CONTRIBUTING.md, mise plugin-link): writes only under
+# scratch XDG_CONFIG_HOME, never from install or ordinary launch.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+fail() { printf '%s\n' "$@" >&2; exit 1; }
+
+scratch=$(mktemp -d /tmp/omastorm-link.XXXXXX)
+trap 'rm -rf "$scratch"' EXIT
+export XDG_CONFIG_HOME="$scratch/config"
+plugins=$XDG_CONFIG_HOME/omarchy/plugins
+target=$plugins/com.omastorm.radar
+backup=$plugins/.com.omastorm.radar.unlinked
+root=$(readlink -f "$PWD")
+path=$(bash scripts/link-plugin.sh --print-path)
+[[ $path == "$target" ]] || fail "--print-path: $path"
+
+if bash scripts/link-plugin.sh --bogus 2>"$scratch/usage.err"; then
+  fail 'link-plugin.sh accepted an unknown argument'
+fi
+rg -q 'usage: link-plugin.sh' "$scratch/usage.err" \
+  || fail "Unknown-arg error was unclear: $(cat "$scratch/usage.err")"
+
+rg -q '\[tasks\.plugin-link\]' mise.toml || fail 'mise.toml is missing plugin-link'
+rg -q '\[tasks\.plugin-unlink\]' mise.toml || fail 'mise.toml is missing plugin-unlink'
+if rg -q '^\[tasks\.link\]' mise.toml; then
+  fail 'mise.toml must not use tasks.link; mise link is reserved'
+fi
+rg -q 'link-plugin.sh --rescan' run.sh \
+  || fail 'run.sh does not call link-plugin.sh --rescan'
+if rg -q 'link-plugin' scripts/install-engine.sh scripts/install-launcher.sh; then
+  fail 'an installer references link-plugin.sh'
+fi
+if rg -q 'OMASTORM_RESCAN_PLUGIN' scripts/check.sh scripts/capture-*.sh; then
+  fail 'check or capture sets OMASTORM_RESCAN_PLUGIN'
+fi
+[[ ! -e $target && ! -L $target ]] || fail 'Scratch already had the plugin path'
+
+status=$(bash scripts/link-plugin.sh --status)
+[[ $status == 'installed copy' ]] || fail "unlinked --status: $status"
+
+mkdir -p -- "$scratch/bin"
+cat > "$scratch/bin/omarchy-shell" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${OMASTORM_SHELL_LOG:?}"
+case $* in
+  'shell listPlugins') printf '[{"id":"com.omastorm.radar"}]\n' ;;
+  'shell enablePlugin com.omastorm.radar {}') printf 'ok\n' ;;
+  'shell ping') printf 'ok\n' ;;
+esac
+exit 0
+EOF
+cat > "$scratch/bin/omarchy" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${OMASTORM_OMARCHY_LOG:?}"
+exit 0
+EOF
+chmod +x -- "$scratch/bin/omarchy-shell" "$scratch/bin/omarchy"
+export PATH="$scratch/bin:$PATH" OMASTORM_SHELL_LOG="$scratch/ipc.log" \
+  OMASTORM_OMARCHY_LOG="$scratch/omarchy.log"
+: > "$OMASTORM_SHELL_LOG"
+: > "$OMASTORM_OMARCHY_LOG"
+
+bash scripts/link-plugin.sh --rescan
+[[ ! -s $OMASTORM_SHELL_LOG ]] || fail 'unlinked --rescan talked to omarchy-shell'
+[[ ! -s $OMASTORM_OMARCHY_LOG ]] || fail 'unlinked --rescan talked to omarchy'
+
+bash scripts/link-plugin.sh
+[[ -L $target ]] || fail 'link did not create a symlink'
+[[ $(readlink -f "$target") == "$root" ]] || fail "link points at $(readlink -f "$target")"
+[[ ! -e $backup ]] || fail 'link without a clone wrote a backup'
+rg -q '^restart shell$' "$OMASTORM_OMARCHY_LOG" || fail 'link did not restart the shell'
+rg -q 'enablePlugin com.omastorm.radar \{\}' "$OMASTORM_SHELL_LOG" \
+  || fail 'link did not enable the shell plugin'
+status=$(bash scripts/link-plugin.sh --status)
+[[ $status == 'this checkout (linked)' ]] || fail "linked --status: $status"
+
+: > "$OMASTORM_SHELL_LOG"
+: > "$OMASTORM_OMARCHY_LOG"
+bash scripts/link-plugin.sh
+[[ -L $target ]] || fail 'second link dropped the symlink'
+[[ ! -e $backup ]] || fail 'second link invented a backup'
+rg -q '^restart shell$' "$OMASTORM_OMARCHY_LOG" || fail 'second link did not restart the shell'
+rg -q 'enablePlugin com.omastorm.radar \{\}' "$OMASTORM_SHELL_LOG" \
+  || fail 'second link did not enable the shell plugin'
+
+: > "$OMASTORM_SHELL_LOG"
+out=$(bash scripts/link-plugin.sh --unlink)
+[[ ! -e $target && ! -L $target ]] || fail 'unlink without a clone left a plugin path'
+[[ ! -e $backup ]] || fail 'unlink left a backup with no clone'
+if rg -q 'enablePlugin' "$OMASTORM_SHELL_LOG"; then
+  fail 'unlink enabled the plugin'
+fi
+printf '%s\n' "$out" | rg -q 'omarchy plugin add https://github.com/wesleygrimes/omastorm --enable' \
+  || fail "unlink without clone should name plugin add: $out"
+
+if bash scripts/link-plugin.sh --unlink 2>"$scratch/unlink.err"; then
+  fail 'unlink succeeded when the plugin was already gone'
+fi
+rg -q 'not installed' "$scratch/unlink.err" || fail "gone-unlink error was unclear: $(cat "$scratch/unlink.err")"
+
+mkdir -p -- "$target/ui"
+printf 'clone\n' > "$target/manifest.json"
+: > "$OMASTORM_SHELL_LOG"
+bash scripts/link-plugin.sh
+[[ -L $target ]] || fail 'link did not replace the clone'
+[[ -d $backup ]] || fail 'link did not keep the clone'
+[[ -f $backup/manifest.json ]] || fail 'kept clone lost manifest.json'
+[[ $(<"$backup/manifest.json") == clone ]] || fail 'kept clone contents changed'
+
+bash scripts/link-plugin.sh --unlink
+[[ -d $target && ! -L $target ]] || fail 'unlink did not restore the clone'
+[[ ! -e $backup ]] || fail 'unlink left the backup in place'
+[[ $(<"$target/manifest.json") == clone ]] || fail 'restored clone contents changed'
+
+mkdir -p -- "$backup"
+if bash scripts/link-plugin.sh 2>"$scratch/conflict.err"; then
+  fail 'link replaced a clone while a backup already existed'
+fi
+rg -q 'Kept clone already' "$scratch/conflict.err" \
+  || fail "backup-conflict error was unclear: $(cat "$scratch/conflict.err")"
+[[ -d $target && ! -L $target ]] || fail 'failed link moved the live clone'
+
+rm -rf -- "$backup" "$target"
+ln -s -- /tmp "$target"
+if bash scripts/link-plugin.sh 2>"$scratch/other.err"; then
+  fail 'link replaced a symlink to another path'
+fi
+rg -q 'not this checkout' "$scratch/other.err" \
+  || fail "foreign-symlink error was unclear: $(cat "$scratch/other.err")"
+
+echo 'Link-plugin: scratch symlink, backup/restore, gated shell restart, no install/launch write PASS'

--- a/scripts/check-location.sh
+++ b/scripts/check-location.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Location, remembered state, and radar lock (DESIGN.md, location):
+# resolution order, state writes, the picker, a centre outside a locked
+# radar, restore after close, and isolation from the machine's files.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+check_dir="$PWD/target/check-location"
+mkdir -p "$check_dir"
+printf '{\n  "name": "Stokesdale",\n  "latitude": 36.23708,\n  "longitude": -79.97948\n}\n' > "$check_dir/weather.json"
+: > "$check_dir/none.toml"
+export QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME=basic QT_QUICK_BACKEND=rhi QSG_RHI_BACKEND=opengl
+fail() { printf '%s\n' "$@" >&2; [[ -f $check_dir/log ]] && cat "$check_dir/log" >&2; exit 1; }
+expect() { [[ "$3" == "$2" ]] || fail "$1" "Expected: $2" "Actual:   $3"; }
+start() { # config, location, state
+  local config=$1 location=$2 state=$3
+  OMASTORM_CONFIG="$config" OMASTORM_LOCATION="$location" OMASTORM_STATE="$state" \
+    bash run.sh > "$check_dir/log" 2>&1 &
+  pid=$!
+  trap 'kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true' EXIT
+  for _ in {1..100}; do quickshell ipc --pid "$pid" call keys status > /dev/null 2>&1 && return; sleep .1; done
+  fail "The window never answered"
+}
+stop() { kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true; trap - EXIT; pid=; }
+call() { quickshell ipc --pid "$pid" call keys "$@"; }
+field() { call field "$1"; }
+until_field() {
+  for _ in {1..100}; do [[ $(field "$1") == "$2" ]] && return; sleep .1; done
+  fail "$1 never became $2: $(call status)"
+}
+
+# Isolated from the machine: a remembered centre is the camera, weather is
+# not read unless OMASTORM_LOCATION names a file.
+cat > "$check_dir/state.json" <<'JSON'
+{"lat":35.5,"lon":-97.4,"span":180,"name":"Edmond"}
+JSON
+start "$check_dir/none.toml" "$check_dir/missing.json" "$check_dir/state.json"
+until_field locationSource state
+until_field needsLocation false
+until_field lat 35.5
+until_field lon -97.4
+stop
+
+# Weather outranks a missing state; nearest radar is KFCX, camera on Stokesdale.
+: > "$check_dir/state-weather.json"
+start "$check_dir/none.toml" "$check_dir/weather.json" "$check_dir/state-weather.json"
+until_field locationSource weather
+until_field site KFCX
+until_field lat 36.237
+until_field lon -79.979
+until_field locked false
+# Pan writes state, never config. Reset returns to the weather place.
+call run pan_left
+for _ in {1..30}; do grep -q '"lat"' "$check_dir/state-weather.json" 2>/dev/null && break; sleep .1; done
+grep -q '"lat"' "$check_dir/state-weather.json" || fail "Pan did not write state.json" "$(cat "$check_dir/state-weather.json" 2>/dev/null || true)"
+grep -q home_site "$check_dir/none.toml" && fail "Pan wrote config.toml"
+panned_lon=$(field lon)
+call run reset
+until_field lon -79.979
+[[ $panned_lon != -79.979 ]] || fail "pan_left did not move the camera"
+# Location picker: labeled lat/lon fields write state; a bad latitude is named.
+quickshell ipc --pid "$pid" call location open ""
+for _ in {1..30}; do [[ $(quickshell ipc --pid "$pid" call location status | grep -o '"open":[a-z]*' | cut -d: -f2) == true ]] && break; sleep .1; done
+quickshell ipc --pid "$pid" call location setLat 95
+quickshell ipc --pid "$pid" call location setLon -97.5
+err=$(quickshell ipc --pid "$pid" call location status)
+[[ $err == *latitude* ]] || fail "Invalid latitude was not named: $err"
+quickshell ipc --pid "$pid" call location setLat 35.4
+quickshell ipc --pid "$pid" call location accept
+until_field lat 35.4
+until_field lon -97.5
+until_field locationSource state
+until_field locked false
+grep -q '"lat":35.4' "$check_dir/state-weather.json" || fail "Location picker did not write state" "$(cat "$check_dir/state-weather.json")"
+grep -q center_lat "$check_dir/none.toml" && fail "Location picker wrote config.toml"
+# n selects the nearest radar and does not move the camera.
+before_lat=$(field lat); before_lon=$(field lon)
+call run nearest
+until_field locked false
+expect 'n left the camera' "$before_lat $before_lon" "$(field lat) $(field lon)"
+# Place search through the engine.
+quickshell ipc --pid "$pid" call location open oklahoma
+for _ in {1..40}; do
+  matches=$(quickshell ipc --pid "$pid" call location matches)
+  [[ $matches == *Oklahoma* ]] && break
+  sleep .1
+done
+[[ $matches == *Oklahoma* ]] || fail "Place search did not find Oklahoma City: $matches"
+quickshell ipc --pid "$pid" call location open jacksonville
+for _ in {1..40}; do
+  matches=$(quickshell ipc --pid "$pid" call location matches)
+  [[ $matches == *Texas* && $matches == *Arkansas* ]] && break
+  sleep .1
+done
+[[ $matches == *Texas* && $matches == *Arkansas* ]] || fail "Jacksonville results did not name their states: $matches"
+quickshell ipc --pid "$pid" call location open stokesdale
+for _ in {1..40}; do
+  matches=$(quickshell ipc --pid "$pid" call location matches)
+  [[ $matches == *Stokesdale* && $matches == *North\ Carolina* ]] && break
+  sleep .1
+done
+[[ $matches == *Stokesdale* && $matches == *North\ Carolina* ]] || fail "Stokesdale was not in the gazetteer: $matches"
+quickshell ipc --pid "$pid" call location close
+stop
+
+# Remembered centre outranks weather.
+cat > "$check_dir/state.json" <<'JSON'
+{"lat":29.65,"lon":-82.32,"span":180,"name":"Gainesville"}
+JSON
+start "$check_dir/none.toml" "$check_dir/weather.json" "$check_dir/state.json"
+until_field locationSource state
+until_field lat 29.65
+until_field lon -82.32
+stop
+
+# Explicit centre outranks remembered state on every launch.
+cat > "$check_dir/config.toml" <<'TOML'
+center_lat = 30.332
+center_lon = -81.656
+locked_radar = "KTLX"
+TOML
+start "$check_dir/config.toml" "$check_dir/weather.json" "$check_dir/state.json"
+until_field locationSource config
+until_field lat 30.332
+until_field lon -81.656
+until_field site KTLX
+until_field locked true
+until_field outsideCoverage true
+until_field lockSource config
+# Unlocking lasts this session: a later pan must not restore the configured lock.
+call run lock
+until_field locked false
+call run pan_left
+until_field locked false
+stop
+
+# First-run picker keeps a configured lock; centre and radar stay independent.
+cat > "$check_dir/lock-only.toml" <<'TOML'
+locked_radar = "KTLX"
+TOML
+: > "$check_dir/lock-only-state.json"
+start "$check_dir/lock-only.toml" "$check_dir/missing.json" "$check_dir/lock-only-state.json"
+until_field needsLocation true
+quickshell ipc --pid "$pid" call location go 30.332 -81.656 Jacksonville
+until_field lat 30.332
+until_field lon -81.656
+until_field site KTLX
+until_field locked true
+until_field lockSource config
+stop
+
+# Restore a view that this process actually changed: pan and zoom, persist,
+# close, reopen, and match the saved camera including span.
+: > "$check_dir/empty.toml"
+cat > "$check_dir/state.json" <<'JSON'
+{"lat":35.5,"lon":-97.4,"span":180}
+JSON
+start "$check_dir/empty.toml" "$check_dir/missing.json" "$check_dir/state.json"
+until_field lat 35.5
+until_field lon -97.4
+call run pan_left
+call run zoom_in
+sleep 1
+want_lat=$(field lat)
+want_lon=$(field lon)
+want_span=$(field span)
+grep -q '"lat"' "$check_dir/state.json" || fail "Pan did not persist state for reopen" "$(cat "$check_dir/state.json")"
+stop
+start "$check_dir/empty.toml" "$check_dir/missing.json" "$check_dir/state.json"
+until_field lat "$want_lat"
+until_field lon "$want_lon"
+expect 'Reopened span matches the saved view' "$want_span" "$(field span)"
+stop
+
+# Invalid state fields are dropped; a bad pair in config is named.
+printf '{"lat":"south","lock":1}\n' > "$check_dir/bad-state.json"
+cat > "$check_dir/bad.toml" <<'TOML'
+center_lat = 30.3
+locked_radar = 4
+home_site = "KTLX"
+follow = true
+TOML
+start "$check_dir/bad.toml" "$check_dir/missing.json" "$check_dir/bad-state.json"
+e=""
+for _ in {1..50}; do e=$(call errors); [[ $e == *center_lat* ]] && break; sleep .1; done
+[[ $e == *center_lat* ]] || fail "Unpaired centre was not reported: $e"
+[[ $e == *locked_radar* ]] || fail "Non-string locked_radar was not reported: $e"
+[[ $e == *home_site* ]] || fail "home_site was not reported unused: $e"
+[[ $e == *follow* ]] || fail "follow was not reported unused: $e"
+stop
+
+if rg -q 'TypeError|ReferenceError|Unable to assign|Failed to create.*context|is not a function' "$check_dir/log"; then fail "QML errors in the log"; fi
+echo "LOCATION_PASSED"

--- a/scripts/check-picker.sh
+++ b/scripts/check-picker.sh
@@ -9,9 +9,10 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 check_dir="$PWD/target/check-picker"
 mkdir -p "$check_dir"
-: > "$check_dir/none.toml" # no home site: the fixture's own camera
+: > "$check_dir/none.toml"
+jq -c '.sites[] | select(.id=="KTLX") | {lat, lon, span: 210}' engine/data/sites.json > "$check_dir/state.json"
 export QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME=basic QT_QUICK_BACKEND=rhi QSG_RHI_BACKEND=opengl
-OMASTORM_CONFIG="$check_dir/none.toml" bash run.sh > "$check_dir/log" 2>&1 &
+OMASTORM_CONFIG="$check_dir/none.toml" OMASTORM_STATE="$check_dir/state.json" bash run.sh > "$check_dir/log" 2>&1 &
 pid=$!
 trap 'kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true' EXIT
 call() { quickshell ipc --pid "$pid" call picker "$@"; }

--- a/scripts/check-popover.sh
+++ b/scripts/check-popover.sh
@@ -7,9 +7,11 @@ scratch=$(mktemp -d /tmp/omastorm-popover.XXXXXX)
 export XDG_RUNTIME_DIR="$scratch/runtime" XDG_CACHE_HOME="$scratch/cache"
 export QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME=basic QT_QUICK_BACKEND=rhi QSG_RHI_BACKEND=opengl
 export OMASTORM_CONFIG="$scratch/config.toml"
+export OMASTORM_STATE="$scratch/state.json"
 export OMASTORM_ROOT="$PWD"
 mkdir -p "$XDG_RUNTIME_DIR"
 : > "$OMASTORM_CONFIG"
+jq -c '.sites[] | select(.id=="KTLX") | {lat, lon, span: 210}' engine/data/sites.json > "$OMASTORM_STATE"
 pid=
 cleanup() {
   [[ -z $pid ]] || kill "$pid" 2>/dev/null || true
@@ -81,11 +83,11 @@ tell '{"type":"select_site","id":"KTLX"}' '{"type":"seek","id":"popover-test-0"}
 until_status '.frame == "popover-test-0"'
 call expand
 until_status '.window and .windowFrame == "popover-test-0" and (.windowPlaying | not)'
-# Home edits apply immediately; subsequently selecting another station must
-# survive expansion, and closing the window returns to the configured home.
-printf 'home_site = "KFCX"\n' > "$OMASTORM_CONFIG"
+# A configured lock applies immediately; subsequently selecting another
+# station must survive expansion, and closing the window leaves it there.
+printf 'locked_radar = "KFCX"\n' > "$OMASTORM_CONFIG"
 until_status '.site == "KFCX"'
-tell '{"type":"select_site","id":"KTLX"}' '{"type":"seek","id":"popover-test-0"}'
+tell '{"type":"select_site","id":"KTLX"}' '{"type":"lock","enabled":true}' '{"type":"seek","id":"popover-test-0"}'
 until_status '.frame == "popover-test-0"'
 call step 1
 until_status '.frame == "popover-test-1" and .windowFrame == "popover-test-1"'
@@ -96,8 +98,10 @@ call reopen
 call expand
 until_status '.playing and .windowPlaying and .site == "KTLX"'
 call closeWindow
-until_status '.window == false and .site == "KFCX"'
+until_status '.window == false and .site == "KTLX"'
 # A stopped daemon followed by ensure must reconnect all surviving clients.
+# Reconnect keeps the session lock and camera; this process never unlocked,
+# so KFCX is selected again.
 target/debug/omastorm-engine stop
 until_status '.connected == false'
 target/debug/omastorm-engine ensure
@@ -106,4 +110,4 @@ call quit
 wait "$pid"
 pid=
 if rg 'Binding loop|ReferenceError|TypeError|Unable to assign|Failed to load' "$scratch/ui.log"; then fail 'QML runtime errors'; fi
-echo 'Popover: archived provenance, expand preservation, treatment sharing, close/reopen, playback, home return, daemon restart PASS'
+echo 'Popover: archived provenance, expand preservation, treatment sharing, close/reopen, playback, lock, daemon restart PASS'

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -38,7 +38,7 @@ export OMASTORM_ARCHIVE="$PWD/data/raw/KTLX20130520_201643_V06.gz"
 # check-picker and check-keys select stations for real, so they run last.
 export XDG_RUNTIME_DIR="$scratch/runtime"
 mkdir -p "$XDG_RUNTIME_DIR"
-for check in check-engine-ui check-engine-install check-map-tiles check-map-sites check-map-network check-theme check-picker check-keys check-popover check-launcher check-bind; do
+for check in check-engine-ui check-engine-install check-map-tiles check-map-sites check-map-network check-theme check-location check-picker check-keys check-popover check-launcher check-bind; do
   step "$check" timeout 180 bash "scripts/$check.sh"
 done
 target/debug/omastorm-engine stop > /dev/null 2>&1 || true

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -38,7 +38,7 @@ export OMASTORM_ARCHIVE="$PWD/data/raw/KTLX20130520_201643_V06.gz"
 # check-picker and check-keys select stations for real, so they run last.
 export XDG_RUNTIME_DIR="$scratch/runtime"
 mkdir -p "$XDG_RUNTIME_DIR"
-for check in check-engine-ui check-engine-install check-map-tiles check-map-sites check-map-network check-theme check-location check-picker check-keys check-popover check-launcher check-bind; do
+for check in check-engine-ui check-engine-install check-map-tiles check-map-sites check-map-network check-theme check-location check-picker check-keys check-popover check-launcher check-link-plugin check-bind; do
   step "$check" timeout 180 bash "scripts/$check.sh"
 done
 target/debug/omastorm-engine stop > /dev/null 2>&1 || true

--- a/scripts/link-plugin.sh
+++ b/scripts/link-plugin.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Point the Omarchy bar plugin at this checkout, or restore the clone.
+# Ordinary install and launch never call this; mise plugin-link / plugin-unlink do.
+# --rescan restarts the Omarchy shell when this checkout is linked, so the bar
+# drops cached QML (inotify and rescanPlugins do not follow the symlink).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+die() { printf '%s\n' "$@" >&2; exit 1; }
+
+id=com.omastorm.radar
+root=$(readlink -f "$PWD")
+plugins=${XDG_CONFIG_HOME:-${HOME:?}/.config}/omarchy/plugins
+target=$plugins/$id
+backup=$plugins/.$id.unlinked
+
+[[ -f $root/manifest.json ]] || die "Not an Omastorm checkout: missing $root/manifest.json"
+got=$(jq -r .id "$root/manifest.json")
+[[ $got == "$id" ]] || die "manifest id is $got, expected $id"
+
+linked() {
+  [[ -L $target ]] || return 1
+  [[ $(readlink -f "$target") == "$root" ]]
+}
+
+shell_up() {
+  command -v omarchy-shell >/dev/null 2>&1 || return 1
+  omarchy-shell shell ping >/dev/null 2>&1
+}
+
+rescan() {
+  command -v omarchy >/dev/null 2>&1 || return 0
+  shell_up || return 0
+  # rescanPlugins leaves the popover on the QML loaded before the symlink.
+  omarchy restart shell >/dev/null 2>&1 || true
+  local i
+  for (( i = 0; i < 50; i++ )); do
+    shell_up && return 0
+    sleep 0.1
+  done
+}
+
+enable() {
+  if ! shell_up; then
+    printf 'Enable it when the shell is running: omarchy plugin enable %s\n' "$id"
+    return 0
+  fi
+  local attempt result
+  local discovered=0
+  for (( attempt = 0; attempt < 40; attempt++ )); do
+    if omarchy-shell shell listPlugins 2>/dev/null | jq -e --arg id "$id" 'any(.[]; .id == $id)' >/dev/null; then
+      discovered=1
+      break
+    fi
+    sleep 0.05
+  done
+  if (( ! discovered )); then
+    die "The shell does not know $id yet. Is omarchy-shell running?"
+  fi
+  result=$(omarchy-shell shell enablePlugin "$id" '{}')
+  [[ $result == ok ]] || die "Could not enable $id: ${result:-no reply}"
+  printf 'Enabled %s\n' "$id"
+}
+
+link() {
+  mkdir -p -- "$plugins"
+  if linked; then
+    printf 'Already linked: %s -> %s\n' "$target" "$root"
+    rescan
+    enable
+    return 0
+  fi
+  if [[ -L $target ]]; then
+    die "Plugin is a symlink to $(readlink -f "$target"), not this checkout. Unlink that first."
+  fi
+  if [[ -e $target ]]; then
+    [[ -d $target ]] || die "Refusing to replace $target (not a directory)"
+    if [[ -e $backup || -L $backup ]]; then
+      die "Kept clone already at $backup. mise plugin-unlink, or remove that backup, then retry."
+    fi
+    mv -- "$target" "$backup" || die "Could not move $target aside. Check ownership, then retry."
+    printf 'Kept installed clone at %s\n' "$backup"
+  fi
+  ln -s -- "$root" "$target" || {
+    if [[ -d $backup ]]; then
+      mv -- "$backup" "$target" || true
+    fi
+    die "Could not link $target -> $root. Check ownership, then retry."
+  }
+  printf 'Linked %s -> %s\n' "$target" "$root"
+  rescan
+  enable
+}
+
+unlink() {
+  if [[ ! -e $target && ! -L $target ]]; then
+    die "Plugin is not installed at $target"
+  fi
+  linked || die "Plugin at $target is not a symlink to this checkout."
+  rm -f -- "$target"
+  if [[ -d $backup ]]; then
+    mv -- "$backup" "$target" || die "Removed the link but could not restore $backup"
+    printf 'Restored installed clone at %s\n' "$target"
+  else
+    printf 'Unlinked %s. No clone to restore; omarchy plugin add https://github.com/wesleygrimes/omastorm --enable\n' "$target"
+  fi
+  rescan
+}
+
+case ${1:-} in
+  ''|--link) link ;;
+  --unlink) unlink ;;
+  --rescan)
+    linked || exit 0
+    rescan
+    ;;
+  --status)
+    if linked; then printf 'this checkout (linked)\n'
+    else printf 'installed copy\n'
+    fi
+    ;;
+  --print-path) printf '%s\n' "$target" ;;
+  *) die "usage: link-plugin.sh [--link|--unlink|--rescan|--status|--print-path]" ;;
+esac

--- a/ui/Config.qml
+++ b/ui/Config.qml
@@ -3,16 +3,16 @@ import Quickshell
 import Quickshell.Io
 import "Toml.js" as Toml
 
-// ~/.config/omastorm/config.toml (docs/protocol.md, configuration): the
-// home station, whether the map centre picks the station, the treatment,
-// the weak-return floor, and the `[keys]` table. Watched like the theme
-// files, so an edit applies to the running window. OMASTORM_CONFIG names
-// another file for checks and captures; a missing file is no config.
+// ~/.config/omastorm/config.toml (docs/protocol.md, configuration):
+// deliberate preferences — an explicit map centre, a locked radar, the
+// treatment, the weak-return floor, and the `[keys]` table. Watched like
+// the theme files, so an edit applies to the running window. OMASTORM_CONFIG
+// names another file for checks and captures; a missing file is no config.
 //
-// Omarchy's own location (DESIGN.md, site model), the file its weather
-// panel writes, is read beside it for the current-location home. It is
-// this machine's setting, so a check or capture that names its own config
-// leaves it alone unless OMASTORM_LOCATION names a location file too.
+// Omarchy's own location (DESIGN.md, location), the file its weather panel
+// writes, is read beside it when no explicit or remembered centre exists.
+// It is this machine's setting, so a check or capture that names its own
+// config leaves it alone unless OMASTORM_LOCATION names a location file too.
 QtObject {
     id: root
     readonly property string path: Quickshell.env("OMASTORM_CONFIG") || (Quickshell.env("HOME") + "/.config/omastorm/config.toml")
@@ -24,9 +24,9 @@ QtObject {
     readonly property bool ready: configRead && locationRead
     property bool configRead: false
     property bool locationRead: false
-    readonly property string homeSite: typeof values.home_site === "string" ? values.home_site.trim().toUpperCase() : ""
-    // undefined while unset: the engine's shared flag stands.
-    readonly property var follow: typeof values.follow === "boolean" ? values.follow : undefined
+    readonly property var centerLat: typeof values.center_lat === "number" ? values.center_lat : undefined
+    readonly property var centerLon: typeof values.center_lon === "number" ? values.center_lon : undefined
+    readonly property string lockedRadar: typeof values.locked_radar === "string" ? values.locked_radar.trim().toUpperCase() : ""
     // The raw value; the window judges it against the three treatments.
     readonly property var treatment: values.treatment
     // The raw value; the window judges it: a dBZ number, false, or unset.
@@ -45,35 +45,8 @@ QtObject {
         watchChanges: true
         printErrors: false
         onFileChanged: reload()
-        onLoaded: { root.raw = text(); root.values = Toml.parse(root.raw); root.configRead = true; }
-        onLoadFailed: { root.raw = ""; root.values = ({}); root.configRead = true; }
-    }
-    // The file as last read, so a save keeps every other line.
-    property string raw: ""
-    property string pendingText: ""
-    // Save `id` as home_site: the top-level line is replaced in place, or
-    // added above the first table; nothing else in the file changes. The
-    // directory may not exist yet, so the write follows its creation, and
-    // the watch above reloads the result like any other edit.
-    function setHome(id) {
-        var lines = raw.length ? raw.replace(/\n$/, "").split("\n") : [];
-        var line = 'home_site = "' + id + '"', out = [], done = false, inTable = false;
-        for (var l of lines) {
-            if (/^\s*\[/.test(l)) inTable = true;
-            if (!done && !inTable && /^\s*home_site\s*=/.test(l)) { out.push(line); done = true; }
-            else out.push(l);
-        }
-        if (!done) {
-            var at = out.findIndex(l => /^\s*\[/.test(l));
-            if (at < 0) out.push(line); else out.splice(at, 0, line);
-        }
-        pendingText = out.join("\n") + "\n";
-        mkdir.running = true;
-    }
-    property Process mkdir: Process {
-        command: ["mkdir", "-p", root.path.substring(0, root.path.lastIndexOf("/"))]
-        // The view does not report its own write, so the values follow at once.
-        onExited: { file.setText(root.pendingText); root.raw = root.pendingText; root.values = Toml.parse(root.raw); }
+        onLoaded: { root.values = Toml.parse(text()); root.configRead = true; }
+        onLoadFailed: { root.values = ({}); root.configRead = true; }
     }
     property FileView locationFile: FileView {
         path: root.locationPath

--- a/ui/Engine.qml
+++ b/ui/Engine.qml
@@ -17,6 +17,8 @@ QtObject {
     property bool incompatible: false
     /// One tile answering this client's `tiles_needed`; a reply, not state.
     signal tileReady(var tile)
+    /// Places answering this client's `search_places`; a reply, not state.
+    signal placesReady(var message)
     readonly property string runtime: Quickshell.env("XDG_RUNTIME_DIR") + "/omastorm/"
     readonly property string texture: state && state.frame ? "file://" + runtime + state.frame.texture : ""
     readonly property string azimuthLut: state && state.frame ? "file://" + runtime + state.frame.azimuthLut : ""
@@ -67,11 +69,13 @@ QtObject {
                 if (!validTilePath(message.path))
                     throw new Error("Invalid tile path: " + JSON.stringify(message.path));
                 tileReady(message);
+            } else if (message.type === "places") {
+                placesReady(message);
             }
         } catch (e) { state = null; error = "Invalid engine message: " + e; }
     }
     function send(command) {
-        if (command.type !== "tiles_needed") rejection = "";
+        if (command.type !== "tiles_needed" && command.type !== "search_places") rejection = "";
         socket.write(JSON.stringify(command) + "\n");
     }
     property var socket: socketFactory.createObject(engine)

--- a/ui/Keys.js
+++ b/ui/Keys.js
@@ -36,12 +36,12 @@ var ACTIONS = [
 // several actions shows each one's first key and names the alternates.
 var ROWS = [
     [{ label: "search sites", actions: ["search"] },
-     { label: "nearest site", actions: ["nearest"] },
-     { label: "lock / release site", actions: ["lock"] },
-     { label: "save site as home", actions: ["home"] },
+     { label: "nearest radar", actions: ["nearest"] },
+     { label: "lock / release radar", actions: ["lock"] },
+     { label: "choose location", actions: ["home"] },
      { label: "pan", actions: ["pan_left", "pan_down", "pan_up", "pan_right"] },
      { label: "zoom", actions: ["zoom_in", "zoom_out"] },
-     { label: "reset to home view", actions: ["reset"] }],
+     { label: "reset to location", actions: ["reset"] }],
     [{ label: "previous frame", actions: ["previous_frame"] },
      { label: "next frame", actions: ["next_frame"] },
      { label: "play / pause", actions: ["play"] },

--- a/ui/Location.js
+++ b/ui/Location.js
@@ -1,0 +1,156 @@
+.pragma library
+// Map centre, remembered view, and radar lock (DESIGN.md, location and
+// remembered state). Pure functions so a check can drive them without a
+// window. Config.toml holds deliberate preferences; state.json holds the
+// last camera and the UI radar lock.
+
+var DEFAULT_SPAN = 210;
+var MIN_SPAN = 25;
+
+function validLat(value) {
+    return typeof value === "number" && isFinite(value) && Math.abs(value) <= 90;
+}
+function validLon(value) {
+    return typeof value === "number" && isFinite(value) && Math.abs(value) <= 180;
+}
+function validPair(lat, lon) { return validLat(lat) && validLon(lon); }
+
+function clampSpan(value) {
+    var n = typeof value === "number" && isFinite(value) ? value : DEFAULT_SPAN;
+    return Math.max(MIN_SPAN, n);
+}
+
+function parseLatitude(text) {
+    var t = String(text).trim();
+    if (!t) return { empty: true };
+    var n = Number(t);
+    if (!isFinite(n)) return { error: "latitude is not a number" };
+    if (Math.abs(n) > 90) return { error: "latitude must be in [-90, 90]" };
+    return { value: n };
+}
+function parseLongitude(text) {
+    var t = String(text).trim();
+    if (!t) return { empty: true };
+    var n = Number(t);
+    if (!isFinite(n)) return { error: "longitude is not a number" };
+    if (Math.abs(n) > 180) return { error: "longitude must be in [-180, 180]" };
+    return { value: n };
+}
+function parseCoordFields(latText, lonText) {
+    var lat = parseLatitude(latText), lon = parseLongitude(lonText);
+    if (lat.empty && lon.empty) return { empty: true };
+    if (lat.empty || lon.empty) return { error: "latitude and longitude must both be set" };
+    if (lat.error) return { error: lat.error };
+    if (lon.error) return { error: lon.error };
+    return { lat: lat.value, lon: lon.value };
+}
+
+function distanceKm(lat1, lon1, lat2, lon2) {
+    var r = Math.PI / 180, dp = (lat2 - lat1) * r, dl = (lon2 - lon1) * r;
+    var h = Math.sin(dp / 2) ** 2 + Math.cos(lat1 * r) * Math.cos(lat2 * r) * Math.sin(dl / 2) ** 2;
+    return 2 * 6371 * Math.asin(Math.sqrt(Math.max(0, Math.min(1, h))));
+}
+
+function nearestSite(sites, lat, lon) {
+    var best = null, bestKm = Infinity;
+    if (!validPair(lat, lon) || !sites) return null;
+    for (var s of sites) {
+        var km = distanceKm(lat, lon, s.lat, s.lon);
+        if (km < bestKm) { bestKm = km; best = s; }
+    }
+    return best;
+}
+
+function envView(text) {
+    if (!text) return null;
+    var parts = String(text).split(",");
+    if (parts.length !== 3) return null;
+    var lat = Number(parts[0]), lon = Number(parts[1]), span = Number(parts[2]);
+    return validPair(lat, lon) && isFinite(span) && span > 0 ? { lat: lat, lon: lon, span: span } : null;
+}
+
+// Explicit centre from config.toml: both keys, both in range, or null.
+function configCenter(values) {
+    if (!values || values.center_lat === undefined && values.center_lon === undefined) return null;
+    if (values.center_lat === undefined || values.center_lon === undefined) return null;
+    return validPair(values.center_lat, values.center_lon)
+        ? { lat: values.center_lat, lon: values.center_lon } : null;
+}
+
+function configLock(values) {
+    if (!values || typeof values.locked_radar !== "string") return "";
+    return values.locked_radar.trim().toUpperCase();
+}
+
+function configErrors(values) {
+    var errors = [];
+    if (!values) return errors;
+    var hasLat = values.center_lat !== undefined, hasLon = values.center_lon !== undefined;
+    if (hasLat !== hasLon)
+        errors.push("center_lat and center_lon must both be set");
+    else if (hasLat && !validPair(values.center_lat, values.center_lon))
+        errors.push("center_lat/center_lon must be latitudes in [-90, 90] and longitudes in [-180, 180]");
+    if (values.locked_radar !== undefined) {
+        if (typeof values.locked_radar !== "string")
+            errors.push("locked_radar must be a quoted station id");
+        else if (!values.locked_radar.trim())
+            errors.push("locked_radar must be a quoted station id");
+    }
+    if (values.home_site !== undefined)
+        errors.push("home_site is unused; location is a place (center_lat/center_lon or the location picker)");
+    if (values.follow !== undefined)
+        errors.push("follow is unused; the map follows the nearest radar unless locked");
+    return errors;
+}
+
+// Remembered view from state.json. Invalid fields are dropped, not fatal.
+function parseState(raw) {
+    var empty = { lat: undefined, lon: undefined, span: undefined, lock: "", name: "" };
+    if (raw === undefined || raw === null || raw === "") return empty;
+    try {
+        var json = typeof raw === "string" ? JSON.parse(raw) : raw;
+        if (!json || typeof json !== "object") return empty;
+        var lat = json.lat, lon = json.lon, span = json.span;
+        return {
+            lat: validLat(lat) ? lat : undefined,
+            lon: validLon(lon) ? lon : undefined,
+            span: typeof span === "number" && isFinite(span) && span > 0 ? span : undefined,
+            lock: typeof json.lock === "string" ? json.lock.trim().toUpperCase() : "",
+            name: typeof json.name === "string" ? json.name : ""
+        };
+    } catch (e) { return empty; }
+}
+
+function stateObject(viewLat, viewLon, span, lock, name) {
+    var o = {};
+    if (validPair(viewLat, viewLon)) { o.lat = viewLat; o.lon = viewLon; }
+    if (typeof span === "number" && isFinite(span) && span > 0) o.span = span;
+    if (lock) o.lock = lock;
+    if (name) o.name = name;
+    return o;
+}
+
+// Map centre at launch: explicit config, remembered view, Omarchy weather,
+// else nothing (the location picker). Captures may pass env as the first
+// argument to outrank the rest for that process.
+function resolvePlace(explicit, remembered, weather, env) {
+    if (env && validPair(env.lat, env.lon))
+        return { lat: env.lat, lon: env.lon, name: "", source: "view", span: env.span };
+    if (explicit && validPair(explicit.lat, explicit.lon))
+        return { lat: explicit.lat, lon: explicit.lon, name: "", source: "config", span: remembered && remembered.span };
+    if (remembered && validPair(remembered.lat, remembered.lon))
+        return { lat: remembered.lat, lon: remembered.lon, name: remembered.name || "", source: "state", span: remembered.span };
+    if (weather && validPair(weather.lat, weather.lon))
+        return { lat: weather.lat, lon: weather.lon, name: weather.name || "", source: "weather", span: remembered && remembered.span };
+    return null;
+}
+
+// RESET target: configured centre, else weather, else none (keep the camera,
+// restore the default span).
+function resolveReset(explicit, weather) {
+    if (explicit && validPair(explicit.lat, explicit.lon))
+        return { lat: explicit.lat, lon: explicit.lon, name: "", source: "config" };
+    if (weather && validPair(weather.lat, weather.lon))
+        return { lat: weather.lat, lon: weather.lon, name: weather.name || "", source: "weather" };
+    return null;
+}

--- a/ui/LocationPicker.qml
+++ b/ui/LocationPicker.qml
@@ -1,0 +1,292 @@
+import QtQuick
+import QtQuick.Layouts
+import "Location.js" as Location
+import "Sites.js" as Sites
+
+// The location picker (DESIGN.md, location): engine search_places plus
+// labeled lat/lon; Enter writes state, never config. The keys are handled
+// here while it is open; the window's own shortcuts stand down.
+Item {
+    id: picker
+    property var theme
+    property var engine
+    property real centerLat: 0
+    property real centerLon: 0
+    property bool compact: false
+    property real cardTop: 20
+    property bool open: false
+    property bool closeOnScrim: true
+    property alias query: field.text
+    property alias latText: latField.text
+    property alias lonText: lonField.text
+    readonly property bool fieldFocused: field.activeFocus || latField.activeFocus || lonField.activeFocus
+    property int selected: 0
+    property var results: []
+    property string pendingQuery: ""
+    readonly property int limit: 4
+    readonly property var coordEntry: Location.parseCoordFields(latText, lonText)
+    readonly property string coordError: coordEntry.error || ""
+    component Word: Text {
+        color: picker.theme.foreground
+        font.family: picker.theme.font
+        font.pixelSize: 12
+        elide: Text.ElideRight
+        verticalAlignment: Text.AlignVCenter
+    }
+    signal chosen(real lat, real lon, string name)
+    readonly property var rows: {
+        var out = [];
+        for (var p of results) {
+            var bits = [];
+            if (p.region) bits.push(p.region);
+            if (p.country && p.country !== "-99") bits.push(p.country);
+            var where = bits.join(", ");
+            if (!where) {
+                var km = Location.validPair(centerLat, centerLon) ? Location.distanceKm(centerLat, centerLon, p.lat, p.lon) : 0;
+                where = Location.validPair(centerLat, centerLon) ? Sites.where(km, Sites.bearingDeg(centerLat, centerLon, p.lat, p.lon)) : (p.class || "").toUpperCase();
+            }
+            out.push({ name: p.name, lat: p.lat, lon: p.lon, kind: p.class || "place",
+                       where: where, label: p.region ? p.name + ", " + p.region : p.name });
+            if (out.length >= limit) break;
+        }
+        return out;
+    }
+    visible: open
+    function show(text) {
+        field.text = text || "";
+        latField.text = "";
+        lonField.text = "";
+        selected = 0;
+        results = [];
+        open = true;
+        Qt.callLater(() => { field.cursorPosition = field.length; field.forceActiveFocus(); });
+        search.restart();
+    }
+    function close() {
+        open = false;
+        field.text = "";
+        latField.text = "";
+        lonField.text = "";
+        selected = 0;
+        results = [];
+        field.focus = false;
+        latField.focus = false;
+        lonField.focus = false;
+    }
+    function accept() {
+        if (!open) return;
+        if (coordEntry.lat !== undefined) { var lat = coordEntry.lat, lon = coordEntry.lon; close(); chosen(lat, lon, ""); return; }
+        if (coordError || !rows.length) return;
+        var row = rows[Math.min(selected, rows.length - 1)];
+        close();
+        chosen(row.lat, row.lon, row.label);
+    }
+    function move(delta) { selected = Math.max(0, Math.min(rows.length - 1, selected + delta)); }
+    function go(lat, lon, name) { close(); chosen(lat, lon, name || ""); }
+    onQueryChanged: { selected = 0; search.restart(); }
+    Timer {
+        id: search
+        interval: 120
+        onTriggered: {
+            if (!picker.open || !picker.engine) return;
+            var q = picker.query.trim();
+            if (!q) { picker.results = []; return; }
+            picker.pendingQuery = q;
+            var cmd = {type: "search_places", query: q};
+            if (Location.validPair(picker.centerLat, picker.centerLon)) {
+                cmd.lat = picker.centerLat;
+                cmd.lon = picker.centerLon;
+            }
+            picker.engine.send(cmd);
+        }
+    }
+    Connections {
+        target: picker.engine
+        function onPlacesReady(message) {
+            if (!picker.open || message.query !== picker.pendingQuery) return;
+            picker.results = message.results || [];
+        }
+    }
+    Rectangle {
+        anchors.fill: parent
+        color: Qt.alpha(picker.theme.background, .5)
+        MouseArea { anchors.fill: parent; onClicked: if (picker.closeOnScrim) picker.close() }
+    }
+    Rectangle {
+        id: card
+        width: Math.min(520, picker.width - 40)
+        x: Math.round((picker.width - width) / 2)
+        y: Math.round(Math.max(20, Math.min(picker.cardTop, picker.height - height - 20)))
+        height: column.implicitHeight + 28
+        color: Qt.alpha(picker.theme.background, .95)
+        border.width: 1
+        border.color: picker.theme.foreground
+        MouseArea { anchors.fill: parent }
+        ColumnLayout {
+            id: column
+            anchors.fill: parent
+            anchors.margins: 14
+            spacing: 10
+            Rectangle {
+                Layout.fillWidth: true
+                implicitHeight: 36
+                color: Qt.alpha(picker.theme.foreground, .04)
+                border.width: 1
+                border.color: Qt.alpha(picker.theme.foreground, .4)
+                RowLayout {
+                    anchors.fill: parent
+                    anchors.leftMargin: 10
+                    anchors.rightMargin: 10
+                    spacing: 10
+                    Canvas {
+                        implicitWidth: 16; implicitHeight: 16
+                        property color ink: picker.theme.foreground
+                        onInkChanged: requestPaint()
+                        onPaint: {
+                            var ctx = getContext("2d");
+                            ctx.reset(); ctx.clearRect(0, 0, width, height);
+                            ctx.strokeStyle = ink; ctx.lineWidth = 1.5;
+                            ctx.beginPath(); ctx.arc(6.5, 6.5, 4.5, 0, 2 * Math.PI); ctx.stroke();
+                            ctx.beginPath(); ctx.moveTo(10, 10); ctx.lineTo(14, 14); ctx.stroke();
+                        }
+                    }
+                    TextInput {
+                        id: field
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        color: picker.theme.foreground
+                        font.family: picker.theme.font
+                        font.pixelSize: 13
+                        verticalAlignment: TextInput.AlignVCenter
+                        clip: true
+                        leftPadding: 0; rightPadding: 0
+                        cursorVisible: false
+                        cursorDelegate: Item {}
+                        Keys.onPressed: event => {
+                            if (event.key === Qt.Key_Escape) { picker.close(); event.accepted = true; }
+                            else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) { picker.accept(); event.accepted = true; }
+                            else if (event.key === Qt.Key_Up) { picker.move(-1); event.accepted = true; }
+                            else if (event.key === Qt.Key_Down) { picker.move(1); event.accepted = true; }
+                            else if (event.key === Qt.Key_U && event.modifiers === Qt.ControlModifier) { field.text = ""; event.accepted = true; }
+                        }
+                        Rectangle {
+                            width: 7; height: 15
+                            x: field.cursorRectangle.x
+                            y: Math.round(field.cursorRectangle.y + (field.cursorRectangle.height - height) / 2)
+                            color: picker.theme.foreground
+                            opacity: .9
+                        }
+                    }
+                    Word { text: "place"; font.pixelSize: 10; opacity: .45; visible: !picker.compact }
+                }
+            }
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 10
+                Word { text: "LAT"; font.pixelSize: 10; opacity: .55; Layout.preferredWidth: 28 }
+                Rectangle {
+                    Layout.fillWidth: true
+                    implicitHeight: 28
+                    color: Qt.alpha(picker.theme.foreground, .04)
+                    border.width: 1
+                    border.color: Qt.alpha(picker.theme.foreground, .4)
+                    TextInput {
+                        id: latField
+                        anchors.fill: parent
+                        anchors.leftMargin: 8
+                        anchors.rightMargin: 8
+                        color: picker.theme.foreground
+                        font.family: picker.theme.font
+                        font.pixelSize: 12
+                        verticalAlignment: TextInput.AlignVCenter
+                        clip: true
+                        Keys.onPressed: event => {
+                            if (event.key === Qt.Key_Escape) { picker.close(); event.accepted = true; }
+                            else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) { picker.accept(); event.accepted = true; }
+                        }
+                    }
+                }
+                Word { text: "LON"; font.pixelSize: 10; opacity: .55; Layout.preferredWidth: 28 }
+                Rectangle {
+                    Layout.fillWidth: true
+                    implicitHeight: 28
+                    color: Qt.alpha(picker.theme.foreground, .04)
+                    border.width: 1
+                    border.color: Qt.alpha(picker.theme.foreground, .4)
+                    TextInput {
+                        id: lonField
+                        anchors.fill: parent
+                        anchors.leftMargin: 8
+                        anchors.rightMargin: 8
+                        color: picker.theme.foreground
+                        font.family: picker.theme.font
+                        font.pixelSize: 12
+                        verticalAlignment: TextInput.AlignVCenter
+                        clip: true
+                        Keys.onPressed: event => {
+                            if (event.key === Qt.Key_Escape) { picker.close(); event.accepted = true; }
+                            else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) { picker.accept(); event.accepted = true; }
+                        }
+                    }
+                }
+            }
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 0
+                Repeater {
+                    model: picker.rows
+                    Rectangle {
+                        id: row
+                        required property var modelData
+                        required property int index
+                        readonly property bool current: index === picker.selected
+                        readonly property color ink: current ? picker.theme.accent : picker.theme.foreground
+                        Layout.fillWidth: true
+                        implicitHeight: 28
+                        color: current ? Qt.alpha(picker.theme.foreground, .08) : "transparent"
+                        RowLayout {
+                            anchors.fill: parent
+                            anchors.leftMargin: 12
+                            anchors.rightMargin: 12
+                            spacing: 12
+                            Word { text: row.modelData.name; font.bold: true; color: row.ink; Layout.fillWidth: true }
+                            Word { text: row.modelData.where; font.pixelSize: 10; color: row.ink; opacity: .6 }
+                        }
+                        MouseArea {
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            onPositionChanged: picker.selected = row.index
+                            onClicked: { picker.selected = row.index; picker.accept(); }
+                        }
+                    }
+                }
+                Word {
+                    visible: !!picker.coordError
+                    text: picker.coordError.toUpperCase()
+                    color: picker.theme.accent
+                    Layout.fillWidth: true; Layout.leftMargin: 12; Layout.preferredHeight: 28; font.letterSpacing: 1
+                }
+                Word {
+                    visible: !picker.coordError && picker.coordEntry.lat !== undefined
+                    text: picker.coordEntry.lat === undefined ? "" : "↵ GO TO " + picker.coordEntry.lat.toFixed(4) + ", " + picker.coordEntry.lon.toFixed(4)
+                    Layout.fillWidth: true; Layout.leftMargin: 12; Layout.preferredHeight: 28; opacity: .55; font.letterSpacing: 1
+                }
+                Word {
+                    visible: !picker.coordError && picker.coordEntry.lat === undefined && !picker.rows.length
+                    text: picker.query.trim() ? "NO PLACE MATCHES · TRY COORDINATES" : "TOWNS OF 5,000+ PEOPLE, OR ENTER LATITUDE AND LONGITUDE"
+                    Layout.fillWidth: true; Layout.leftMargin: 12; Layout.preferredHeight: 28; opacity: .55; font.letterSpacing: 1
+                }
+            }
+            Rectangle { Layout.fillWidth: true; height: 1; color: Qt.alpha(picker.theme.foreground, .17) }
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 14
+                Word { text: "↑ ↓ move"; font.pixelSize: 10; opacity: .55 }
+                Word { text: "↵ set location"; font.pixelSize: 10; opacity: .55 }
+                Word { text: "esc close"; font.pixelSize: 10; opacity: .55; visible: !picker.compact }
+                Item { Layout.fillWidth: true }
+                Word { text: picker.rows.length ? picker.rows.length + " shown" : ""; font.pixelSize: 10; opacity: .55 }
+            }
+        }
+    }
+}

--- a/ui/PluginSession.qml
+++ b/ui/PluginSession.qml
@@ -2,7 +2,7 @@ pragma Singleton
 import QtQuick
 import Quickshell
 import Quickshell.Io
-import "Sites.js" as Sites
+import "Location.js" as Location
 import "Keys.js" as KeyMap
 
 QtObject {
@@ -11,6 +11,7 @@ QtObject {
     // outputs. Visible maps have separate sockets for their tile rectangles.
     property Engine engine: Engine {}
     property Config config: Config {}
+    property Remembered remembered: Remembered {}
     property Theme theme: Theme {}
     property bool windowOpen: false
     property bool initialized: false
@@ -20,40 +21,217 @@ QtObject {
     // key change it, OMASTORM_WEAK outranks the file for captures.
     property var weakFloor: KeyMap.envFloor(Quickshell.env("OMASTORM_WEAK")) !== undefined ? KeyMap.envFloor(Quickshell.env("OMASTORM_WEAK")) : KeyMap.DEFAULT_FLOOR
     property string startupError: ""
-    signal homeRequested()
-    readonly property string homeSite: {
-        if (config.homeSite) return config.homeSite;
-        if (!config.location) return "";
-        var best = "", distance = Infinity;
-        for (var site of engine.sites) {
-            var km = Sites.distanceKm(config.location.lat, config.location.lon, site.lat, site.lon);
-            if (km < distance) { best = site.id; distance = km; }
-        }
-        return best;
+    readonly property bool ready: config.ready && remembered.ready
+    readonly property string persistError: remembered.error ? remembered.error.toUpperCase() : ""
+    property bool hasView: false
+    property bool needsLocation: false
+    property string placeName: ""
+    property string locationSource: ""
+    property real centerLat: 0
+    property real centerLon: 0
+    property real span: Location.DEFAULT_SPAN
+    property string lockId: ""
+    property bool lockWanted: false
+    property string lockSource: ""
+    property string lastConfigLock: ""
+    property bool pendingLocationPicker: false
+    property var appliedExplicit: null
+    signal viewChanged()
+    signal locationPickerRequested()
+
+    function requestLocationPicker() {
+        pendingLocationPicker = true;
+        locationPickerRequested();
     }
-    function returnHome() {
-        if (!engine.state || !config.ready) return;
-        if (homeSite && (engine.state.site.id !== homeSite || engine.state.source !== "live")) {
-            engine.send({type: "select_site", id: homeSite});
-            homeRequested();
+
+    function resolve() {
+        if (!config.ready || !remembered.ready) return;
+        var env = Location.envView(Quickshell.env("OMASTORM_VIEW"));
+        var explicit = Location.configCenter(config.values);
+        var rememberedView = remembered.parsed;
+        var place = Location.resolvePlace(explicit, rememberedView, config.location, env);
+        if (!hasView) {
+            if (place) {
+                needsLocation = false;
+                centerLat = place.lat;
+                centerLon = place.lon;
+                span = Location.clampSpan(place.span);
+                hasView = true;
+                locationSource = place.source;
+                placeName = place.name || "";
+            } else {
+                needsLocation = true;
+                locationSource = "";
+                placeName = "";
+            }
+            applyLaunchLock(rememberedView);
+        }
+        if (explicit) {
+            var same = appliedExplicit && appliedExplicit.lat === explicit.lat && appliedExplicit.lon === explicit.lon;
+            appliedExplicit = explicit;
+            if (hasView && !same) {
+                placeName = "";
+                locationSource = "config";
+                centerLat = explicit.lat;
+                centerLon = explicit.lon;
+                needsLocation = false;
+            }
+        } else {
+            appliedExplicit = null;
+        }
+        applyConfigLockChange();
+        viewChanged();
+    }
+
+    function applyLaunchLock(rememberedView) {
+        var cfg = Location.configLock(config.values);
+        lastConfigLock = cfg;
+        if (cfg) {
+            lockId = cfg;
+            lockWanted = true;
+            lockSource = "config";
+        } else if (rememberedView && rememberedView.lock) {
+            lockId = rememberedView.lock;
+            lockWanted = true;
+            lockSource = "state";
+        } else {
+            lockId = "";
+            lockWanted = false;
+            lockSource = "nearest";
         }
     }
+
+    function applyConfigLockChange() {
+        var cfg = Location.configLock(config.values);
+        if (cfg === lastConfigLock) return;
+        lastConfigLock = cfg;
+        if (cfg) {
+            lockId = cfg;
+            lockWanted = true;
+            lockSource = "config";
+        } else {
+            lockId = remembered.lock || "";
+            lockWanted = !!lockId;
+            lockSource = lockWanted ? "state" : "nearest";
+        }
+    }
+
+    function persist() {
+        if (!hasView) return;
+        remembered.snapshot(centerLat, centerLon, span, lockWanted ? lockId : "", placeName);
+    }
+
+    function rememberView(lat, lon, spanKm) {
+        if (needsLocation) return;
+        if (!Location.validPair(lat, lon)) return;
+        var next = Location.clampSpan(spanKm);
+        if (hasView && centerLat === lat && centerLon === lon && span === next) return;
+        centerLat = lat;
+        centerLon = lon;
+        span = next;
+        hasView = true;
+        persistTimer.restart();
+    }
+
+    function setPlace(lat, lon, name) {
+        if (!Location.validPair(lat, lon)) return;
+        placeName = name || "";
+        locationSource = "state";
+        needsLocation = false;
+        pendingLocationPicker = false;
+        centerLat = lat;
+        centerLon = lon;
+        span = Location.DEFAULT_SPAN;
+        hasView = true;
+        var cfg = Location.configLock(config.values);
+        if (cfg && lockSource === "config") {
+            lockId = cfg;
+            lockWanted = true;
+            lockSource = "config";
+        } else {
+            lockId = "";
+            lockWanted = false;
+            lockSource = "nearest";
+        }
+        persist();
+        applyRadar();
+        viewChanged();
+    }
+
+    function resetView() {
+        var target = Location.resolveReset(Location.configCenter(config.values), config.location);
+        if (target) {
+            centerLat = target.lat;
+            centerLon = target.lon;
+            locationSource = target.source;
+            placeName = target.name || "";
+        } else if (!hasView) {
+            requestLocationPicker();
+            return;
+        }
+        span = Location.DEFAULT_SPAN;
+        hasView = true;
+        persist();
+        applyRadar();
+        viewChanged();
+    }
+
+    function setLock(id, on) {
+        if (on && id) {
+            lockId = id;
+            lockWanted = true;
+            lockSource = "state";
+        } else {
+            lockId = "";
+            lockWanted = false;
+            lockSource = "nearest";
+        }
+        persist();
+        applyRadar();
+    }
+
+    function followNearest(id) {
+        lockId = "";
+        lockWanted = false;
+        lockSource = "nearest";
+        persist();
+        if (!engine.state) return;
+        if (engine.state.site.locked) engine.send({type: "lock", enabled: false});
+        if (!engine.state.site.follow) engine.send({type: "follow", enabled: true});
+        if (id && (engine.state.site.id !== id || engine.state.source !== "live"))
+            engine.send({type: "select_site", id: id});
+    }
+
+    function applyRadar() {
+        if (!engine.state || !ready) return;
+        if (needsLocation) return;
+        if (lockWanted && lockId) {
+            if (engine.state.site.id !== lockId || engine.state.source !== "live")
+                engine.send({type: "select_site", id: lockId});
+            if (!engine.state.site.locked) engine.send({type: "lock", enabled: true});
+            if (!engine.state.site.follow) engine.send({type: "follow", enabled: true});
+        } else {
+            if (engine.state.site.locked) engine.send({type: "lock", enabled: false});
+            if (!engine.state.site.follow) engine.send({type: "follow", enabled: true});
+            if (hasView) engine.send({type: "view_center", lat: centerLat, lon: centerLon});
+        }
+    }
+
     function initialize() {
-        if (initialized || !engine.state || !config.ready) return;
+        if (initialized || !engine.state || !ready) return;
         initialized = true;
-        if (!windowOpen || engine.state.source === "archived") returnHome();
-        applyFollow();
+        resolve();
+        applyRadar();
+        persist();
     }
-    function applyFollow() {
-        if (engine.state && config.follow !== undefined && config.follow !== engine.state.site.follow)
-            engine.send({type: "follow", enabled: config.follow});
-    }
+
     function applyTreatment() {
         var errors = [], wanted = KeyMap.treatment(config.treatment, errors);
         if (!Quickshell.env("OMASTORM_STYLE") && wanted) treatment = wanted;
         if (KeyMap.envFloor(Quickshell.env("OMASTORM_WEAK")) === undefined) weakFloor = KeyMap.weakFloor(config.weakFloor, errors);
     }
-    onHomeSiteChanged: if (initialized) returnHome()
+
+    property Timer persistTimer: Timer { interval: 400; onTriggered: session.persist() }
     property Connections engineEvents: Connections {
         target: session.engine
         function onStateChanged() {
@@ -63,10 +241,15 @@ QtObject {
     }
     property Connections configEvents: Connections {
         target: session.config
-        function onReadyChanged() { session.initialize(); }
-        function onFollowChanged() { session.applyFollow(); }
+        function onReadyChanged() { session.resolve(); session.initialize(); }
+        function onValuesChanged() { if (session.initialized) { session.resolve(); session.applyRadar(); } }
+        function onLocationChanged() { if (!session.hasView) session.resolve(); if (session.initialized) session.applyRadar(); }
         function onTreatmentChanged() { session.applyTreatment(); }
         function onWeakFloorChanged() { session.applyTreatment(); }
+    }
+    property Connections rememberedEvents: Connections {
+        target: session.remembered
+        function onReadyChanged() { session.resolve(); session.initialize(); }
     }
     // The engine bootstrap (run.sh --ensure: install the pinned engine if
     // needed, start or replace the daemon) runs detached, so a plugin reload
@@ -91,5 +274,5 @@ QtObject {
         onFileChanged: reload()
         onLoaded: { var lines = text().trim().split("\n"); session.startupError = session.engine.state ? "" : lines[lines.length - 1]; }
     }
-    Component.onCompleted: { applyTreatment(); bootstrap(); }
+    Component.onCompleted: { applyTreatment(); resolve(); bootstrap(); }
 }

--- a/ui/Popover.qml
+++ b/ui/Popover.qml
@@ -114,8 +114,20 @@ FocusScope {
                 labelSize: 10
                 radarOpacity: card.condition === "unavailable" ? .6 : 1
                 onTilesNeeded: (z, x0, y0, x1, y1) => connection.send({type: "tiles_needed", z: z, x0: x0, y0: y0, x1: x1, y1: y1})
+                function applyView() {
+                    if (!card.session.hasView) return;
+                    holdSpan = true;
+                    lookAt(card.session.centerLat, card.session.centerLon);
+                    span = card.session.span;
+                    Qt.callLater(() => { holdSpan = false; });
+                }
+                Component.onCompleted: applyView()
             }
             Connections { target: connection; function onTileReady(tile) { map.tileReady(tile); } }
+            Connections {
+                target: card.session
+                function onViewChanged() { map.applyView(); }
+            }
             Label { anchors.top: parent.top; anchors.right: parent.right; anchors.margins: 8; text: "⤢"; font.pixelSize: 20; opacity: .65 }
             RowLayout {
                 anchors.left: parent.left; anchors.right: parent.right; anchors.bottom: parent.bottom; anchors.margins: 8
@@ -139,6 +151,25 @@ FocusScope {
                 horizontalAlignment: Text.AlignHCenter
                 visible: !card.state
                 text: card.session.startupError || connection.error
+            }
+            Rectangle {
+                anchors.fill: parent
+                visible: card.session.needsLocation
+                color: Qt.alpha(card.theme.background, .82)
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: { card.session.requestLocationPicker(); card.expandRequested(); }
+                }
+                ColumnLayout {
+                    anchors.centerIn: parent
+                    width: parent.width - 32
+                    spacing: 10
+                    Label { Layout.fillWidth: true; horizontalAlignment: Text.AlignHCenter; text: "CHOOSE A LOCATION"; font.bold: true; font.pixelSize: 13 }
+                    Label { Layout.fillWidth: true; horizontalAlignment: Text.AlignHCenter; wrapMode: Text.Wrap; opacity: .7; font.pixelSize: 11
+                        text: "Search a town of 5,000+ people, or enter latitude and longitude in the window." }
+                    Control { Layout.alignment: Qt.AlignHCenter; text: "CHOOSE A LOCATION"; onClicked: { card.session.requestLocationPicker(); card.expandRequested(); } }
+                }
             }
         }
         Label {
@@ -185,14 +216,10 @@ FocusScope {
         RowLayout {
             Layout.fillWidth: true
             Label {
-                Layout.fillWidth: true; font.pixelSize: 10; opacity: .55; wrapMode: Text.Wrap
-                text: "click radar or ↵ opens the window · " + (card.bindings.previous_frame || []).join("/") + " " + (card.bindings.next_frame || []).join("/") + " step · " + (card.bindings.play || []).join("/") + " play"
+                Layout.fillWidth: true; font.pixelSize: 8; opacity: .5; elide: Text.ElideRight
+                text: map.osmOnScreen ? "NOAA · © OpenStreetMap" : "NOAA · Natural Earth"
             }
-            Control { text: "⤢ EXPAND"; onClicked: card.expandRequested() }
-        }
-        Label {
-            Layout.fillWidth: true; font.pixelSize: 8; opacity: .5; wrapMode: Text.Wrap
-            text: "NOAA · Natural Earth · " + (map.osmOnScreen && card.state ? card.state.basemap.osm.attribution : "© OpenStreetMap contributors (ODbL)")
+            Control { text: "EXPAND"; onClicked: card.expandRequested() }
         }
     }
 }

--- a/ui/PopoverHarness.qml
+++ b/ui/PopoverHarness.qml
@@ -50,7 +50,8 @@ ShellRoot {
                 playing: popover.state ? popover.state.playing : false, treatment: session.treatment,
                 connected: popover.engine.socket.connected, retry: popover.engine.reconnect.running, transport: popover.engine.error, condition: popover.condition, text: popover.statusText, expanded: harness.expanded,
                 window: panel.opened, windowSite: panel.siteId, windowFrame: panel.scan ? panel.scan.id : "",
-                windowPlaying: panel.playing, windowTreatment: panel.treatment, error: session.startupError});
+                windowPlaying: panel.playing, windowTreatment: panel.treatment, error: session.startupError,
+                needsLocation: session.needsLocation, lat: session.centerLat, lon: session.centerLon});
         }
         function capture(path: string): void { picture.grabToImage(result => result.saveToFile(path)); }
         function quit(): void { Qt.quit(); }

--- a/ui/RadarBar.qml
+++ b/ui/RadarBar.qml
@@ -13,7 +13,6 @@ BarWidget {
     readonly property bool live: state && state.source === "live" && state.connection.status === "ok"
     readonly property bool down: !state || state.connection.status === "offline" || state.connection.status === "unavailable"
     function open() {
-        if (!session.windowOpen) session.returnHome();
         popoutSwitchClosing = false;
         opened = true;
     }

--- a/ui/RadarMap.qml
+++ b/ui/RadarMap.qml
@@ -86,6 +86,10 @@ Item {
     function reset() { center = null; span = Math.min(210, maxSpan); }
     function zoom(value) { span = Math.max(25, Math.min(maxSpan, value)); }
     function look(mx, my) { center = Qt.point(longitude(mx), latitude(my)); }
+    // Centre exactly on a place. Loading frames and radar hand-offs must
+    // not call this; the camera is the user's (DESIGN.md, location).
+    function lookAt(lat, lon) { center = Qt.point(lon, lat); }
+    signal resetRequested()
     // The keyboard pan (DESIGN.md, keyboard map): one step is an eighth of
     // the viewport's shorter side, in the given screen direction.
     function pan(dx, dy) {
@@ -104,7 +108,13 @@ Item {
     // is measured at the site's latitude, so it is rescaled to keep the
     // ground scale on screen exactly where it was.
     property real heldKmPerUnit: 0
-    onKmPerUnitChanged: { if (center && heldKmPerUnit > 0) span *= kmPerUnit / heldKmPerUnit; heldKmPerUnit = kmPerUnit; }
+    // Restoring a remembered view sets span itself; a site change under that
+    // restore must not rescale it.
+    property bool holdSpan: false
+    onKmPerUnitChanged: {
+        if (center && heldKmPerUnit > 0 && !holdSpan) span *= kmPerUnit / heldKmPerUnit;
+        heldKmPerUnit = kmPerUnit;
+    }
     function distanceKm(lat1, lon1, lat2, lon2) {
         var r = Math.PI / 180, dp = (lat2 - lat1) * r, dl = (lon2 - lon1) * r;
         var h = Math.sin(dp / 2) ** 2 + Math.cos(lat1 * r) * Math.cos(lat2 * r) * Math.sin(dl / 2) ** 2;
@@ -139,15 +149,16 @@ Item {
     onUnitsPerPixelChanged: settle.restart()
     // A state change re-asks even for an unchanged rectangle: a restarted
     // engine publishes under a new generation.
-    onScanChanged: { scheduleLayout(); if (scan) { settle.reask = true; settle.restart(); } else reportedLat = NaN; }
+    onScanChanged: { scheduleLayout(); if (scan) { settle.reask = true; settle.restart(); } else { reportedLat = NaN; reportedSpan = NaN; } }
     Timer { id: settle; interval: 120; property bool reask: true; onTriggered: { map.requestTiles(); map.reportCenter(); } }
     // Forgotten when the engine goes away, so a reconnect reports the centre
     // the camera is at rather than the one the old daemon knew.
     property real reportedLat: NaN
     property real reportedLon: NaN
+    property real reportedSpan: NaN
     function reportCenter() {
-        if (!scan || (centerLat === reportedLat && centerLon === reportedLon)) return;
-        reportedLat = centerLat; reportedLon = centerLon;
+        if (!scan || (centerLat === reportedLat && centerLon === reportedLon && span === reportedSpan)) return;
+        reportedLat = centerLat; reportedLon = centerLon; reportedSpan = span;
         viewSettled(centerLat, centerLon);
     }
     function tileRect(z) {
@@ -627,6 +638,6 @@ Item {
             map.zoom(Math.min(map.span,map.maxSpan)*(wheel.angleDelta.y>0?.85:1/.85));
             map.look(mx-(wheel.x-width/2)*map.unitsPerPixel, my-(wheel.y-height/2)*map.unitsPerPixel);
         }
-        onDoubleClicked: map.reset()
+        onDoubleClicked: map.resetRequested()
     }
 }

--- a/ui/RadarWindow.qml
+++ b/ui/RadarWindow.qml
@@ -5,6 +5,7 @@ import Quickshell
 import Quickshell.Io
 import "Sites.js" as Sites
 import "Keys.js" as KeyMap
+import "Location.js" as Location
 import "Timeline.js" as Timeline
 
 Item {
@@ -13,12 +14,19 @@ Item {
     property var session: null
     property var shell: null
     property var manifest: null
+    readonly property var store: PluginSession
     property bool opened: session === null
-    function open(payload) { opened = true; if (session) session.windowOpen = true; map.reset(); }
+    function open(payload) {
+        opened = true;
+        if (session) session.windowOpen = true;
+        applyView();
+        if (store.needsLocation || store.pendingLocationPicker) Qt.callLater(() => locationPicker.show(""));
+    }
     function close() {
         if (!opened) return;
         opened = false;
-        if (session) { session.windowOpen = false; session.returnHome(); }
+        store.persist();
+        if (session) session.windowOpen = false;
     }
     function dismiss() {
         if (!session) Qt.quit();
@@ -128,45 +136,47 @@ Item {
         return shown;
     }
     Engine { id: engine }
-    // ~/.config/omastorm/config.toml (docs/protocol.md, configuration). The
-    // home station is selected when the engine's state first arrives and
-    // again after a reconnect (a rebuilt daemon starts on the archived
-    // fixture), with the camera on its home view; the follow setting goes
-    // with it. An edit to the file while the window is open applies at once.
-    // Without a home_site the home is the station nearest Omarchy's own
-    // location (DESIGN.md, site model), when that file has one.
-    Config { id: config }
-    readonly property string homeSource: config.homeSite ? "config" : config.location ? "location" : ""
-    readonly property string homeSite: config.homeSite ? config.homeSite
-        : config.location ? nearestTo(config.location.lat, config.location.lon) : ""
-    function nearestTo(lat, lon) {
-        var best = null, bestKm = Infinity;
-        for (var s of engine.sites) {
-            var km = Sites.distanceKm(lat, lon, s.lat, s.lon);
-            if (km < bestKm) { bestKm = km; best = s; }
-        }
-        return best ? best.id : "";
+    // Deliberate preferences and remembered view (DESIGN.md, location).
+    // PluginSession owns config.toml, state.json, and the camera; this
+    // window applies the view to its map and sends map-local tile requests.
+    readonly property var config: store.config
+    function applyView() {
+        if (!store.hasView) return;
+        map.holdSpan = true;
+        map.lookAt(store.centerLat, store.centerLon);
+        map.span = store.span;
+        Qt.callLater(() => { map.holdSpan = false; });
     }
-    property bool configApplied: false
-    function applyConfig() {
-        if (session || !state || !config.ready || configApplied) return;
-        configApplied = true;
-        if (homeSite) {
-            var home = engine.sites.find(s => s.id === homeSite);
-            if (home && (home.id !== siteId || state.source !== "live")) { map.jumpTo(home.lat, home.lon); engine.send({type: "select_site", id: home.id}); }
-            else if (!home) engine.send({type: "select_site", id: homeSite}); // the engine names the mistake
+    property bool viewApplied: false
+    onStateChanged: {
+        if (!state) viewApplied = false;
+        else {
+            store.initialize();
+            if (!viewApplied) { applyView(); viewApplied = true; }
+            maybeOfferLocation();
         }
-        if (config.follow !== undefined && config.follow !== state.site.follow) engine.send({type: "follow", enabled: config.follow});
     }
-    onStateChanged: { if (!state) configApplied = false; else applyConfig(); }
-    onHomeSiteChanged: { configApplied = false; applyConfig(); }
+    function maybeOfferLocation() {
+        if (!opened || !store.needsLocation || locationPicker.open) return;
+        Qt.callLater(() => {
+            if (app.opened && app.store.needsLocation && !locationPicker.open) locationPicker.show("");
+        });
+    }
+    Connections {
+        target: store
+        function onViewChanged() {
+            if (app.opened) app.applyView();
+            app.maybeOfferLocation();
+        }
+        function onLocationPickerRequested() { if (app.opened) locationPicker.show(""); }
+    }
     Connections {
         target: config
-        function onReadyChanged() { app.applyConfig(); }
-        function onFollowChanged() { app.configApplied = false; app.applyConfig(); }
+        function onReadyChanged() { app.applyView(); }
         function onKeysChanged() { app.applySettings(); }
         function onTreatmentChanged() { app.applySettings(); }
         function onWeakFloorChanged() { app.applySettings(); }
+        function onValuesChanged() { app.applySettings(); }
     }
     // The keyboard map (DESIGN.md, keyboard map as built): Keys.js lays the
     // `[keys]` table over the defaults, asking Qt whether each sequence
@@ -181,7 +191,8 @@ Item {
     Shortcut { id: probe; enabled: false }
     function canon(sequence) { probe.sequence = sequence; return probe.portableText; }
     function applySettings() {
-        var errors = [], wanted = KeyMap.treatment(config.treatment, errors), floor = KeyMap.weakFloor(config.weakFloor, errors);
+        var errors = Location.configErrors(config.values);
+        var wanted = KeyMap.treatment(config.treatment, errors), floor = KeyMap.weakFloor(config.weakFloor, errors);
         var resolved = KeyMap.resolve(config.keys, canon);
         bindings = resolved.bindings;
         configErrors = errors.concat(resolved.errors);
@@ -189,20 +200,20 @@ Item {
         if (!session && KeyMap.envFloor(Quickshell.env("OMASTORM_WEAK")) === undefined) weakFloor = floor;
     }
     Component.onCompleted: applySettings()
-    readonly property bool overlayOpen: picker.open || sheet.open
+    readonly property bool overlayOpen: picker.open || locationPicker.open || sheet.open
     function run(action) {
         switch (action) {
         case "search": treatmentMenu.close(); picker.show(""); break;
         case "nearest": nearest(); break;
         case "lock": toggleLock(); break;
-        case "home": setHome(); break;
+        case "home": locationPicker.show(""); break;
         case "pan_left": map.pan(-1, 0); break;
         case "pan_right": map.pan(1, 0); break;
         case "pan_up": map.pan(0, -1); break;
         case "pan_down": map.pan(0, 1); break;
         case "zoom_in": map.zoom(Math.min(map.span, map.maxSpan) / 1.25); break;
         case "zoom_out": map.zoom(Math.min(map.span, map.maxSpan) * 1.25); break;
-        case "reset": map.reset(); break;
+        case "reset": resetView(); break;
         case "previous_frame": step(-1); break;
         case "next_frame": step(1); break;
         case "play": togglePlay(); break;
@@ -226,40 +237,38 @@ Item {
         function status(): string {
             return JSON.stringify({sheet: sheet.open, menu: treatmentMenu.opened, treatment: app.treatment, weakFloor: app.weakFloor === null ? "off" : app.weakFloor, error: app.configError,
                                    span: Math.round(map.span * 10) / 10, lat: Math.round(map.centerLat * 1000) / 1000, lon: Math.round(map.centerLon * 1000) / 1000,
-                                   home: app.homeSite, homeSource: app.homeSource, site: app.siteId, locked: app.locked});
+                                   locationSource: app.store.locationSource, needsLocation: app.store.needsLocation,
+                                   site: app.siteId, locked: app.locked, lockSource: app.store.lockSource, outsideCoverage: app.outsideCoverage});
         }
     }
-    // Site navigation (DESIGN.md, markers): the lock pins the station against
-    // hand-offs; `n` releases it, takes the station nearest the map centre,
-    // and puts the camera on that station's home view.
+    // Site navigation (DESIGN.md, location): the lock pins the radar against
+    // hand-offs without moving the camera; `n` releases it and selects the
+    // nearest radar. The site picker locks. Neither moves the camera.
     readonly property bool locked: state ? state.site.locked : false
     readonly property bool following: state ? state.site.follow && !state.site.locked : false
-    function toggleLock() { if (state) engine.send({type: "lock", enabled: !locked}); }
-    // Shift+H or the HOME control: the station on screen becomes home_site in
-    // config.toml (Config.setHome); the status slot confirms it for a moment
-    // and the header's HOME tag follows the file.
+    readonly property var resetTarget: Location.resolveReset(Location.configCenter(config.values), config.location)
+    readonly property bool outsideCoverage: {
+        var s = engine.site;
+        return !!(locked && s && Location.distanceKm(map.centerLat, map.centerLon, s.lat, s.lon) > map.coverageKm);
+    }
+    function toggleLock() {
+        if (!state || !siteId) return;
+        store.setLock(locked ? "" : siteId, !locked);
+    }
     property string notice: ""
     Timer { id: noticeTimer; interval: 3000; onTriggered: app.notice = "" }
-    function setHome() {
-        if (!state || !siteId) return;
-        config.setHome(siteId);
-        notice = "HOME · " + siteId + " SAVED TO CONFIG.TOML";
-        noticeTimer.restart();
+    function resetView() {
+        store.resetView();
+        applyView();
     }
     function nearest() {
         var s = map.nearest();
         if (!state || !s) return;
-        if (locked) engine.send({type: "lock", enabled: false});
-        map.jumpTo(s.lat, s.lon);
-        engine.send({type: "select_site", id: s.id});
+        store.followNearest(s.id);
     }
-    // A station chosen in the picker is selected, locked (DESIGN.md,
-    // markers), and given the camera the way `n` does.
     function choose(s) {
         if (!state) return;
-        map.jumpTo(s.lat, s.lon);
-        engine.send({type: "select_site", id: s.id});
-        if (!locked) engine.send({type: "lock", enabled: true});
+        store.setLock(s.id, true);
     }
     // Drives the picker from outside for checks and captures:
     // quickshell ipc --pid <pid> call picker open tul
@@ -271,6 +280,18 @@ Item {
         function move(delta: int): void { picker.move(delta); }
         function matches(): string { return JSON.stringify(picker.rows.map(r => r.site.id)); }
         function status(): string { return JSON.stringify({open: picker.open, query: picker.query, selected: picker.selected, total: picker.ranked.total, focused: picker.fieldFocused}); }
+    }
+    IpcHandler {
+        target: "location"
+        function open(query: string): void { locationPicker.show(query); }
+        function accept(): void { locationPicker.accept(); }
+        function close(): void { locationPicker.close(); }
+        function move(delta: int): void { locationPicker.move(delta); }
+        function go(lat: string, lon: string, name: string): void { locationPicker.go(Number(lat), Number(lon), name); }
+        function setLat(text: string): void { locationPicker.latText = text; }
+        function setLon(text: string): void { locationPicker.lonText = text; }
+        function matches(): string { return JSON.stringify(locationPicker.rows.map(r => r.where ? r.name + ", " + r.where : r.name)); }
+        function status(): string { return JSON.stringify({open: locationPicker.open, query: locationPicker.query, selected: locationPicker.selected, focused: locationPicker.fieldFocused, count: locationPicker.rows.length, lat: locationPicker.latText, lon: locationPicker.lonText, error: locationPicker.coordError}); }
     }
     readonly property var theme: session ? session.theme.snapshot : themeInputs.snapshot
     Theme { id: themeInputs; registerIpc: !app.session }
@@ -288,7 +309,7 @@ Item {
         target: app.session
         function onTreatmentChanged() { app.treatment = app.session.treatment; }
         function onWeakFloorChanged() { app.weakFloor = app.session.weakFloor; }
-        function onHomeRequested() { if (app.opened) map.reset(); }
+        function onLocationPickerRequested() { if (app.opened) locationPicker.show(""); }
     }
     // Quickshell keeps the process alive after its last window closes, which
     // left 400-600 MB orphans behind every close. Quit with the window; the
@@ -431,14 +452,17 @@ Item {
                     visible: app.locked || app.following
                     readonly property color ink: app.locked ? app.theme.accent : Qt.alpha(app.theme.foreground, .55)
                     Glyph { glyph: app.locked ? "lock" : "follow"; ink: siteChip.ink }
-                    LabelText { text: app.locked ? "LOCKED" : "FOLLOWING"; visible: !win.compact; color: siteChip.ink; font.pixelSize: 10; font.letterSpacing: 1 }
+                    LabelText {
+                        text: app.locked && app.outsideCoverage ? "LOCKED · OUTSIDE COVERAGE" : app.locked ? "LOCKED" : "FOLLOWING"
+                        visible: !win.compact; color: siteChip.ink; font.pixelSize: 10; font.letterSpacing: 1
+                    }
                 }
-                // Where the home came from, while the home station is shown
-                // (DESIGN.md, site model): the configured home_site, or the
-                // station nearest Omarchy's weather location.
                 LabelText {
-                    visible: !win.compact && app.homeSite !== "" && app.siteId === app.homeSite
-                    text: app.homeSource === "location" ? "HOME · NEAR " + (config.location.name || "OMARCHY'S LOCATION").toUpperCase() : "HOME · CONFIG.TOML"
+                    visible: !win.compact && !!app.resetTarget && Location.distanceKm(map.centerLat, map.centerLon, app.resetTarget.lat, app.resetTarget.lon) < 2
+                    text: !app.resetTarget ? ""
+                        : app.resetTarget.source === "weather"
+                        ? "LOCATION · " + (app.resetTarget.name || "OMARCHY'S LOCATION").toUpperCase()
+                        : "LOCATION · CONFIG.TOML"
                     color: Qt.alpha(app.theme.foreground, .55)
                     font.pixelSize: 10; font.letterSpacing: 1
                     Layout.leftMargin: 10
@@ -463,10 +487,10 @@ Item {
                 // config.toml mistake stands there the same way until the
                 // file is fixed. The radar underneath stays clear.
                 LabelText {
-                    text: engine.rejection || app.configError || app.notice || app.sourceDetail
-                    color: engine.rejection || app.configError || app.notice ? app.theme.accent : app.conditionColor
-                    opacity: engine.rejection || app.configError || app.notice || app.alert ? 1 : .5
-                    visible: !win.compact || engine.rejection !== "" || app.configError !== "" || app.notice !== "" || app.alert
+                    text: engine.rejection || app.configError || store.persistError || app.notice || app.sourceDetail
+                    color: engine.rejection || app.configError || store.persistError || app.notice ? app.theme.accent : app.conditionColor
+                    opacity: engine.rejection || app.configError || store.persistError || app.notice || app.alert ? 1 : .5
+                    visible: !win.compact || engine.rejection !== "" || app.configError !== "" || store.persistError !== "" || app.notice !== "" || app.alert
                     horizontalAlignment: Text.AlignRight
                     Layout.fillWidth: true
                 }
@@ -496,12 +520,13 @@ Item {
                     locked: app.locked
                     // A settled pan hands the centre to the engine, which switches
                     // station while following and unlocked; the camera stays.
-                    onViewSettled: (lat, lon) => { if (app.opened) engine.send({type: "view_center", lat: lat, lon: lon}); }
-                    // Captures start the camera at OMASTORM_VIEW="lat,lon,spanKm".
-                    Component.onCompleted: {
-                        var view = (Quickshell.env("OMASTORM_VIEW") || "").split(",").map(Number);
-                        if (view.length === 3 && view.every(isFinite)) { center = Qt.point(view[1], view[0]); span = view[2]; }
+                    onViewSettled: (lat, lon) => {
+                        if (!app.opened || app.store.needsLocation) return;
+                        engine.send({type: "view_center", lat: lat, lon: lon});
+                        app.store.rememberView(lat, lon, map.span);
                     }
+                    onResetRequested: app.resetView()
+                    Component.onCompleted: app.applyView()
                     // The map asks for tiles when its camera settles and the
                     // engine answers this window alone, tile by tile.
                     onTilesNeeded: (z, x0, y0, x1, y1) => engine.send({type: "tiles_needed", z: z, x0: x0, y0: y0, x1: x1, y1: y1})
@@ -704,8 +729,7 @@ Item {
                     }
                 }
                 GlyphButton { glyph: app.locked ? "lock" : "follow"; selected: app.locked; enabled: !!app.state; onClicked: app.toggleLock() }
-                // Save the station on screen as home; away once it is the home.
-                Control { text: win.compact ? "⌂" : "⌂ HOME"; visible: !!app.state && app.siteId !== "" && app.siteId !== app.homeSite; onClicked: app.setHome() }
+                Control { text: win.compact ? "⌂" : "⌂ LOCATION"; onClicked: locationPicker.show("") }
                 Item { Layout.fillWidth: true }
                 // The treatment chip (DESIGN.md, treatment control): one
                 // low-emphasis control naming the treatment; click opens the
@@ -733,7 +757,7 @@ Item {
                 Rectangle { width: 1; height: 18; color: Qt.alpha(app.theme.foreground, .22); Layout.leftMargin: 4; Layout.rightMargin: 4; visible: !win.compact }
                 Control { text: "−"; visible: !win.compact; onClicked: map.zoom(Math.min(map.span,map.maxSpan)*1.25) }
                 Control { text: "+"; visible: !win.compact; onClicked: map.zoom(Math.min(map.span,map.maxSpan)/1.25) }
-                Control { text: "RESET"; onClicked: map.reset() }
+                Control { text: "RESET"; onClicked: app.resetView() }
             }
             LabelText {
                 Layout.fillWidth: true
@@ -749,10 +773,27 @@ Item {
             theme: app.theme
             centerLat: map.centerLat
             centerLon: map.centerLon
-            homeSite: app.homeSite
+            homeSite: ""
             compact: win.compact
             cardTop: layout.anchors.margins + mapFrame.y
             onChosen: site => app.choose(site)
+          }
+          LocationPicker {
+            id: locationPicker
+            anchors.fill: parent
+            theme: app.theme
+            engine: engine
+            closeOnScrim: !app.store.needsLocation
+            centerLat: map.centerLat
+            centerLon: map.centerLon
+            compact: win.compact
+            cardTop: layout.anchors.margins + mapFrame.y
+            onChosen: (lat, lon, name) => {
+                app.store.setPlace(lat, lon, name);
+                app.applyView();
+                app.notice = name ? "LOCATION · " + name.toUpperCase() : "LOCATION · " + lat.toFixed(4) + ", " + lon.toFixed(4);
+                noticeTimer.restart();
+            }
           }
           // The treatment menu over the surface (not a Popup, which the
           // window overlay would draw outside the captured surface): a card

--- a/ui/Remembered.qml
+++ b/ui/Remembered.qml
@@ -1,0 +1,50 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import "Location.js" as Location
+
+// ~/.local/state/omastorm/state.json (DESIGN.md, location and remembered
+// state): the last camera and the UI radar lock. Onboarding and navigation
+// write this file, never config.toml. OMASTORM_STATE names another file for
+// checks and captures; when OMASTORM_CONFIG is set the machine's own state
+// is not read unless OMASTORM_STATE names one.
+QtObject {
+    id: root
+    readonly property string path: Quickshell.env("OMASTORM_STATE")
+        || (Quickshell.env("OMASTORM_CONFIG") ? "" : (Quickshell.env("XDG_STATE_HOME") || Quickshell.env("HOME") + "/.local/state") + "/omastorm/state.json")
+    property var parsed: Location.parseState("")
+    readonly property bool ready: stateRead
+    property bool stateRead: false
+    property string error: ""
+    readonly property var lat: parsed.lat
+    readonly property var lon: parsed.lon
+    readonly property var span: parsed.span
+    readonly property string lock: parsed.lock
+    readonly property string name: parsed.name
+    property FileView file: FileView {
+        path: root.path
+        watchChanges: true
+        printErrors: false
+        onFileChanged: reload()
+        onLoaded: { root.parsed = Location.parseState(text()); root.stateRead = true; }
+        onLoadFailed: { root.parsed = Location.parseState(""); root.stateRead = true; }
+    }
+    function snapshot(viewLat, viewLon, span, lock, name) {
+        var text = JSON.stringify(Location.stateObject(viewLat, viewLon, span, lock, name));
+        parsed = Location.parseState(text);
+        if (!path) return;
+        var slash = path.lastIndexOf("/");
+        var dir = slash >= 0 ? path.slice(0, slash) : ".";
+        writer.command = ["sh", "-c",
+            "mkdir -p -- \"$1\" && printf '%s\\n' \"$3\" > \"$2\" && mv -f -- \"$2\" \"$4\"",
+            "omastorm-state", dir, path + ".tmp", text, path];
+        writer.running = true;
+    }
+    property Process writer: Process {
+        command: ["true"]
+        onExited: function (exitCode) {
+            root.error = exitCode === 0 ? "" : "Could not write state.json";
+        }
+    }
+    Component.onCompleted: { if (!path) stateRead = true; }
+}

--- a/ui/qmldir
+++ b/ui/qmldir
@@ -1,6 +1,8 @@
 singleton PluginSession 1.0 PluginSession.qml
 Config 1.0 Config.qml
 Engine 1.0 Engine.qml
+LocationPicker 1.0 LocationPicker.qml
+Remembered 1.0 Remembered.qml
 KeysSheet 1.0 KeysSheet.qml
 Panel 1.0 Panel.qml
 Popover 1.0 Popover.qml


### PR DESCRIPTION
## Summary
- The map centre is a place: config.toml, remembered `state.json`, Omarchy weather, then a location picker. Radar lock stays independent. Resolves #1.
- With no location, the popover offers “Choose a location.” The picker uses `search_places` (towns of 5,000+) or lat/lon; `Shift+H` opens it again. Picks write state.json, never config.toml.
- Checkout-only `mise plugin-link` / `plugin-unlink` for bar-widget work, with a scratch check so install and ordinary launch still do not write Omarchy config.

Stacked on current `main` (`engine-0.1.2` is published and pinned). Do not bump `manifest.json` here; that is the plugin release commit after this merges.

## Test plan
- [x] Rebased onto `main` (docs conflicts resolved: keep main’s location spec, use `XDG_STATE_HOME` for state.json)
- [x] `mise check` (includes `check-location` and `check-link-plugin`)
- [ ] `omarchy plugin validate .`
- [ ] Confirm the picker against the published 0.1.2 engine