### PR TITLE
Rebuild UI models only when their content changes; ask for tiles on settle and reconnect

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -345,7 +345,12 @@ onboarding, and validation are in [configuration.md](configuration.md).
 ## Implementation notes
 
 The shell session keeps a status connection; each visible popover and expanded
-window has its own connection so tile requests remain independent. Expand
+window has its own connection so tile requests remain independent. A map asks
+for its tile rectangle when its camera settles, and again when its connection's
+first `state` arrives after none, since a restarted engine publishes under a
+new generation; a broadcast on a standing connection is not a reason to ask,
+and the UI rebuilds its swatches, ticks, and overlay only when `frame` or
+`timeline` changed, not for the once-a-second `ageSeconds` tick. Expand
 uses the shared station, frame, and play state directly, sending no
 select/seek/play commands, and preserves the map center and zoom. Closing
 preserves the view rather than selecting another station. The session owns

--- a/ui/Engine.qml
+++ b/ui/Engine.qml
@@ -20,10 +20,21 @@ QtObject {
     /// Places answering this client's `search_places`; a reply, not state.
     signal placesReady(var message)
     readonly property string runtime: Quickshell.env("XDG_RUNTIME_DIR") + "/omastorm/"
-    readonly property string texture: state && state.frame ? "file://" + runtime + state.frame.texture : ""
-    readonly property string azimuthLut: state && state.frame ? "file://" + runtime + state.frame.azimuthLut : ""
+    /// `frame` and `timeline` as stable slices of `state`. A client replaces
+    /// the whole state on every broadcast (docs/protocol.md), and while live
+    /// one arrives every second for `connection.ageSeconds` alone; these two
+    /// change only when their content does, so swatches, ticks, and the map
+    /// overlay are rebuilt for a new frame or timeline, not for a clock tick.
+    /// A string key compares by value, and the slice is parsed from it.
+    readonly property string frameKey: state && state.frame ? JSON.stringify(state.frame) : ""
+    readonly property var frame: frameKey ? JSON.parse(frameKey) : null
+    readonly property string timelineKey: state && state.timeline ? JSON.stringify(state.timeline) : ""
+    readonly property var timeline: timelineKey ? JSON.parse(timelineKey) : []
+    readonly property string siteId: state ? state.site.id : ""
+    readonly property string texture: frame ? "file://" + runtime + frame.texture : ""
+    readonly property string azimuthLut: frame ? "file://" + runtime + frame.azimuthLut : ""
     /// The selected station's row from `hello`, or null before it arrives.
-    readonly property var site: state ? (sites.find(s => s.id === state.site.id) || null) : null
+    readonly property var site: siteId ? (sites.find(s => s.id === siteId) || null) : null
     /// The protocol's one rule for texture paths (`docs/protocol.md`): the
     /// literal `tex/` prefix and exactly one further segment that is not empty,
     /// `.`, or `..` and holds no `/`, backslash, or NUL. The engine applies the

--- a/ui/PluginSession.qml
+++ b/ui/PluginSession.qml
@@ -23,6 +23,10 @@ QtObject {
     property string startupError: ""
     readonly property bool ready: config.ready && remembered.ready
     readonly property string persistError: remembered.error ? remembered.error.toUpperCase() : ""
+    // The view (DESIGN.md, location): the camera and where its centre came
+    // from. `locationSource` is `config`, `state`, `weather`, or `view`
+    // (OMASTORM_VIEW) once a centre is known; `needsLocation` is the
+    // onboarding state, true only while no source supplies one.
     property bool hasView: false
     property bool needsLocation: false
     property string placeName: ""
@@ -30,8 +34,11 @@ QtObject {
     property real centerLat: 0
     property real centerLon: 0
     property real span: Location.DEFAULT_SPAN
+    // The radar lock: the station pinned against hand-offs, or none while
+    // the nearest station follows the centre, and who asked for it:
+    // `config` (locked_radar), `state` (a session choice, remembered), or
+    // `nearest` when there is none.
     property string lockId: ""
-    property bool lockWanted: false
     property string lockSource: ""
     property string lastConfigLock: ""
     property bool pendingLocationPicker: false
@@ -44,38 +51,53 @@ QtObject {
         locationPickerRequested();
     }
 
+    // Every way a centre is chosen lands here: the camera, its span, and the
+    // provenance the header names. A placed view ends onboarding.
+    function placeView(lat, lon, spanKm, source, name) {
+        centerLat = lat;
+        centerLon = lon;
+        span = Location.clampSpan(spanKm);
+        hasView = true;
+        needsLocation = false;
+        locationSource = source;
+        placeName = name || "";
+    }
+
+    // The lock as one move: a station pins the radar and `source` says who
+    // asked; an empty id releases it to the nearest station.
+    function holdLock(id, source) {
+        lockId = id || "";
+        lockSource = lockId ? source : "nearest";
+    }
+
+    // Launch and a change to config.toml resolve the lock the same way: a
+    // configured lock wins, else the remembered one, else nearest.
+    function resolveLock(rememberedLock) {
+        lastConfigLock = Location.configLock(config.values);
+        holdLock(lastConfigLock || rememberedLock, lastConfigLock ? "config" : "state");
+    }
+
     function resolve() {
-        if (!config.ready || !remembered.ready) return;
+        if (!ready) return;
         var env = Location.envView(Quickshell.env("OMASTORM_VIEW"));
         var explicit = Location.configCenter(config.values);
         var rememberedView = remembered.parsed;
-        var place = Location.resolvePlace(explicit, rememberedView, config.location, env);
         if (!hasView) {
-            if (place) {
-                needsLocation = false;
-                centerLat = place.lat;
-                centerLon = place.lon;
-                span = Location.clampSpan(place.span);
-                hasView = true;
-                locationSource = place.source;
-                placeName = place.name || "";
-            } else {
+            var place = Location.resolvePlace(explicit, rememberedView, config.location, env);
+            if (place) placeView(place.lat, place.lon, place.span, place.source, place.name);
+            else {
                 needsLocation = true;
                 locationSource = "";
                 placeName = "";
             }
-            applyLaunchLock(rememberedView);
+            resolveLock(rememberedView.lock);
         }
+        // An explicit centre applies again whenever it changes, over any view
+        // the session has; removing it leaves the camera where it is.
         if (explicit) {
             var same = appliedExplicit && appliedExplicit.lat === explicit.lat && appliedExplicit.lon === explicit.lon;
             appliedExplicit = explicit;
-            if (hasView && !same) {
-                placeName = "";
-                locationSource = "config";
-                centerLat = explicit.lat;
-                centerLon = explicit.lon;
-                needsLocation = false;
-            }
+            if (hasView && !same) placeView(explicit.lat, explicit.lon, span, "config", "");
         } else {
             appliedExplicit = null;
         }
@@ -83,42 +105,14 @@ QtObject {
         viewChanged();
     }
 
-    function applyLaunchLock(rememberedView) {
-        var cfg = Location.configLock(config.values);
-        lastConfigLock = cfg;
-        if (cfg) {
-            lockId = cfg;
-            lockWanted = true;
-            lockSource = "config";
-        } else if (rememberedView && rememberedView.lock) {
-            lockId = rememberedView.lock;
-            lockWanted = true;
-            lockSource = "state";
-        } else {
-            lockId = "";
-            lockWanted = false;
-            lockSource = "nearest";
-        }
-    }
-
     function applyConfigLockChange() {
-        var cfg = Location.configLock(config.values);
-        if (cfg === lastConfigLock) return;
-        lastConfigLock = cfg;
-        if (cfg) {
-            lockId = cfg;
-            lockWanted = true;
-            lockSource = "config";
-        } else {
-            lockId = remembered.lock || "";
-            lockWanted = !!lockId;
-            lockSource = lockWanted ? "state" : "nearest";
-        }
+        if (Location.configLock(config.values) === lastConfigLock) return;
+        resolveLock(remembered.lock);
     }
 
     function persist() {
         if (!hasView) return;
-        remembered.snapshot(centerLat, centerLon, span, lockWanted ? lockId : "", placeName);
+        remembered.snapshot(centerLat, centerLon, span, lockId, placeName);
     }
 
     function rememberView(lat, lon, spanKm) {
@@ -133,26 +127,13 @@ QtObject {
         persistTimer.restart();
     }
 
+    // A place from the location picker: the default span, a configured lock
+    // kept, any other lock released (DESIGN.md, location).
     function setPlace(lat, lon, name) {
         if (!Location.validPair(lat, lon)) return;
-        placeName = name || "";
-        locationSource = "state";
-        needsLocation = false;
         pendingLocationPicker = false;
-        centerLat = lat;
-        centerLon = lon;
-        span = Location.DEFAULT_SPAN;
-        hasView = true;
-        var cfg = Location.configLock(config.values);
-        if (cfg && lockSource === "config") {
-            lockId = cfg;
-            lockWanted = true;
-            lockSource = "config";
-        } else {
-            lockId = "";
-            lockWanted = false;
-            lockSource = "nearest";
-        }
+        placeView(lat, lon, Location.DEFAULT_SPAN, "state", name);
+        holdLock(lockSource === "config" ? Location.configLock(config.values) : "", "config");
         persist();
         viewChanged();
         applyRadar();
@@ -160,59 +141,37 @@ QtObject {
 
     function resetView() {
         var target = Location.resolveReset(Location.configCenter(config.values), config.location);
-        if (target) {
-            centerLat = target.lat;
-            centerLon = target.lon;
-            locationSource = target.source;
-            placeName = target.name || "";
-        } else if (!hasView) {
+        if (target) placeView(target.lat, target.lon, Location.DEFAULT_SPAN, target.source, target.name);
+        else if (!hasView) {
             requestLocationPicker();
             return;
-        }
-        span = Location.DEFAULT_SPAN;
-        hasView = true;
+        } else span = Location.DEFAULT_SPAN;
         persist();
         viewChanged();
         applyRadar();
     }
 
+    // A station from the site picker: locked and centred, the span kept.
     function chooseRadar(id, lat, lon, name) {
         lat = Number(lat);
         lon = Number(lon);
         if (!id || !Location.validPair(lat, lon)) return;
-        placeName = name || id;
-        locationSource = "state";
-        needsLocation = false;
         pendingLocationPicker = false;
-        centerLat = lat;
-        centerLon = lon;
-        hasView = true;
-        lockId = id;
-        lockWanted = true;
-        lockSource = "state";
+        placeView(lat, lon, span, "state", name || id);
+        holdLock(id, "state");
         persist();
         viewChanged();
         applyRadar();
     }
 
     function setLock(id, on) {
-        if (on && id) {
-            lockId = id;
-            lockWanted = true;
-            lockSource = "state";
-        } else {
-            lockId = "";
-            lockWanted = false;
-            lockSource = "nearest";
-        }
+        holdLock(on ? id : "", "state");
         persist();
         applyRadar();
     }
 
     function followNearest(id) {
-        lockId = "";
-        lockWanted = false;
-        lockSource = "nearest";
+        holdLock("");
         persist();
         if (!engine.state) return;
         if (engine.state.site.locked) engine.send({type: "lock", enabled: false});
@@ -221,17 +180,19 @@ QtObject {
             engine.send({type: "select_site", id: id});
     }
 
+    // Reconcile the engine with the lock and the view: only what differs is
+    // sent, so a repeat changes nothing (docs/protocol.md, commands).
     function applyRadar() {
-        if (!engine.state || !ready) return;
-        if (needsLocation) return;
-        if (lockWanted && lockId) {
-            if (engine.state.site.id !== lockId || engine.state.source !== "live")
+        if (!engine.state || !ready || needsLocation) return;
+        var site = engine.state.site;
+        if (lockId) {
+            if (site.id !== lockId || engine.state.source !== "live")
                 engine.send({type: "select_site", id: lockId});
-            if (!engine.state.site.locked) engine.send({type: "lock", enabled: true});
-            if (!engine.state.site.follow) engine.send({type: "follow", enabled: true});
+            if (!site.locked) engine.send({type: "lock", enabled: true});
+            if (!site.follow) engine.send({type: "follow", enabled: true});
         } else {
-            if (engine.state.site.locked) engine.send({type: "lock", enabled: false});
-            if (!engine.state.site.follow) engine.send({type: "follow", enabled: true});
+            if (site.locked) engine.send({type: "lock", enabled: false});
+            if (!site.follow) engine.send({type: "follow", enabled: true});
             if (hasView) engine.send({type: "view_center", lat: centerLat, lon: centerLon});
         }
     }

--- a/ui/Popover.qml
+++ b/ui/Popover.qml
@@ -10,8 +10,10 @@ FocusScope {
     property var theme: session.theme.snapshot
     property alias engine: connection
     readonly property var state: connection.state
-    readonly property var scan: state ? state.frame : null
-    readonly property var frames: state ? state.timeline : []
+    // The engine's stable slices: the ticks are rebuilt for a new frame or
+    // timeline, not for the once-a-second live broadcast.
+    readonly property var scan: connection.frame
+    readonly property var frames: connection.timeline
     readonly property var slots: Timeline.slots(frames)
     readonly property string condition: state ? state.source === "archived" ? "archived" : state.connection.status : "offline"
     readonly property color statusColor: condition === "stale" ? theme.yellow
@@ -20,13 +22,8 @@ FocusScope {
         if (!state) return "OFFLINE";
         if (condition === "archived") return "ARCHIVED";
         var label = condition === "ok" ? "LIVE" : condition.toUpperCase();
-        var complete = frames.filter(f => f.status === "complete");
-        if (!scan.scanTime || !complete.length) return label;
-        var age = Math.max(0, state.connection.ageSeconds +
-            Math.round((Date.parse(complete[complete.length - 1].scanTime) - Date.parse(scan.scanTime)) / 1000));
-        var minutes = Math.floor(age / 60);
-        return label + " · " + (minutes < 1 ? "just now" : minutes < 60 ? minutes + " min ago"
-            : minutes < 1440 ? Math.floor(minutes / 60) + "h ago" : Math.floor(minutes / 1440) + "d ago");
+        var age = Timeline.shownAge(frames, scan, state.connection.ageSeconds);
+        return age < 0 ? label : label + " · " + Timeline.ago(age, true);
     }
     signal expandRequested()
     signal closeRequested()
@@ -88,7 +85,7 @@ FocusScope {
         RowLayout {
             Layout.fillWidth: true
             spacing: 6
-            Label { text: card.state ? card.state.site.id : "—"; font.bold: true; font.pixelSize: 14 }
+            Label { text: card.state ? connection.siteId : "—"; font.bold: true; font.pixelSize: 14 }
             Label { Layout.fillWidth: true; text: connection.site ? connection.site.name : ""; opacity: .65 }
             Rectangle { width: 5; height: 5; radius: 3; color: card.statusColor }
             Label { text: card.statusText; color: card.statusColor; font.pixelSize: 11 }
@@ -105,7 +102,7 @@ FocusScope {
                 scan: card.scan
                 texture: connection.texture
                 azimuthLut: connection.azimuthLut
-                siteId: card.state ? card.state.site.id : ""
+                siteId: connection.siteId
                 sites: connection.sites
                 tileRoot: "file://" + connection.runtime
                 theme: card.theme

--- a/ui/RadarMap.qml
+++ b/ui/RadarMap.qml
@@ -160,9 +160,17 @@ Item {
     onViewCenterXChanged: { settle.restart(); Qt.callLater(refreshOverlay); }
     onViewCenterYChanged: { settle.restart(); Qt.callLater(refreshOverlay); }
     onUnitsPerPixelChanged: settle.restart()
-    // A state change re-asks even for an unchanged rectangle: a restarted
-    // engine publishes under a new generation.
-    onScanChanged: { scheduleLayout(); if (scan) { settle.reask = true; settle.restart(); } else { reportedLat = NaN; reportedSpan = NaN; } }
+    // The first frame after none (launch, a reconnect) re-asks even for an
+    // unchanged rectangle, since a restarted engine publishes under a new
+    // generation, and reports the centre again. A frame arriving on a
+    // standing connection asks for nothing: tiles ride the camera, and the
+    // engine broadcasts once a second while live.
+    onScanChanged: {
+        scheduleLayout();
+        if (scan) { if (settle.reask) settle.restart(); return; }
+        settle.reask = true;
+        reportedLat = NaN; reportedLon = NaN; reportedSpan = NaN;
+    }
     Timer { id: settle; interval: 120; property bool reask: true; onTriggered: { map.requestTiles(); map.reportCenter(); } }
     // Forgotten when the engine goes away, so a reconnect reports the centre
     // the camera is at rather than the one the old daemon knew.
@@ -200,7 +208,8 @@ Item {
         var old = tiles[key];
         tiles[key] = { set: tile.set, path: tile.path, labels: tile.labels,
                        ready: !!old && old.path === tile.path && old.ready };
-        rebuildTileModel();
+        // A request is answered tile by tile in one burst; one rebuild serves it.
+        Qt.callLater(rebuildTileModel);
     }
     // Keep delegates for tiles that stay, so a pan or a re-announcement never
     // recreates an Image that is already on screen.

--- a/ui/RadarMap.qml
+++ b/ui/RadarMap.qml
@@ -39,7 +39,12 @@ Item {
     // startup as built). With no station selected yet the rings, crosshair,
     // and tag stay away too.
     readonly property bool drawable: !!scan && scan.scanTime !== ""
-    readonly property int bands: scan ? scan.palette.length : 0
+    // The frame's palette as a list that changes only with its colours: a
+    // live sweep republishes the frame every chunk, and the swatch strip
+    // must not be rebuilt for a palette that stayed the same.
+    readonly property string paletteKey: scan ? scan.palette.join(" ") : ""
+    readonly property var palette: paletteKey ? paletteKey.split(" ") : []
+    readonly property int bands: palette.length
     property string error: ""
     signal tilesNeeded(int z, int x0, int y0, int x1, int y1)
     // The view centre once a pan or zoom settles, when it moved since the last
@@ -59,7 +64,11 @@ Item {
     function longitude(mx) { return mx * 360 - 180; }
     function latitude(my) { return Math.atan(Math.sinh(Math.PI * (1 - 2 * my))) * 180 / Math.PI; }
     readonly property var site: scan ? scan.site : null
+    // Scalars notify only when their value moves, so what hangs off them
+    // (the coverage footprint, the shader's site uniforms) is left alone by
+    // a frame republished at the same site.
     readonly property real siteLat: site ? site.lat : 0
+    readonly property real siteLon: site ? site.lon : 0
     readonly property real siteMx: site ? mercatorX(site.lon) : 0.5
     readonly property real siteMy: site ? mercatorY(site.lat) : 0.5
     // Ground kilometres per Mercator unit at the site's latitude, on the
@@ -327,9 +336,15 @@ Item {
         font.family: map.theme.font
         font.pixelSize: map.labelSize
     }
+    // Either list is replaced only when its layout differs, so the label
+    // delegates survive a relayout that changed nothing.
     function rebuildLabels() {
         var started = Date.now();
-        if (!scan) { labels = []; siteLabels = []; return; }
+        if (!scan) {
+            if (labels.length) labels = [];
+            if (siteLabels.length) siteLabels = [];
+            return;
+        }
         labelMetrics.text = siteId;
         var occupied = [{x:-7, y:-7, w:14, h:14},
                         {x:7, y:4, w:labelMetrics.advanceWidth+6, h:16}], result = [], stations = [];
@@ -357,7 +372,7 @@ Item {
             occupied.push({x:chosen.x,y:chosen.y,w:tw+6,h:16});
             stations.push({name:s.id, x:chosen.x, y:chosen.y, width:tw+6});
         }
-        siteLabels = stations;
+        if (JSON.stringify(siteLabels) !== JSON.stringify(stations)) siteLabels = stations;
         for (var p of places) {
             labelMetrics.text = p.name;
             var tx = (mercatorX(p.lon) - siteMx) * worldPixels, ty = (mercatorY(p.lat) - siteMy) * worldPixels;
@@ -374,7 +389,7 @@ Item {
             result.push({name:p.name, x:chosen.x, y:chosen.y,
                          width:tw+6, markerX:tx, markerY:ty});
         }
-        labels = result;
+        if (JSON.stringify(labels) !== JSON.stringify(result)) labels = result;
         if (Quickshell.env("OMASTORM_PROFILE")) console.log("OVERLAY_MS", Date.now()-started);
     }
 
@@ -427,12 +442,10 @@ Item {
         }
         return lines;
     }
-    readonly property var coverageSites: {
-        if (!drawable || !site) return [];
-        // Only the active radar gets a footprint; overlapping network circles
-        // obscure geography at continental zoom. Use the measured scan site.
-        return [{id:siteId, lat:site.lat, lon:site.lon}];
-    }
+    // Only the active radar gets a footprint; overlapping network circles
+    // obscure geography at continental zoom. Built from the measured scan
+    // site's scalars, so it changes with the station, not with every frame.
+    readonly property var coverageSites: drawable ? [{id:siteId, lat:siteLat, lon:siteLon}] : []
 
     // Upload the immutable sweep and its azimuth lookup once. Pan/zoom updates
     // shader uniforms; the polar-to-screen lookup runs in the shader and no
@@ -460,7 +473,7 @@ Item {
         id: paletteStrip
         width: Math.max(1, map.bands); height: 1
         Repeater {
-            model: map.scan ? map.scan.palette : []
+            model: map.palette
             Rectangle {
                 required property string modelData
                 required property int index
@@ -554,10 +567,13 @@ Item {
                 antialiasing: true
             }
         }
+        // Every table station but the active one, whose marker is the
+        // crosshair; hiding it keeps the 162 others across a hand-off.
         Repeater {
-            model: map.sites.filter(s => s.id !== map.siteId)
+            model: map.sites
             Rectangle {
                 required property var modelData
+                visible: modelData.id !== map.siteId
                 x: (map.mercatorX(modelData.lon)-map.siteMx)*map.worldPixels-3
                 y: (map.mercatorY(modelData.lat)-map.siteMy)*map.worldPixels-3
                 width: 6; height: 6

--- a/ui/RadarWindow.qml
+++ b/ui/RadarWindow.qml
@@ -34,18 +34,20 @@ Item {
         else close();
     }
     readonly property var state: engine.state
-    readonly property var scan: state ? state.frame : null
+    // The frame and the timeline are the engine's stable slices: they change
+    // with their content, not with the once-a-second live broadcast.
+    readonly property var scan: engine.frame
     // Every station, product, and source string on screen comes from the engine.
-    readonly property string siteId: state ? state.site.id : ""
+    readonly property string siteId: engine.siteId
     readonly property string siteName: engine.site ? engine.site.name.toUpperCase() : ""
     readonly property string sourceBadge: state ? state.source.toUpperCase() : ""
     // The timeline (DESIGN.md): the station's frames oldest
     // first with the sweep in progress last; the engine owns the position.
-    readonly property var frames: state ? state.timeline : []
+    readonly property var frames: engine.timeline
     readonly property int frameIndex: scan ? frames.findIndex(f => f.id === scan.id) : -1
     readonly property bool newestShown: frameIndex >= 0 && frameIndex === frames.length - 1
     readonly property bool playing: state ? state.playing : false
-    readonly property var newestComplete: { var done = frames.filter(f => f.status === "complete"); return done.length ? done[done.length - 1] : null; }
+    readonly property var newestComplete: Timeline.newestComplete(frames)
     // The connection condition while live (DESIGN.md):
     // the header's third row shows the age of the frame on screen beside
     // its time, and its status slot names the condition or the sweep in
@@ -57,19 +59,10 @@ Item {
     readonly property color conditionColor: condition === "stale" ? theme.yellow
         : condition === "loading" ? theme.accent
         : condition === "unavailable" || condition === "offline" ? theme.red : theme.foreground
-    // The engine gives the newest complete frame's age, ticking once a
-    // second; an older frame on screen adds the distance between the two
-    // scan times, so no local clock is consulted.
-    readonly property int shownAge: !state || !scan || !scan.scanTime || !newestComplete ? -1
-        : Math.max(0, state.connection.ageSeconds + Math.round((Date.parse(newestComplete.scanTime) - Date.parse(scan.scanTime)) / 1000))
-    readonly property string ageText: condition && shownAge >= 0 ? ago(shownAge) : ""
-    function ago(seconds) {
-        var m = Math.floor(seconds / 60);
-        if (m < 1) return "just now";
-        if (m < 60) return m + " min ago";
-        var h = Math.floor(m / 60);
-        return h < 24 ? h + "h " + (m % 60) + "m ago" : Math.floor(h / 24) + "d " + (h % 24) + "h ago";
-    }
+    // The age of the frame on screen (Timeline.js): the engine's age of the
+    // newest complete frame plus the distance back to the shown one.
+    readonly property int shownAge: state ? Timeline.shownAge(frames, scan, state.connection.ageSeconds) : -1
+    readonly property string ageText: condition && shownAge >= 0 ? Timeline.ago(shownAge) : ""
     function lasting(seconds) {
         var m = Math.floor(seconds / 60), h = Math.floor(m / 60);
         return m < 60 ? m + " MIN" : h < 24 ? h + "H " + (m % 60) + "M" : Math.floor(h / 24) + "D " + (h % 24) + "H";
@@ -84,7 +77,7 @@ Item {
         case "unavailable": return !newestComplete ? siteId + " UNAVAILABLE · NO DATA"
             : siteId + " UNAVAILABLE" + (win.compact ? "" : " · NO DATA FOR " + lasting(state.connection.ageSeconds)) + " · LAST " + last;
         case "offline": return !scan.scanTime ? "OFFLINE · NOTHING CACHED"
-            : "OFFLINE · " + (win.compact ? "" : "SHOWING ") + "CACHED " + clock(scan.scanTime, true) + " · " + ago(shownAge).toUpperCase();
+            : "OFFLINE · " + (win.compact ? "" : "SHOWING ") + "CACHED " + clock(scan.scanTime, true) + " · " + Timeline.ago(shownAge).toUpperCase();
         default: return scan.status === "partial" && scan.scanTime ? "SCANNING · " + Math.max(0, scan.rays - 1) + " RADIALS" : "";
         }
     }
@@ -102,7 +95,11 @@ Item {
     function togglePlay() { if (frames.length > 1) engine.send({type: playing ? "pause" : "play"}); }
     function step(delta) { if (frames.length > 1) engine.send({type: "step", delta: delta}); }
     function jump(toNewest) { if (frames.length > 1) engine.send({type: "seek", id: frames[toNewest ? frames.length - 1 : 0].id}); }
-    readonly property int bands: scan ? scan.palette.length : 0
+    // The palette as a list that changes only with its colours (as the map
+    // keeps it), so the legend's columns outlive a republished live sweep.
+    readonly property string paletteKey: scan ? scan.palette.join(" ") : ""
+    readonly property var palette: paletteKey ? paletteKey.split(" ") : []
+    readonly property int bands: palette.length
     function legendLabel(index) {
         var bounds = scan.bounds;
         return index === 0 ? "<" + bounds[1] : index === bands - 1 ? bounds[index] + "+" : String(bounds[index]);
@@ -154,13 +151,15 @@ Item {
         Qt.callLater(() => { map.holdSpan = false; });
     }
     property bool viewApplied: false
-    onStateChanged: {
-        if (!state) viewApplied = false;
-        else {
-            store.initialize();
-            if (!viewApplied) { applyView(); viewApplied = true; }
-            maybeOfferLocation();
-        }
+    // The window acts on the connection, not on every broadcast: the first
+    // state after none restores the camera, nudges the session, and offers
+    // the location picker when nothing supplies a centre.
+    readonly property bool connected: !!state
+    onConnectedChanged: {
+        if (!connected) { viewApplied = false; return; }
+        store.initialize();
+        if (!viewApplied) { applyView(); viewApplied = true; }
+        maybeOfferLocation();
     }
     function maybeOfferLocation() {
         if (!opened || !store.needsLocation || locationPicker.open) return;
@@ -672,7 +671,7 @@ Item {
                         id: legendRow
                         anchors.fill: parent; spacing: 0
                         Repeater {
-                            model: app.scan ? app.scan.palette : []
+                            model: app.palette
                             ColumnLayout {
                                 required property string modelData
                                 required property int index

--- a/ui/RadarWindow.qml
+++ b/ui/RadarWindow.qml
@@ -205,7 +205,13 @@ Item {
         if (!session && KeyMap.envFloor(Quickshell.env("OMASTORM_WEAK")) === undefined) weakFloor = floor;
     }
     Component.onCompleted: applySettings()
-    readonly property bool overlayOpen: picker.open || locationPicker.open || sheet.open
+    // The overlay that is up (DESIGN.md, picker and keys): the keys sheet,
+    // the location picker, the site picker, or the treatment menu, else
+    // none. Each owns its card and handles its own keys; the window's
+    // shortcuts stand down while one is up, except that the menu leaves the
+    // treatment keys to choose.
+    readonly property string overlay: sheet.open ? "sheet" : locationPicker.open ? "location"
+        : picker.open ? "picker" : treatmentMenu.opened ? "menu" : ""
     function run(action) {
         switch (action) {
         case "search": treatmentMenu.close(); picker.show(""); break;
@@ -421,15 +427,13 @@ Item {
           anchors.fill: parent
           color: app.theme.background
           // One Shortcut per action with the bindings in force (Keys.js has
-          // the defaults). While the picker or the sheet is open its card
-          // has the keyboard and every window shortcut stands down; while
-          // the treatment menu is open the treatment keys still choose and
-          // the menu itself takes Escape.
+          // the defaults), live while no overlay is up; the treatment menu
+          // alone leaves its own keys live and takes Escape itself.
           Instantiator {
             model: KeyMap.ACTIONS.map(a => a.id)
             delegate: Shortcut {
                 sequences: app.bindings[modelData] || []
-                enabled: app.opened && !app.overlayOpen && (!treatmentMenu.opened || modelData === "pixels" || modelData === "glyphs" || modelData === "stipple")
+                enabled: app.opened && (app.overlay === "" || app.overlay === "menu" && KeyMap.TREATMENTS.indexOf(modelData.toUpperCase()) >= 0)
                 onActivated: app.run(modelData)
             }
           }

--- a/ui/Timeline.js
+++ b/ui/Timeline.js
@@ -1,4 +1,36 @@
 .pragma library
+// The timeline as the surfaces read it (docs/protocol.md, timeline): the
+// ticks, the frame whose age the engine reports, and the age of the frame
+// on screen. Pure functions shared by the window and the popover.
+
+// The newest complete frame, or null; the sweep in progress does not count.
+function newestComplete(frames) {
+    for (var i = frames.length - 1; i >= 0; i--) if (frames[i].status === "complete") return frames[i];
+    return null;
+}
+
+// The age in seconds of the frame on screen, or -1 while nothing can be
+// judged. The engine gives the newest complete frame's age, ticking once a
+// second; an older frame on screen adds the distance between the two scan
+// times, so no local clock is consulted.
+function shownAge(frames, scan, ageSeconds) {
+    var newest = newestComplete(frames);
+    if (!scan || !scan.scanTime || !newest) return -1;
+    return Math.max(0, ageSeconds + Math.round((Date.parse(newest.scanTime) - Date.parse(scan.scanTime)) / 1000));
+}
+
+// An age as the header says it; `brief` drops the lesser unit for the
+// popover's width.
+function ago(seconds, brief) {
+    var m = Math.floor(seconds / 60);
+    if (m < 1) return "just now";
+    if (m < 60) return m + " min ago";
+    var h = Math.floor(m / 60);
+    if (h < 24) return brief ? h + "h ago" : h + "h " + (m % 60) + "m ago";
+    var d = Math.floor(h / 24);
+    return brief ? d + "d ago" : d + "d " + (h % 24) + "h ago";
+}
+
 // Frame ticks and up to three stubs for missing scan intervals.
 function slots(frames) {
     var out = [], n = frames.length;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

While live, the engine broadcasts `state` once a second so `connection.ageSeconds` moves (`engine/src/main.rs`, the cleanup tick). The UI bound its frame, timeline, palette, and coverage inputs straight to that object, so every tick:

- handed a fresh array to the `Repeater`s behind the timeline ticks (window and popover), the legend columns, the palette strip that feeds the radar shader, the coverage footprint `Shape`, and rebuilt them all;
- restarted the map's settle timer with `reask` set, so each visible map re-sent `tiles_needed` every second. The engine answers a rendered rectangle at once, so up to 64 `tile_ready` replies came back per second, each one rebuilding the tile model and re-sorting the place labels.

## What changed

**Rebuild only on real change** (`Engine.qml`, `RadarMap.qml`, `RadarWindow.qml`, `Popover.qml`)
- `Engine` exposes `frame`, `timeline`, and `siteId` as slices that change only with their content (a string key compares by value; the slice is parsed from it). Surfaces bind to those instead of `state.frame` / `state.timeline`.
- The map and window derive a stable `palette` list the same way, so the legend and swatch strip survive a live sweep republished chunk by chunk.
- `coverageSites` is built from scalar site properties (`siteLat`/`siteLon`) rather than the `site` object, so the footprint `Shape` is not re-tessellated per frame.
- Label lists are replaced only when the layout differs (JSON compare), so label delegates survive a no-op relayout.
- The station marker `Repeater` uses `visible` instead of re-filtering 163 sites on each hand-off.
- The window reacts to the connection coming and going (`onConnectedChanged`) rather than to every broadcast.

**Tiles** (`RadarMap.qml`, `docs/protocol.md`)
- Re-ask the rectangle only when a frame arrives after none (launch, reconnect); frames on a standing connection ride the camera.
- `tileReady` defers the model rebuild with `Qt.callLater`, so a burst of replies costs one rebuild.

**Simplification / state** (`PluginSession.qml`, `RadarWindow.qml`, `Timeline.js`)
- `PluginSession`: `placeView`, `holdLock`, and `resolveLock` are now the only way the view fields and lock move; `lockWanted` (always `lockId !== ""`) is gone; `applyLaunchLock`/`applyConfigLockChange` collapse into one rule. ~60 lines shorter.
- The window names the overlay that is up (`overlay`: sheet / location / picker / menu / none) and the shortcut rule reads off it.
- The frame-age text, computed twice with the same rule, lives in `Timeline.js` for both surfaces.

## Verification

This environment has no Quickshell or Qt Quick runtime, so `mise check` and the capture scripts could not be run here; **please run `mise check` (and `mise check --gpu` for the map changes) on an Omarchy desktop before merging.** What was done instead:

- `qmllint` (Qt 6.4) parses every edited file; the only warnings are the same unresolved-Quickshell-type warnings as on `main`.
- `Timeline.js` helpers checked in node against the previous inline formats over a range of ages (identical output).
- `PluginSession` old vs. new function bodies run side by side in node over 17 location/lock scenarios (weather / remembered / explicit centre, config lock added and removed, picker, `chooseRadar`, `setLock`, `followNearest`, `resetView`, engine offline, env view): identical fields, sends, and persisted snapshots.
- Walked `tests/map-tiles.qml`, `tests/map-sites.qml`, `tests/map-network.qml`, and the `check-*.sh` scripts against the new code paths (synchronous expectations after `requestTiles()`, `siteLabels` identity across a pan, `coverageSites` contents, `coverageRepeater` alias).

One intentional edge: `resetView` to a configured/weather target now also clears `needsLocation`, which previously could stay `true` over a valid view in a transient window before `resolve()` ran.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08487-6acc-7213-816f-b7787a0a6cd5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08487-6acc-7213-816f-b7787a0a6cd5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

