### PR TITLE
Keep mise check off /tmp, run it in lanes, and steady the socket tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,11 @@ and no remembered view, so the location picker shows.
 ## Verify and submit
 
 Keep each change scoped to one issue. Run `mise check` before every commit;
-it uses a scratch daemon and leaves the shared daemon alone.
+it uses scratch daemons and leaves the shared daemon alone. Cargo runs
+first, then the Rust tests run alongside the UI checks, which proceed in two
+lanes. Scratch and logs live under `target/check/`, never `/tmp`; the daemons
+and runtime files go on every exit, and the logs stay until the next run.
+The checks read `target/debug/`, so leave `CARGO_TARGET_DIR` unset.
 
 For shader, sampling, or camera changes, also run `mise check --gpu` and
 `bash scripts/capture-review.sh`, inspect the images in `review/`, and include

--- a/engine/tests/protocol.rs
+++ b/engine/tests/protocol.rs
@@ -3,8 +3,9 @@ use std::{
     fs,
     io::{BufRead, BufReader, Write},
     os::unix::net::{UnixListener, UnixStream},
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::{Child, Command, Stdio},
+    sync::{Mutex, MutexGuard},
     thread,
     time::{Duration, Instant},
 };
@@ -15,18 +16,55 @@ const ARCHIVE: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../data/raw/KTLX20130520_201643_V06.gz"
 );
+/// How long a daemon may take to decode the archive and listen, and how long
+/// a reply may take. Both are far above the usual fraction of a second, so a
+/// busy machine gets a slow test rather than a failed one; they only bound
+/// how long a genuinely hung daemon holds the suite.
+const STARTUP: Duration = Duration::from_secs(30);
+const REPLY: Duration = Duration::from_secs(10);
+/// One daemon at a time. Each test starts its own; run at once they compete
+/// for the CPU with each other and with whatever else the machine is doing,
+/// and the suite has missed a reply (`WouldBlock`) or a launch under that
+/// load. Serial, each daemon's timing is its own.
+static SERIAL: Mutex<()> = Mutex::new(());
+fn serial() -> MutexGuard<'static, ()> {
+    // A failed test poisons the lock; the next test is still its own.
+    SERIAL.lock().unwrap_or_else(|e| e.into_inner())
+}
+/// A fresh scratch `XDG_RUNTIME_DIR` under `target/` for this test. An
+/// interrupted run leaves its tree behind, and a later process with the same
+/// PID would otherwise find a socket file no daemon listens on.
+fn scratch_root(name: &str) -> PathBuf {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!(
+        "../target/t-{name}-{}-{:?}",
+        std::process::id(),
+        thread::current().id()
+    ));
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+    root
+}
+/// Connect once the daemon under `root` listens, within `STARTUP`; `alive`
+/// fails early when the daemon has already exited.
+fn await_daemon(root: &Path, mut alive: impl FnMut() -> bool) -> BufReader<UnixStream> {
+    let deadline = Instant::now() + STARTUP;
+    loop {
+        if let Ok(stream) = UnixStream::connect(root.join("omastorm/engine.sock")) {
+            stream.set_read_timeout(Some(REPLY)).unwrap();
+            return BufReader::new(stream);
+        }
+        assert!(alive(), "engine exited");
+        assert!(Instant::now() < deadline, "engine startup timed out");
+        thread::sleep(Duration::from_millis(10));
+    }
+}
 struct Engine {
     child: Child,
     root: PathBuf,
 }
 impl Engine {
     fn start() -> Self {
-        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!(
-            "../target/t-{}-{:?}",
-            std::process::id(),
-            thread::current().id()
-        ));
-        fs::create_dir_all(&root).unwrap();
+        let root = scratch_root("engine");
         let child = Command::new(env!("CARGO_BIN_EXE_omastorm-engine"))
             .env("OMASTORM_ARCHIVE", ARCHIVE)
             .env("XDG_RUNTIME_DIR", &root)
@@ -34,19 +72,12 @@ impl Engine {
             .spawn()
             .unwrap();
         let mut engine = Self { child, root };
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while !engine.root.join("omastorm/engine.sock").exists() {
-            assert!(engine.child.try_wait().unwrap().is_none(), "engine exited");
-            assert!(Instant::now() < deadline, "engine startup timed out");
-            thread::sleep(Duration::from_millis(10));
-        }
+        await_daemon(&engine.root, || engine.child.try_wait().unwrap().is_none());
         engine
     }
     fn connect(&self) -> BufReader<UnixStream> {
         let stream = UnixStream::connect(self.root.join("omastorm/engine.sock")).unwrap();
-        stream
-            .set_read_timeout(Some(Duration::from_secs(2)))
-            .unwrap();
+        stream.set_read_timeout(Some(REPLY)).unwrap();
         BufReader::new(stream)
     }
 }
@@ -76,6 +107,7 @@ fn state(client: &mut BufReader<UnixStream>, predicate: impl Fn(&Value) -> bool)
 }
 #[test]
 fn fixture_transport_and_shared_commands() {
+    let _serial = serial();
     let engine = Engine::start();
     let mut first = engine.connect();
     let hello = read(&mut first);
@@ -277,6 +309,7 @@ fn fixture_transport_and_shared_commands() {
 }
 #[test]
 fn crash_recovery_and_immutable_revisions() {
+    let _serial = serial();
     let mut engine = Engine::start();
     let mut client = engine.connect();
     read(&mut client);
@@ -293,14 +326,7 @@ fn crash_recovery_and_immutable_revisions() {
         .env("XDG_RUNTIME_DIR", &engine.root)
         .spawn()
         .unwrap();
-    let deadline = Instant::now() + Duration::from_secs(5);
-    let mut client = loop {
-        if let Ok(stream) = UnixStream::connect(engine.root.join("omastorm/engine.sock")) {
-            break BufReader::new(stream);
-        }
-        assert!(Instant::now() < deadline);
-        thread::sleep(Duration::from_millis(10));
-    };
+    let mut client = await_daemon(&engine.root, || engine.child.try_wait().unwrap().is_none());
     read(&mut client);
     let new = read(&mut client)["frame"]["texture"]
         .as_str()
@@ -333,6 +359,7 @@ fn crash_recovery_and_immutable_revisions() {
 }
 #[test]
 fn oversized_client_is_disconnected_without_harming_server() {
+    let _serial = serial();
     let engine = Engine::start();
     let mut bad = engine.connect();
     read(&mut bad);
@@ -346,14 +373,10 @@ fn oversized_client_is_disconnected_without_harming_server() {
 }
 #[test]
 fn launcher_replaces_a_daemon_of_another_build() {
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!(
-        "../target/t-{}-{:?}",
-        std::process::id(),
-        thread::current().id()
-    ));
+    let _serial = serial();
+    let root = scratch_root("launcher");
     let dir = root.join("omastorm");
     fs::create_dir_all(&dir).unwrap();
-    let _ = fs::remove_file(dir.join("engine.sock"));
     let listener = UnixListener::bind(dir.join("engine.sock")).unwrap();
     // Stand in for a daemon left over from an earlier build: a real process
     // that the launcher must end, whose PID the socket reports. It answers the
@@ -389,9 +412,7 @@ fn launcher_replaces_a_daemon_of_another_build() {
         "the stale process was terminated: {status}"
     );
     let stream = UnixStream::connect(dir.join("engine.sock")).unwrap();
-    stream
-        .set_read_timeout(Some(Duration::from_secs(2)))
-        .unwrap();
+    stream.set_read_timeout(Some(REPLY)).unwrap();
     let mut client = BufReader::new(stream);
     let hello = read(&mut client);
     assert_eq!(hello["type"], "hello");
@@ -415,13 +436,7 @@ fn launcher_replaces_a_daemon_of_another_build() {
 }
 #[test]
 fn stop_with_no_daemon_is_quiet_and_leaves_nothing_behind() {
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!(
-        "../target/t-{}-{:?}",
-        std::process::id(),
-        thread::current().id()
-    ));
-    let _ = fs::remove_dir_all(&root);
-    fs::create_dir_all(&root).unwrap();
+    let root = scratch_root("stop");
     let output = Command::new(env!("CARGO_BIN_EXE_omastorm-engine"))
         .env("OMASTORM_ARCHIVE", ARCHIVE)
         .arg("stop")
@@ -443,6 +458,7 @@ fn stop_with_no_daemon_is_quiet_and_leaves_nothing_behind() {
 }
 #[test]
 fn tiles_needed_is_answered_tile_by_tile_to_the_sender() {
+    let _serial = serial();
     let engine = Engine::start();
     let mut asker = engine.connect();
     read(&mut asker);
@@ -536,27 +552,15 @@ fn tiles_needed_is_answered_tile_by_tile_to_the_sender() {
 /// to draw, an empty timeline, `loading` until a client selects a site.
 #[test]
 fn a_lean_start_has_no_frame_until_a_site_is_selected() {
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join(format!("../target/t-lean-{}", std::process::id()));
-    let _ = fs::remove_dir_all(&root);
-    fs::create_dir_all(&root).unwrap();
+    let _serial = serial();
+    let root = scratch_root("lean");
     let mut child = Command::new(env!("CARGO_BIN_EXE_omastorm-engine"))
         .env("XDG_RUNTIME_DIR", &root)
         .env_remove("OMASTORM_ARCHIVE")
         .stdout(Stdio::null())
         .spawn()
         .unwrap();
-    let deadline = Instant::now() + Duration::from_secs(5);
-    while !root.join("omastorm/engine.sock").exists() {
-        assert!(child.try_wait().unwrap().is_none(), "engine exited");
-        assert!(Instant::now() < deadline, "engine startup timed out");
-        thread::sleep(Duration::from_millis(10));
-    }
-    let stream = UnixStream::connect(root.join("omastorm/engine.sock")).unwrap();
-    stream
-        .set_read_timeout(Some(Duration::from_secs(2)))
-        .unwrap();
-    let mut client = BufReader::new(stream);
+    let mut client = await_daemon(&root, || child.try_wait().unwrap().is_none());
     let hello = read(&mut client);
     assert_eq!(hello["type"], "hello");
     let initial = read(&mut client);

--- a/scripts/check-engine-install.sh
+++ b/scripts/check-engine-install.sh
@@ -12,7 +12,11 @@ cd "$(dirname "$0")/.."
 fail() { printf '%s\n' "$@" >&2; exit 1; }
 [[ -x target/debug/omastorm-engine ]] || fail 'Need target/debug/omastorm-engine (check.sh builds it).'
 
-scratch=$(mktemp -d /tmp/omastorm-engine-install.XXXXXX)
+# Several copies of the debug engine and a tree of HEAD: under target/, and
+# gone on exit, pass or fail.
+scratch=$PWD/target/check-engine-install
+rm -rf "$scratch"
+mkdir -p "$scratch"
 trap 'rm -rf "$scratch"' EXIT
 export XDG_DATA_HOME="$scratch/data" XDG_CACHE_HOME="$scratch/cache" XDG_RUNTIME_DIR="$scratch/runtime"
 mkdir -p "$XDG_RUNTIME_DIR"

--- a/scripts/check-keys.sh
+++ b/scripts/check-keys.sh
@@ -39,6 +39,13 @@ until_field() { # name, wanted
   for _ in {1..100}; do [[ $(field "$1") == "$2" ]] && return; sleep .1; done
   fail "$1 never became $2: $(call status)"
 }
+# The map reports its settled centre back through projection math, so a
+# picked 35.4 may be on disk as 35.39999999999999 moments later; compare
+# the numbers, not the text.
+state_at() { # file, lat, lon
+  jq -e --argjson lat "$2" --argjson lon "$3" \
+    '(.lat - $lat | fabs) < 1e-6 and (.lon - $lon | fabs) < 1e-6' "$1" > /dev/null 2>&1
+}
 for _ in {1..100}; do call status > /dev/null 2>&1 && break; sleep .1; done
 call status > /dev/null || fail "The window's keys IPC never answered"
 
@@ -101,7 +108,7 @@ quickshell ipc --pid "$pid" call location go 35.4 -97.5 "Moore"
 until_field lat 35.4
 until_field lon -97.5
 until_field locationSource state
-grep -q '"lat":35.4' "$check_dir/state.json" || fail "Shift+H location did not write state.json" "$(cat "$check_dir/state.json")"
+state_at "$check_dir/state.json" 35.4 -97.5 || fail "Shift+H location did not write state.json" "$(cat "$check_dir/state.json")"
 grep -q home_site "$check_dir/config.toml" && fail "Shift+H wrote home_site into config.toml"
 
 # The fix applies through the file watch: no report, the new key in force,

--- a/scripts/check-launcher.sh
+++ b/scripts/check-launcher.sh
@@ -6,7 +6,9 @@ cd "$(dirname "$0")/.."
 
 fail() { printf '%s\n' "$@" >&2; exit 1; }
 
-scratch=$(mktemp -d /tmp/omastorm-launcher.XXXXXX)
+scratch=$PWD/target/check-launcher
+rm -rf "$scratch"
+mkdir -p "$scratch"
 trap 'rm -rf "$scratch"' EXIT
 export XDG_DATA_HOME="$scratch/data"
 apps=$XDG_DATA_HOME/applications

--- a/scripts/check-link-plugin.sh
+++ b/scripts/check-link-plugin.sh
@@ -6,7 +6,9 @@ cd "$(dirname "$0")/.."
 
 fail() { printf '%s\n' "$@" >&2; exit 1; }
 
-scratch=$(mktemp -d /tmp/omastorm-link.XXXXXX)
+scratch=$PWD/target/check-link-plugin
+rm -rf "$scratch"
+mkdir -p "$scratch"
 trap 'rm -rf "$scratch"' EXIT
 export XDG_CONFIG_HOME="$scratch/config"
 plugins=$XDG_CONFIG_HOME/omarchy/plugins

--- a/scripts/check-location.sh
+++ b/scripts/check-location.sh
@@ -27,6 +27,13 @@ until_field() {
   for _ in {1..100}; do [[ $(field "$1") == "$2" ]] && return; sleep .1; done
   fail "$1 never became $2: $(call status)"
 }
+# The map reports its settled centre back through projection math, so a
+# picked 35.4 may be on disk as 35.39999999999999 moments later; compare
+# the numbers, not the text.
+state_at() { # file, lat, lon
+  jq -e --argjson lat "$2" --argjson lon "$3" \
+    '(.lat - $lat | fabs) < 1e-6 and (.lon - $lon | fabs) < 1e-6' "$1" > /dev/null 2>&1
+}
 
 # Isolated from the machine: a remembered centre is the camera, weather is
 # not read unless OMASTORM_LOCATION names a file.
@@ -74,7 +81,7 @@ until_field locked false
 sleep 0.4
 until_field lat 35.4
 until_field lon -97.5
-grep -q '"lat":35.4' "$check_dir/state-weather.json" || fail "Location picker did not write state" "$(cat "$check_dir/state-weather.json")"
+state_at "$check_dir/state-weather.json" 35.4 -97.5 || fail "Location picker did not write state" "$(cat "$check_dir/state-weather.json")"
 grep -q center_lat "$check_dir/none.toml" && fail "Location picker wrote config.toml"
 # n selects the nearest radar and does not move the camera.
 before_lat=$(field lat); before_lon=$(field lon)

--- a/scripts/check-popover.sh
+++ b/scripts/check-popover.sh
@@ -3,7 +3,9 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 mkdir -p review
-scratch=$(mktemp -d /tmp/omastorm-popover.XXXXXX)
+scratch=$PWD/target/check-popover
+rm -rf "$scratch"
+mkdir -p "$scratch"
 export XDG_RUNTIME_DIR="$scratch/runtime" XDG_CACHE_HOME="$scratch/cache"
 export QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME=basic QT_QUICK_BACKEND=rhi QSG_RHI_BACKEND=opengl
 export OMASTORM_CONFIG="$scratch/config.toml"
@@ -16,6 +18,8 @@ pid=
 cleanup() {
   [[ -z $pid ]] || kill "$pid" 2>/dev/null || true
   target/debug/omastorm-engine stop >/dev/null 2>&1 || true
+  # The textures and the seeded frame ring go; ui.log stays for reading.
+  rm -rf "$scratch/runtime" "$scratch/cache"
 }
 trap cleanup EXIT
 quickshell -p ui/PopoverHarness.qml > "$scratch/ui.log" 2>&1 &

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,50 +1,107 @@
 #!/usr/bin/env bash
 # The regression suite in one run: formatting, Clippy with warnings denied,
 # the Rust unit and socket tests, and the UI checks, each with a
-# pass/fail line. The UI checks launch their windows against a scratch
-# daemon under a scratch XDG_RUNTIME_DIR, so the shared daemon and any open
-# window are left alone; the socket tests already use their own. `--gpu`
-# adds the ignored rendering tests (about 50 s; needed after a shader,
-# sampling, or camera change). The capture scripts are not here: run the
-# one whose picture the session changed.
+# pass/fail line. Cargo goes first and alone, since every Cargo command
+# takes the build directory lock; once the binaries exist the tests run
+# while the UI checks proceed in two lanes: the windows that share one
+# scratch daemon, in order, and the checks that bring their own daemon or
+# need none. Each lane's daemon lives under its own scratch
+# XDG_RUNTIME_DIR, so the shared daemon and any open window are left
+# alone; the socket tests already use their own. Scratch and logs live
+# under target/check/, never /tmp (a tmpfs, which two leftover trees fill),
+# and the daemons and runtime files go on every exit, a failure or Ctrl-C
+# included; the logs stay until the next run. `--gpu` adds the ignored
+# rendering tests (about 50 s; needed after a shader, sampling, or camera
+# change). The capture scripts are not here: run the one whose picture the
+# session changed.
 set -uo pipefail
 cd "$(dirname "$0")/.." || exit 1
 gpu=0
 [[ ${1:-} == --gpu ]] && gpu=1
-scratch=$(mktemp -d /tmp/omastorm-check.XXXXXX)
-logs="$scratch/logs"
-mkdir -p "$logs"
+# run.sh and the UI checks read target/debug/omastorm-engine. Cargo output
+# elsewhere leaves that engine stale or missing, and every window then
+# reports that it never answered; a target directory on a tmpfs also
+# rebuilds the native crates once the tmpfs fills.
+if [[ -n ${CARGO_TARGET_DIR:-} ]]; then
+  echo "CARGO_TARGET_DIR is set ($CARGO_TARGET_DIR); the checks build and read target/. Unset it." >&2
+  exit 1
+fi
+scratch=$PWD/target/check
+logs=$scratch/logs
+rm -rf "$scratch"
+mkdir -p "$logs" "$scratch/tmp"
+# The check scripts' mktemp calls and the engine installer's work dir land here.
+export TMPDIR=$scratch/tmp
 failed=0
-step() { # name, command...
-  local name=$1
+lanes=()
+child=
+cleanup() {
+  for pid in "${lanes[@]}"; do kill "$pid" 2> /dev/null; done
+  wait 2> /dev/null
+  for runtime in "$scratch"/runtime-*; do
+    [[ -d $runtime ]] && XDG_RUNTIME_DIR=$runtime target/debug/omastorm-engine stop > /dev/null 2>&1
+  done
+  rm -rf "$scratch"/runtime-* "$scratch/tmp"
+}
+trap cleanup EXIT
+trap 'kill "${child:-}" 2> /dev/null; exit 130' INT TERM
+step() { # name, command...: one line per step; the output goes to its log
+  local name=$1 started=$SECONDS
   shift
-  local started=$SECONDS
-  if "$@" > "$logs/$name.log" 2>&1; then
+  # In the background so a signal ends the step at once instead of after it.
+  "$@" > "$logs/$name.log" 2>&1 &
+  child=$!
+  if wait "$child"; then
+    child=
     printf '%-20s PASS  %3ds\n' "$name" $((SECONDS - started))
   else
+    child=
     printf '%-20s FAIL  %3ds  (%s)\n' "$name" $((SECONDS - started)) "$logs/$name.log"
-    failed=1
+    return 1
   fi
 }
-step fmt bash scripts/cargo.sh fmt --check
-step clippy bash scripts/cargo.sh clippy --offline --locked --all-targets -- -D warnings
-step test bash scripts/cargo.sh test --offline --locked
-if (( gpu )); then
-  step rendering env QT_QPA_PLATFORM=offscreen bash scripts/cargo.sh test --offline --locked -- --ignored rendering
+lane() { # name, checks...: the checks in order, sharing one scratch daemon
+  local rc=0
+  export XDG_RUNTIME_DIR=$scratch/runtime-$1
+  shift
+  mkdir -p "$XDG_RUNTIME_DIR"
+  trap 'kill "${child:-}" 2> /dev/null; exit 143' TERM
+  for check in "$@"; do
+    step "$check" timeout 180 bash "scripts/$check.sh" || rc=1
+  done
+  target/debug/omastorm-engine stop > /dev/null 2>&1
+  return $rc
+}
+tests() { # the compiled tests; the cap ends a hung test and its daemons
+  local rc=0
+  trap 'kill "${child:-}" 2> /dev/null; exit 143' TERM
+  step test timeout 600 bash scripts/cargo.sh test --offline --locked || rc=1
+  if (( gpu )); then
+    step rendering timeout 600 env QT_QPA_PLATFORM=offscreen bash scripts/cargo.sh test --offline --locked -- --ignored rendering || rc=1
+  fi
+  return $rc
+}
+step fmt bash scripts/cargo.sh fmt --check || failed=1
+step clippy bash scripts/cargo.sh clippy --offline --locked --all-targets -- -D warnings || failed=1
+# The engine and the test binaries, so the tests and the windows below
+# start without compiling under each other. Without them there is nothing
+# to run, and each window would only wait out its timeout.
+if step build bash scripts/cargo.sh test --offline --locked --no-run; then
+  # The UI checks assume the archived KTLX scan; a fresh daemon shows it when
+  # OMASTORM_ARCHIVE names the volume (a shipped daemon starts with no frame).
+  export OMASTORM_ARCHIVE="$PWD/data/raw/KTLX20130520_201643_V06.gz"
+  tests & lanes+=($!)
+  # check-picker and check-keys select stations for real, so they run last.
+  lane window check-engine-ui check-map-sites check-map-network check-location check-picker check-keys & lanes+=($!)
+  lane alone check-bind check-link-plugin check-launcher check-theme check-map-tiles check-engine-install check-popover & lanes+=($!)
+  for pid in "${lanes[@]}"; do wait "$pid" || failed=1; done
+  lanes=()
+else
+  failed=1
+  echo 'The engine did not build; the tests and the UI checks did not run.'
 fi
-# The UI checks assume the archived KTLX scan; a fresh daemon shows it when
-# OMASTORM_ARCHIVE names the volume (a shipped daemon starts with no frame).
-export OMASTORM_ARCHIVE="$PWD/data/raw/KTLX20130520_201643_V06.gz"
-# check-picker and check-keys select stations for real, so they run last.
-export XDG_RUNTIME_DIR="$scratch/runtime"
-mkdir -p "$XDG_RUNTIME_DIR"
-for check in check-engine-ui check-engine-install check-map-tiles check-map-sites check-map-network check-theme check-location check-picker check-keys check-popover check-launcher check-link-plugin check-bind; do
-  step "$check" timeout 180 bash "scripts/$check.sh"
-done
-target/debug/omastorm-engine stop > /dev/null 2>&1 || true
 if (( failed )); then
   echo "Logs under $logs"
   exit 1
 fi
-rm -rf "$scratch"
 echo "All checks passed."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #27.

## Resulting behavior

**Nothing under `/tmp`.** `scripts/check.sh` keeps its scratch tree, per-lane `XDG_RUNTIME_DIR`s, and logs under `target/check/`, exports `TMPDIR` there so the check scripts' `mktemp` calls and the engine installer's work dir follow, and a trap stops the scratch daemons and removes the runtime files on every exit, a failure or Ctrl-C included. Only the logs stay, until the next run. `check-launcher`, `check-link-plugin`, `check-engine-install`, and `check-popover` (which never removed its tree) now scratch under `target/check-<name>/` and remove the bulky parts on exit.

**Lanes.** Cargo goes first and alone (fmt, clippy, then `cargo test --no-run` for the engine and the test binaries). Once those exist, `cargo test` runs beside the UI checks, which proceed in two lanes: the windows that share one scratch daemon (`engine-ui`, `map-sites`, `map-network`, `location`, `picker`, `keys`, in the existing order) and the checks that bring their own daemon or need none (`bind`, `link-plugin`, `launcher`, `theme`, `map-tiles`, `engine-install`, `popover`). Cargo releases the build-directory lock before running tests (verified: `cargo build` returned in 0.1 s mid-test-run), so `run.sh`'s build is not blocked. A failed build skips the tests and the windows rather than letting each wait out its timeout. `CARGO_TARGET_DIR` is refused up front, since `run.sh` and the checks read `target/debug/` and the symptom otherwise is every window "never answered".

**Socket tests.** `engine/tests/protocol.rs` serialises the daemon-starting tests behind a static mutex (no new dependency), waits for a successful connect instead of the socket file existing (a stale tree from an interrupted run under a reused PID read as connection refused), removes each test's scratch root first, and widens the startup/reply timeouts to 30 s/10 s so a loaded machine gets a slow test rather than a false failure. Serial costs ~6 s on that suite (33 s → 40 s here), hidden in `mise check` by the overlap with the UI lanes.

**Location assertions.** `check-location` and `check-keys` asserted the literal text `"lat":35.4` in the state file after a pick at 35.4, -97.5. The picker writes exactly that, but the map then reports its settled centre back through the projection math and the file becomes `35.39999999999999` about half a second later; whether the round trip lands on 35.4 exactly depends on pixel quantisation at the moment the view is applied, so the check raced the second write. Both now compare the numbers within 1e-6°.

## Why

Per #27: `/tmp` is a ~5 GB tmpfs; a 1.6 GB `target/` plus leftover check trees filled it, and the required pre-commit suite then failed for disk. The suite also ran ~13 window launches and a 45 s retention test strictly in series.

## Verification

- On an Omarchy desktop (maintainer run): the full `mise check` completed in about 45 s, `test` at 42 s fully overlapped by the UI lanes; the one failure was the `check-location` text-vs-number race above, fixed in the last commit.
- `cargo fmt --check`, `cargo clippy --offline --locked --all-targets -- -D warnings`, `cargo test --offline --locked` (33 unit + 7 protocol tests) pass with Rust 1.98; `shellcheck -x run.sh scripts/*.sh` clean.
- Protocol suite 3/3 old and 3/3 new under 6 busy-loop CPU load on 4 cores; the tests leave no `target/t-*` behind. `cargo build` and `cargo test --no-run` produce the identical `target/debug/omastorm-engine` (same inode), so the background tests never restart the lanes' daemons as "another build".
- `check.sh` orchestration exercised in a sandbox with stubbed `cargo.sh`, check scripts, and engine: lanes interleave, PASS/FAIL lines and exit codes are right, a failing step reports its log path, a failed build skips the rest, `CARGO_TARGET_DIR` is refused, and SIGINT to the process group tears down every lane process within a second, stops both scratch daemons, and removes `runtime-*` and `tmp` while keeping `logs/`.
- The new `state_at` jq predicate matches the exact and the noisy file, and rejects a different coordinate, an empty file, a file without `lat`, and a missing file.

## Notes

- `scripts/setup-fixture.sh` currently fails its `sha256sum -c` on `cities5000.txt` (GeoNames republishes it daily); unrelated to this change and left alone.
- `mise clean` still removes `/tmp/omastorm-check.*` for trees left by earlier versions; new runs create none.
- Possible follow-up outside this issue: `rememberView` could keep the store's exact centre when the map's settled centre differs by less than ~1e-6°, so users' `state.json` never holds `35.39999999999999` for a picked 35.4.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08497-bc24-72bf-b52e-b92492af13b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08497-bc24-72bf-b52e-b92492af13b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

