### PR TITLE
Use approximate IP location after configured, remembered, and weather locations

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -76,10 +76,15 @@ map center in this order:
 1. Explicit `center_lat` and `center_lon` in `config.toml`.
 2. The last center remembered in `state.json`.
 3. Valid coordinates from Omarchy's weather location (`weather.json`).
-4. A location chosen through Omastorm's location picker.
+4. Approximate IP location, unless `ip_location = false`.
+5. A location chosen through Omastorm's location picker.
 
-Only show onboarding when none of the first three sources supplies a valid
-center. The popover offers "Choose a location", opening the expanded
+If the first three sources have no valid center, the UI requests one bounded
+IP lookup from the running live engine. Remember a successful center like a
+weather-derived view. While it is pending, the location picker remains
+available; opening it or navigating takes priority over a late reply.
+Failure, opt-out, or an older engine leaves onboarding available.
+The popover offers "Choose a location", opening the expanded
 window's picker. Offer place search and "Enter coordinates", which reveals
 labeled latitude and longitude fields with validation. Place search is an
 engine `search_places` reply over GeoNames cities with population ≥ 5000
@@ -92,8 +97,10 @@ radar. Choosing a location writes `state.json`, never `config.toml`.
 
 Reuse Omarchy's location when available without requiring its weather plugin.
 Read weather settings only; never write them. Location search is an explicit
-user action handled through the engine. Do not use GeoClue or fetch at launch
-to discover the user's location.
+user action handled through the engine. The IP fallback is an engine request
+after bootstrap; the launcher itself fetches nothing. Do not use GeoClue.
+Archived views and isolated checks do not request IP location unless a live
+check explicitly opts in. Disabling IP lookup does not erase remembered views.
 
 Resolve the radar separately: an explicit `locked_radar` in config wins,
 otherwise restore a remembered radar lock, otherwise choose the station

--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ sha256 against `engine/release.pin`, and installs it under
 `~/.local/share/omastorm/bin`. Runtime files, cached data, remembered view state, and configuration stay
 inside Omastorm's own directories.
 
-On first use, Omastorm uses your Omarchy weather location when available;
-otherwise it prompts you to search for a place or enter coordinates. To set
+On first use, Omastorm uses your Omarchy weather location when available,
+then approximate IP location to choose a nearby view. If neither is available,
+it prompts you to search for a place or enter coordinates. Set
+`ip_location = false` to disable the IP fallback. To set
 a fixed launch location, including during agent-assisted installation, see
 [configuration and remembered state](docs/configuration.md).
 
@@ -119,8 +121,8 @@ last map center, zoom, and UI radar lock separately in
 `Shift+H`, or LOCATION, opens the location picker; it writes state, not config.
 
 Explicit center coordinates win on every launch. Without them, Omastorm
-restores your last view, then falls back to the weather location or location
-picker. Radar selection is independent: a configured lock wins, otherwise a
+restores your last view, then falls back to weather, approximate IP location,
+or the location picker. Radar selection is independent: a configured lock wins, otherwise a
 remembered lock is restored, otherwise the nearest radar follows the map.
 
 ```toml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,25 @@ Resolve the map center from the first valid source:
 3. Omarchy's weather coordinates in
    `~/.local/state/omarchy/settings/weather.json` (`name`, `latitude`,
    `longitude`). File existence alone is insufficient; coordinates must be valid.
-4. The location picker: search for a place or enter latitude and longitude.
+4. Approximate IP location from ipwho.is over HTTPS, unless disabled.
+5. The location picker: search for a place or enter latitude and longitude.
+
+`ip_location = false` disables IP lookup; omission enables it. The lookup is
+requested only when explicit, remembered, and weather coordinates are absent.
+The provider receives the connection's public IP. The engine retains only
+city and coordinates in memory (success for 24 hours, failure for five minutes),
+and the UI remembers a successful view in `state.json`. A reopened app uses
+that remembered view without another lookup. Opting out does not erase it.
+The initial view is labeled `IP NEAR …`; IP coordinates are approximate and
+may reflect a VPN or ISP location. LOCATION always lets you choose another.
+
+The launcher performs no location request. After engine connection, one lookup
+takes at most ten seconds; the UI also times out an older engine that cannot
+answer. Failure leaves the picker available. Opening the picker, navigating,
+or selecting a radar prevents a late reply from changing the view. Archived
+sessions never locate. When `OMASTORM_CONFIG` isolates a check, `ip_location =
+true` is required to opt it in; `OMASTORM_LOCATION_URL` can direct the engine
+to a local test endpoint.
 
 A missing location opens a "Choose a location" prompt in the popover; its
 button opens the expanded window's picker. Accepting a location saves the

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -158,6 +158,25 @@ when `osm` becomes available. `labels` are the tile's places for the overlay.
 
 ## Client commands
 
+`locate_home` requests approximate IP location from the running engine. It
+does not select a station or alter shared radar state. The sender receives
+either a private `location` reply or an `error` naming `locate_home`:
+
+```json
+{"type":"locate_home"}
+{"type":"location","v":1,"name":"Stamford","lat":41.0534,"lon":-73.5387}
+```
+
+Concurrent clients share a bounded lookup cache (24 hours for success, five
+minutes for failure). HTTPS requests to ipwho.is time out after ten seconds
+and responses are limited to 16 KiB. Replies contain city and valid numeric
+coordinates, never an IP address. The UI requests this only for a live view
+without explicit, remembered, or weather coordinates, unless opted out. It
+honors later user choices, applies radar selection independently, and saves
+the resulting center through the normal remembered-view path. The engine
+still reads neither config nor remembered state. An older engine ignores the
+unknown command, so the UI times out and offers the location picker.
+
 ```json
 {"type":"select_site","id":"KTLX"}
 {"type":"follow","enabled":true}
@@ -355,7 +374,7 @@ to the engine restores the necessary selection and flags without resetting
 the active camera. A change of frame or station never re-centers the map
 except when the user picks a station in search, which the UI centres on.
 Location picks write state.json. With no location, the popover offers the
-picker instead of inventing a centre.
+picker if the optional IP fallback cannot supply a center.
 
 `hello` additionally includes `pid`, `build` (an opaque fingerprint),
 `sitesSource`, `sitesRetrieved`, and `sitesNotes`. These allow the launcher to

--- a/engine/src/location.rs
+++ b/engine/src/location.rs
@@ -1,0 +1,121 @@
+//! Approximate IP location, fetched only on a client's `locate_home` request.
+//! https://ipwhois.io/documentation documents the keyless HTTPS endpoint.
+//! Retain only the city and coordinates, in memory; never store the IP.
+
+use crate::protocol::{Location, VERSION};
+use serde::Deserialize;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+
+const URL: &str = "https://ipwho.is/?fields=success,message,city,region,latitude,longitude";
+const MAX_BODY: usize = 16 * 1024;
+const TTL: Duration = Duration::from_secs(24 * 60 * 60);
+const BACKOFF: Duration = Duration::from_secs(5 * 60);
+
+type Cached = Option<(Instant, Result<Location, String>)>;
+pub struct Locator {
+    url: String,
+    // Serializes concurrent windows/popovers so they share one lookup.
+    cached: Mutex<Cached>,
+}
+impl Locator {
+    pub fn new() -> Self {
+        Self {
+            url: std::env::var("OMASTORM_LOCATION_URL").unwrap_or_else(|_| URL.into()),
+            cached: Mutex::new(None),
+        }
+    }
+
+    pub async fn locate(&self) -> Result<Location, String> {
+        let mut cached = self.cached.lock().await;
+        if let Some((until, result)) = &*cached
+            && Instant::now() < *until
+        {
+            return result.clone();
+        }
+        let result = self
+            .fetch()
+            .await
+            .map_err(|_| "IP location unavailable; choose a location with LOCATION.".to_owned());
+        let lifetime = if result.is_ok() { TTL } else { BACKOFF };
+        *cached = Some((Instant::now() + lifetime, result.clone()));
+        result
+    }
+
+    async fn fetch(&self) -> Result<Location, Box<dyn std::error::Error + Send + Sync>> {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .user_agent(concat!(
+                "omastorm/",
+                env!("CARGO_PKG_VERSION"),
+                " (https://omastorm.com)"
+            ))
+            .build()?;
+        let mut response = client.get(&self.url).send().await?.error_for_status()?;
+        let mut body = Vec::new();
+        while let Some(chunk) = response.chunk().await? {
+            if body.len() + chunk.len() > MAX_BODY {
+                return Err("location response too large".into());
+            }
+            body.extend_from_slice(&chunk);
+        }
+        parse(&body).ok_or_else(|| "invalid location response".into())
+    }
+}
+
+#[derive(Deserialize)]
+struct Response {
+    success: bool,
+    #[serde(default)]
+    city: String,
+    #[serde(default)]
+    region: String,
+    latitude: f64,
+    longitude: f64,
+}
+fn parse(bytes: &[u8]) -> Option<Location> {
+    let value: Response = serde_json::from_slice(bytes).ok()?;
+    if !value.success
+        || !value.latitude.is_finite()
+        || !value.longitude.is_finite()
+        || value.latitude.abs() > 90.0
+        || value.longitude.abs() > 180.0
+    {
+        return None;
+    }
+    let name = if value.city.trim().is_empty() {
+        value.region
+    } else {
+        value.city
+    };
+    Some(Location {
+        v: VERSION,
+        name: name.chars().filter(|c| !c.is_control()).take(100).collect(),
+        lat: value.latitude,
+        lon: value.longitude,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_only_successful_numeric_coordinates() {
+        let good = br#"{"success":true,"city":"Stamford","latitude":41.0534,"longitude":-73.5387,"ip":"not retained"}"#;
+        let result = parse(good).unwrap();
+        assert_eq!(result.name, "Stamford");
+        assert_eq!((result.lat, result.lon), (41.0534, -73.5387));
+        assert!(!serde_json::to_string(&result).unwrap().contains("retained"));
+        for bad in [
+            r#"{"success":false,"latitude":0,"longitude":0}"#,
+            r#"{"success":true,"latitude":null,"longitude":0}"#,
+            r#"{"success":true,"latitude":"41","longitude":0}"#,
+            r#"{"success":true,"latitude":91,"longitude":0}"#,
+            r#"{"success":true,"latitude":0,"longitude":181}"#,
+            r#"{"success":true}"#,
+        ] {
+            assert!(parse(bad.as_bytes()).is_none(), "{bad}");
+        }
+    }
+}

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -1,5 +1,6 @@
 mod catalog;
 mod live;
+mod location;
 mod osm;
 mod protocol;
 mod sweep;
@@ -859,8 +860,11 @@ impl Shared {
                 false,
                 Some("Only reflectivity at elevation index 0 is available in this build.".into()),
             ),
-            // Tile requests and place search are answered to the sender, not state.
-            Command::TilesNeeded { .. } | Command::SearchPlaces { .. } | Command::Unsupported => {
+            // Private replies never change shared radar state.
+            Command::LocateHome
+            | Command::TilesNeeded { .. }
+            | Command::SearchPlaces { .. }
+            | Command::Unsupported => {
                 return None;
             }
         };
@@ -1197,6 +1201,7 @@ fn receive(
     shared: &Mutex<Shared>,
     reply: &Sender<String>,
     tiles: &Sender<tiles::Request>,
+    location: &Sender<()>,
     bytes: &[u8],
 ) {
     let value = match serde_json::from_slice::<Value>(bytes) {
@@ -1208,6 +1213,10 @@ fn receive(
         // A command newer than this build; the sender is not told, since
         // ignoring it is the documented answer (docs/protocol.md).
         Ok(Command::Unsupported) => return eprintln!("Ignoring unsupported command: {kind}"),
+        Ok(Command::LocateHome) => {
+            let _ = location.try_send(());
+            return;
+        }
         Ok(Command::TilesNeeded { z, x0, y0, x1, y1 }) => {
             match (tiles::Request { z, x0, y0, x1, y1 }).validate() {
                 // A full request queue means the client is flooding; the
@@ -1273,10 +1282,12 @@ fn client(
     stream: tokio::net::UnixStream,
     shared: Arc<Mutex<Shared>>,
     osm: Arc<osm::Osm>,
+    locator: Arc<location::Locator>,
 ) -> io::Result<()> {
     let (reader, mut writer) = stream.into_split();
     let (tx, mut rx) = mpsc::channel::<String>(QUEUE);
     let (tiles_tx, tiles_rx) = mpsc::channel::<tiles::Request>(8);
+    let (location_tx, mut location_rx) = mpsc::channel::<()>(1);
     let id;
     {
         let mut shared = shared.lock().unwrap();
@@ -1291,6 +1302,22 @@ fn client(
         shared.clients.push((id, tx.clone()));
     }
     tokio::spawn(serve_tiles(shared.clone(), osm, tx.clone(), tiles_rx));
+    let location_reply = tx.clone();
+    tokio::spawn(async move {
+        while location_rx.recv().await.is_some() {
+            let message = match locator.locate().await {
+                Ok(location) => line(&Message::Location(&location)),
+                Err(message) => line(&Message::Error(&Rejection {
+                    v: VERSION,
+                    command: "locate_home",
+                    message: &message,
+                })),
+            };
+            if location_reply.try_send(message).is_err() {
+                break;
+            }
+        }
+    });
     tokio::spawn(async move {
         while let Some(message) = rx.recv().await {
             if !matches!(
@@ -1317,7 +1344,7 @@ fn client(
             {
                 break;
             }
-            receive(&shared, &tx, &tiles_tx, &bytes);
+            receive(&shared, &tx, &tiles_tx, &location_tx, &bytes);
         }
         shared
             .lock()
@@ -1563,6 +1590,7 @@ fn serve(dir: PathBuf) -> io::Result<()> {
     let tile_store = tiles::Store::open(&dir, &build_id()[..8])?;
     // Opens the vector tile cache and builds the HTTP client; fetches nothing.
     let osm = Arc::new(osm::Osm::open()?);
+    let locator = Arc::new(location::Locator::new());
     // The frame ring buffer; live frames are written here as they complete.
     let catalog = Arc::new(catalog::Catalog::open(osm::cache_root()?.join("frames"))?);
     let (events, event_rx) = mpsc::channel(16);
@@ -1632,11 +1660,9 @@ fn serve(dir: PathBuf) -> io::Result<()> {
     });
     runtime.block_on(async {
         loop {
-            match listener
-                .accept()
-                .await
-                .and_then(|(stream, _)| client(stream, shared.clone(), osm.clone()))
-            {
+            match listener.accept().await.and_then(|(stream, _)| {
+                client(stream, shared.clone(), osm.clone(), locator.clone())
+            }) {
                 Ok(()) => {}
                 Err(e) => eprintln!("Client: {e}"),
             }

--- a/engine/src/protocol.rs
+++ b/engine/src/protocol.rs
@@ -18,6 +18,16 @@ pub enum Message<'a> {
     Error(&'a Rejection<'a>),
     TileReady(&'a TileReady<'a>),
     Places(&'a Places<'a>),
+    Location(&'a Location),
+}
+
+/// Approximate IP location answering `locate_home`, only to its requester.
+#[derive(Serialize, Clone, Debug)]
+pub struct Location {
+    pub v: u32,
+    pub name: String,
+    pub lat: f64,
+    pub lon: f64,
 }
 
 /// One tile answering a client's `tiles_needed`, sent to that client alone
@@ -320,6 +330,8 @@ pub struct Geometry {
 #[derive(Deserialize, PartialEq, Debug)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Command {
+    /// Request approximate IP location; never changes the station itself.
+    LocateHome,
     /// Go live on a station from the `hello` table: the newest
     /// cached frame or an empty one shows at once, and the poller follows.
     SelectSite {

--- a/engine/tests/location.rs
+++ b/engine/tests/location.rs
@@ -1,0 +1,170 @@
+use serde_json::{Value, json};
+use std::{
+    fs,
+    io::{BufRead, BufReader, Write},
+    net::TcpListener,
+    os::unix::net::UnixStream,
+    process::{Command, Stdio},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+    thread,
+    time::{Duration, Instant},
+};
+
+// A local HTTP service counts lookups; no external endpoint is used.
+struct Service {
+    url: String,
+    count: Arc<AtomicUsize>,
+    stop: Arc<AtomicBool>,
+    worker: Option<thread::JoinHandle<()>>,
+}
+impl Service {
+    fn start(status: &str, body: &str) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let url = format!("http://{}/", listener.local_addr().unwrap());
+        let count = Arc::new(AtomicUsize::new(0));
+        let stop = Arc::new(AtomicBool::new(false));
+        let (counted, stopped) = (count.clone(), stop.clone());
+        let response = format!(
+            "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        let worker = thread::spawn(move || {
+            while !stopped.load(Ordering::SeqCst) {
+                let Ok((stream, _)) = listener.accept() else {
+                    thread::sleep(Duration::from_millis(5));
+                    continue;
+                };
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(2)))
+                    .unwrap();
+                let mut request = BufReader::new(stream);
+                loop {
+                    let mut line = String::new();
+                    if request.read_line(&mut line).unwrap() == 0 || line == "\r\n" {
+                        break;
+                    }
+                }
+                counted.fetch_add(1, Ordering::SeqCst);
+                request.get_mut().write_all(response.as_bytes()).unwrap();
+            }
+        });
+        Self {
+            url,
+            count,
+            stop,
+            worker: Some(worker),
+        }
+    }
+}
+impl Drop for Service {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        self.worker.take().unwrap().join().unwrap();
+    }
+}
+fn read(client: &mut BufReader<UnixStream>) -> Value {
+    let mut line = String::new();
+    client.read_line(&mut line).unwrap();
+    serde_json::from_str(&line).unwrap()
+}
+fn location_reply(client: &mut BufReader<UnixStream>) -> Value {
+    // State broadcasts can arrive between the command and its private reply.
+    for _ in 0..8 {
+        let reply = read(client);
+        if reply["type"] != "state" {
+            return reply;
+        }
+        assert_eq!(reply["site"]["id"], "", "lookup selected a station");
+    }
+    panic!("location reply not received");
+}
+
+#[test]
+fn location_is_on_demand_shared_cached_and_never_selects_a_station() {
+    for (case, status, body, expected) in [
+        (
+            "success",
+            "200 OK",
+            r#"{"success":true,"city":"Stamford","latitude":41.0534,"longitude":-73.5387}"#,
+            "location",
+        ),
+        ("failure", "503 Unavailable", "unavailable", "error"),
+        ("invalid", "200 OK", r#"{"success":false}"#, "error"),
+    ] {
+        let service = Service::start(status, body);
+        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join(format!("../target/location-{}-{case}", std::process::id()));
+        fs::create_dir_all(&root).unwrap();
+        let binary = env!("CARGO_BIN_EXE_omastorm-engine");
+        let mut daemon = Command::new(binary)
+            .env_remove("OMASTORM_ARCHIVE")
+            .env("XDG_RUNTIME_DIR", &root)
+            .env("XDG_CACHE_HOME", root.join("cache"))
+            .env("OMASTORM_LOCATION_URL", &service.url)
+            .stdout(Stdio::null())
+            .spawn()
+            .unwrap();
+        let socket = root.join("omastorm/engine.sock");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !socket.exists() {
+            assert!(daemon.try_wait().unwrap().is_none());
+            assert!(Instant::now() < deadline);
+            thread::sleep(Duration::from_millis(10));
+        }
+        let connect = || {
+            let stream = UnixStream::connect(&socket).unwrap();
+            stream
+                .set_read_timeout(Some(Duration::from_secs(3)))
+                .unwrap();
+            let mut client = BufReader::new(stream);
+            assert_eq!(read(&mut client)["type"], "hello");
+            let state = read(&mut client);
+            assert_eq!(state["site"]["id"], "");
+            client
+        };
+        let mut first = connect();
+        let mut second = connect();
+        assert_eq!(
+            service.count.load(Ordering::SeqCst),
+            0,
+            "startup performed a lookup"
+        );
+        let command = json!({"type":"locate_home"});
+        writeln!(first.get_mut(), "{command}").unwrap();
+        writeln!(second.get_mut(), "{command}").unwrap();
+        for client in [&mut first, &mut second] {
+            let reply = location_reply(client);
+            assert_eq!(reply["type"], expected, "{reply}");
+            if expected == "location" {
+                assert_eq!(reply["name"], "Stamford");
+                assert_eq!(reply["lat"], 41.0534);
+                assert!(reply.get("ip").is_none());
+            } else {
+                assert_eq!(reply["command"], "locate_home");
+                assert!(reply["message"].as_str().unwrap().contains("LOCATION"));
+            }
+        }
+        writeln!(first.get_mut(), "{command}").unwrap();
+        assert_eq!(location_reply(&mut first)["type"], expected);
+        assert_eq!(
+            service.count.load(Ordering::SeqCst),
+            1,
+            "success/error was not shared and cached"
+        );
+        // A fresh client still sees no selected station: location is a reply,
+        // and does not launch live radar or overwrite a user's selection.
+        drop(connect());
+        let stopped = Command::new(binary)
+            .arg("stop")
+            .env("XDG_RUNTIME_DIR", &root)
+            .status()
+            .unwrap();
+        assert!(stopped.success());
+        daemon.wait().unwrap();
+        fs::remove_dir_all(&root).unwrap();
+    }
+}

--- a/scripts/check-ip-location.sh
+++ b/scripts/check-ip-location.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Exercise the actual shared session and Engine parser with private replies.
+# No network, personal configuration, shell bootstrap, or shared daemon.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+scratch=$(mktemp -d /tmp/omastorm-ip-check.XXXXXX)
+trap 'rm -rf "$scratch"' EXIT
+cp -r ui "$scratch/ui"
+sed -i '/Quickshell.execDetached(/c\        return;' "$scratch/ui/PluginSession.qml"
+sed -i 's/connected: true/connected: false/; /running: engine.socket/c\        running: false' "$scratch/ui/Engine.qml"
+cat > "$scratch/ui/Test.qml" <<'QML'
+import QtQuick
+import Quickshell
+import "Location.js" as Location
+ShellRoot {
+    id: test
+    Engine {
+        id: fake
+        property var sent: []
+        function send(command) { sent = sent.concat([command]); }
+    }
+    function assertThat(ok, why) { if (!ok) throw new Error(why); }
+    function fresh(values, saved, weather, source) {
+        var s = PluginSession;
+        fake.state = null;
+        fake.location = null;
+        fake.locationRequested = false;
+        fake.locationPending = false;
+        fake.locationError = "";
+        fake.locationTimeout.stop();
+        s.initialized = false;
+        s.hasView = false;
+        s.needsLocation = false;
+        s.ipLocationDismissed = false;
+        s.appliedExplicit = null;
+        s.config.values = values;
+        s.remembered.parsed = Location.parseState(saved);
+        s.config.location = weather;
+        fake.sent = [];
+        fake.state = {source: source || "live", site: {id: "", locked: false, follow: true}};
+        s.initialize();
+    }
+    function countLookups() { return fake.sent.filter(c => c.type === "locate_home").length; }
+    function reply() { fake.receive(JSON.stringify({type:"location", v:1, name:"Stamford", lat:41.05, lon:-73.54})); }
+    Timer {
+        interval: 10; running: true; repeat: true
+        onTriggered: {
+            var s = PluginSession;
+            if (!s.ready) return;
+            stop();
+            try {
+                s.engine = fake;
+                fresh({ip_location:true}, "", null);
+                assertThat(s.locating && s.needsLocation && countLookups() === 1, "fresh lookup");
+                s.resolve();
+                assertThat(countLookups() === 1, "duplicate lookup");
+                reply();
+                assertThat(s.hasView && !s.needsLocation && s.locationSource === "ip", "IP view");
+                assertThat(s.centerLat === 41.05 && s.centerLon === -73.54, "IP coordinates");
+                assertThat(s.remembered.lat === 41.05 && s.remembered.lon === -73.54, "remember IP view");
+                assertThat(fake.sent.some(c => c.type === "view_center" && c.lat === 41.05), "nearest radar follows IP center");
+                fresh({ip_location:true}, JSON.stringify(s.remembered.parsed), null);
+                assertThat(s.locationSource === "state" && countLookups() === 0, "reopen remembered IP without lookup");
+                fresh({ip_location:true, center_lat:30, center_lon:-81}, '{"lat":35,"lon":-97}', {lat:36,lon:-79});
+                reply();
+                assertThat(s.locationSource === "config" && s.centerLat === 30 && countLookups() === 0, "explicit precedence");
+                fresh({ip_location:true}, '{"lat":35,"lon":-97}', {lat:36,lon:-79});
+                reply();
+                assertThat(s.locationSource === "state" && s.centerLat === 35 && countLookups() === 0, "state precedence");
+                fresh({ip_location:true}, "", {lat:36,lon:-79});
+                reply();
+                assertThat(s.locationSource === "weather" && s.centerLat === 36 && countLookups() === 0, "weather precedence");
+                fresh({ip_location:true, locked_radar:"KTLX"}, "", null);
+                reply();
+                assertThat(s.lockId === "KTLX" && s.lockWanted && s.centerLat === 41.05, "configured lock independent of IP center");
+                fresh({ip_location:true}, "", null);
+                s.setPlace(30,-81,"Picked"); reply();
+                assertThat(s.centerLat === 30 && s.placeName === "Picked", "late reply after picker choice");
+                fresh({ip_location:true}, "", null);
+                s.chooseRadar("KTLX",35,-97,"Radar"); reply();
+                assertThat(s.centerLat === 35 && s.lockId === "KTLX", "late reply after radar choice");
+                fresh({ip_location:true}, "", null);
+                s.userNavigated(36,-98,170); reply();
+                assertThat(s.centerLat === 36 && s.span === 170 && !s.needsLocation, "late reply after navigation");
+                fresh({ip_location:true}, "", null);
+                s.requestLocationPicker(); reply();
+                assertThat(s.needsLocation && !s.hasView && !s.locating, "manual picker interrupts lookup");
+                fresh({ip_location:true}, "", null);
+                fake.receive('{"type":"error","v":1,"command":"locate_home","message":"unavailable"}');
+                assertThat(s.needsLocation && !s.locating, "failure leaves onboarding available");
+                fresh({ip_location:false}, "", null); reply();
+                assertThat(s.needsLocation && countLookups() === 0, "opt out");
+                fresh({}, "", null);
+                assertThat(s.needsLocation && countLookups() === 0, "isolated config does not opt in");
+                fresh({ip_location:true}, "", null, "archived"); reply();
+                assertThat(s.needsLocation && countLookups() === 0, "archive never locates");
+                assertThat(s.config.parseLocation('{"latitude":null,"longitude":null}') === null, "null weather is not zero");
+                assertThat(Location.configErrors({ip_location:"yes"}).length === 1, "invalid preference is named");
+                fresh({ip_location:true}, "", null);
+                fake.locationTimeout.interval = 1;
+                timeoutCheck.start();
+            } catch (e) { console.error(e); Qt.quit(); }
+        }
+    }
+    Timer {
+        id: timeoutCheck; interval: 30
+        onTriggered: {
+            if (PluginSession.needsLocation && !PluginSession.locating && fake.locationError)
+                console.log("IP_LOCATION_PASSED");
+            else console.error("old-engine timeout did not restore onboarding");
+            Qt.quit();
+        }
+    }
+}
+QML
+OMASTORM_CONFIG="$scratch/empty.toml" OMASTORM_STATE="$scratch/state.json" \
+  XDG_RUNTIME_DIR="$scratch/runtime" QT_QPA_PLATFORM=offscreen \
+  timeout 15 quickshell -p "$scratch/ui/Test.qml" > "$scratch/log" 2>&1 || { cat "$scratch/log"; exit 1; }
+cat "$scratch/log"
+rg -q IP_LOCATION_PASSED "$scratch/log"
+! rg -q 'ReferenceError|TypeError|Binding loop|Unable to assign' "$scratch/log"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -94,7 +94,7 @@ if step build bash scripts/cargo.sh test --offline --locked --no-run; then
   tests & lanes+=($!)
   # check-picker and check-keys select stations for real, so they run last.
   lane window check-engine-ui check-map-sites check-map-network check-location check-picker check-keys & lanes+=($!)
-  lane alone check-bind check-link-plugin check-launcher check-theme check-map-tiles test-engine-pin check-engine-release check-popover & lanes+=($!)
+  lane alone check-ip-location check-bind check-link-plugin check-launcher check-theme check-map-tiles test-engine-pin check-engine-release check-popover & lanes+=($!)
   for pid in "${lanes[@]}"; do wait "$pid" || failed=1; done
   lanes=()
 else

--- a/scripts/test-engine-pin.sh
+++ b/scripts/test-engine-pin.sh
@@ -50,6 +50,9 @@ asset_$other=omastorm-engine-$other-unknown-linux-gnu
 sha256_$other=$other_sum
 PIN
 export OMASTORM_ENGINE_PIN=$pin
+# The installer is still x86-only on this independent feature branch. Its
+# fixtures exercise selection/hash handling using the native debug binary.
+export OMASTORM_ENGINE_MACHINE=x86_64
 dest=$XDG_DATA_HOME/omastorm/bin/omastorm-engine
 install_cmd=(bash scripts/fetch-engine.sh)
 

--- a/scripts/test-engine-pin.sh
+++ b/scripts/test-engine-pin.sh
@@ -50,9 +50,6 @@ asset_$other=omastorm-engine-$other-unknown-linux-gnu
 sha256_$other=$other_sum
 PIN
 export OMASTORM_ENGINE_PIN=$pin
-# The installer is still x86-only on this independent feature branch. Its
-# fixtures exercise selection/hash handling using the native debug binary.
-export OMASTORM_ENGINE_MACHINE=x86_64
 dest=$XDG_DATA_HOME/omastorm/bin/omastorm-engine
 install_cmd=(bash scripts/fetch-engine.sh)
 

--- a/ui/Config.qml
+++ b/ui/Config.qml
@@ -27,6 +27,9 @@ QtObject {
     readonly property var centerLat: typeof values.center_lat === "number" ? values.center_lat : undefined
     readonly property var centerLon: typeof values.center_lon === "number" ? values.center_lon : undefined
     readonly property string lockedRadar: typeof values.locked_radar === "string" ? values.locked_radar.trim().toUpperCase() : ""
+    // Isolated checks/captures must explicitly opt in to network location.
+    readonly property bool ipLocationEnabled: values.ip_location === true
+        || (values.ip_location === undefined && !Quickshell.env("OMASTORM_CONFIG"))
     // The raw value; the window judges it against the three treatments.
     readonly property var treatment: values.treatment
     // The raw value; the window judges it: a dBZ number, false, or unset.
@@ -59,7 +62,8 @@ QtObject {
     function parseLocation(raw) {
         try {
             var json = JSON.parse(raw);
-            var lat = Number(json.latitude), lon = Number(json.longitude);
+            var lat = json.latitude, lon = json.longitude;
+            if (typeof lat !== "number" || typeof lon !== "number") return null;
             if (!isFinite(lat) || !isFinite(lon) || Math.abs(lat) > 90 || Math.abs(lon) > 180) return null;
             return { name: typeof json.name === "string" ? json.name : "", lat: lat, lon: lon };
         } catch (e) { return null; }

--- a/ui/Engine.qml
+++ b/ui/Engine.qml
@@ -6,6 +6,10 @@ QtObject {
     id: engine
     property var state: null
     property var sites: []
+    property var location: null
+    property bool locationRequested: false
+    property bool locationPending: false
+    property string locationError: ""
     /// Transport and parsing trouble: disconnected, unreadable message,
     /// unknown protocol version. Cleared by the next valid state.
     property string error: ""
@@ -56,7 +60,12 @@ QtObject {
                 socket.connected = false;
                 return;
             }
-            if (message.type === "hello") sites = message.sites;
+            if (message.type === "hello") {
+                sites = message.sites;
+                locationRequested = false;
+                location = null;
+                locationError = "";
+            }
             else if (message.type === "state") {
                 if (!message.frame || !validTexturePath(message.frame.texture))
                     throw new Error("Invalid texture path: " + JSON.stringify(message.frame.texture));
@@ -64,6 +73,18 @@ QtObject {
                     throw new Error("Invalid azimuth lookup path: " + JSON.stringify(message.frame.azimuthLut));
                 state = message;
                 error = "";
+            } else if (message.type === "location") {
+                if (typeof message.lat !== "number" || typeof message.lon !== "number"
+                    || !isFinite(message.lat) || !isFinite(message.lon)
+                    || Math.abs(message.lat) > 90 || Math.abs(message.lon) > 180)
+                    throw new Error("Invalid location coordinates");
+                location = {name: typeof message.name === "string" ? message.name : "", lat: message.lat, lon: message.lon};
+                locationPending = false;
+                locationTimeout.stop();
+            } else if (message.type === "error" && message.command === "locate_home") {
+                locationError = message.message;
+                locationPending = false;
+                locationTimeout.stop();
             } else if (message.type === "error") rejection = message.message;
             else if (message.type === "tile_ready") {
                 if (!validTilePath(message.path))
@@ -78,6 +99,21 @@ QtObject {
         if (command.type !== "tiles_needed" && command.type !== "search_places") rejection = "";
         socket.write(JSON.stringify(command) + "\n");
     }
+    function locateHome() {
+        if (locationRequested || !state || state.source !== "live") return;
+        locationRequested = true;
+        locationPending = true;
+        locationTimeout.restart();
+        send({type: "locate_home"});
+    }
+    // Older engines ignore unknown commands. Leave onboarding usable then too.
+    property Timer locationTimeout: Timer {
+        interval: 12000
+        onTriggered: {
+            engine.locationError = "IP location unavailable; choose a location.";
+            engine.locationPending = false;
+        }
+    }
     property var socket: socketFactory.createObject(engine)
     property Component socketFactory: Component {
         Socket {
@@ -86,6 +122,8 @@ QtObject {
             parser: SplitParser { onRead: data => engine.receive(data) }
             onConnectedChanged: {
                 if (!connected && !engine.incompatible) {
+                    engine.locationPending = false;
+                    engine.locationTimeout.stop();
                     engine.state = null;
                     engine.error = "Radar engine disconnected. Reconnecting…";
                 }

--- a/ui/Location.js
+++ b/ui/Location.js
@@ -85,6 +85,8 @@ function configLock(values) {
 function configErrors(values) {
     var errors = [];
     if (!values) return errors;
+    if (values.ip_location !== undefined && typeof values.ip_location !== "boolean")
+        errors.push("ip_location must be true or false");
     var hasLat = values.center_lat !== undefined, hasLon = values.center_lon !== undefined;
     if (hasLat !== hasLon)
         errors.push("center_lat and center_lon must both be set");

--- a/ui/PluginSession.qml
+++ b/ui/PluginSession.qml
@@ -27,6 +27,9 @@ QtObject {
     property bool needsLocation: false
     property string placeName: ""
     property string locationSource: ""
+    property bool ipLocationDismissed: false
+    readonly property bool locating: needsLocation && config.ipLocationEnabled
+        && !ipLocationDismissed && engine.locationPending
     property real centerLat: 0
     property real centerLon: 0
     property real span: Location.DEFAULT_SPAN
@@ -40,8 +43,51 @@ QtObject {
     signal locationPickerRequested()
 
     function requestLocationPicker() {
+        cancelIpLocation();
         pendingLocationPicker = true;
         locationPickerRequested();
+    }
+
+    function cancelIpLocation() { ipLocationDismissed = true; }
+
+    function userNavigated(lat, lon, spanKm) {
+        if (!Location.validPair(lat, lon)) return;
+        if (needsLocation) {
+            centerLat = lat;
+            centerLon = lon;
+            span = Location.clampSpan(spanKm);
+            locationSource = "state";
+            hasView = true;
+            needsLocation = false;
+            persist();
+            applyRadar();
+        }
+        cancelIpLocation();
+    }
+
+    function tryIpLocation() {
+        if (!initialized || !ready || hasView || !needsLocation
+            || !config.ipLocationEnabled || ipLocationDismissed) return;
+        engine.locateHome();
+    }
+
+    function acceptIpLocation() {
+        if (!ready || hasView || !config.ipLocationEnabled || ipLocationDismissed
+            || !engine.state || engine.state.source !== "live" || !engine.location) return;
+        // Recheck sources that may have arrived while the lookup was pending.
+        resolve();
+        if (hasView) return;
+        var place = engine.location;
+        centerLat = place.lat;
+        centerLon = place.lon;
+        placeName = place.name || "";
+        locationSource = "ip";
+        span = Location.clampSpan(remembered.span);
+        hasView = true;
+        needsLocation = false;
+        persist();
+        viewChanged();
+        applyRadar();
     }
 
     function resolve() {
@@ -80,6 +126,7 @@ QtObject {
             appliedExplicit = null;
         }
         applyConfigLockChange();
+        tryIpLocation();
         viewChanged();
     }
 
@@ -142,6 +189,7 @@ QtObject {
 
     function setPlace(lat, lon, name) {
         if (!Location.validPair(lat, lon)) return;
+        cancelIpLocation();
         placeName = name || "";
         locationSource = "state";
         needsLocation = false;
@@ -187,6 +235,7 @@ QtObject {
         lat = Number(lat);
         lon = Number(lon);
         if (!id || !Location.validPair(lat, lon)) return;
+        cancelIpLocation();
         placeName = name || id;
         locationSource = "state";
         needsLocation = false;
@@ -258,8 +307,10 @@ QtObject {
     }
 
     property Timer persistTimer: Timer { interval: 400; onTriggered: session.persist() }
+    onLocatingChanged: viewChanged()
     property Connections engineEvents: Connections {
         target: session.engine
+        function onLocationChanged() { session.acceptIpLocation(); }
         function onStateChanged() {
             if (!session.engine.state) session.initialized = false;
             else { session.startupError = ""; session.initialize(); }

--- a/ui/Popover.qml
+++ b/ui/Popover.qml
@@ -125,6 +125,7 @@ FocusScope {
                 weakFloor: card.session.weakFloor
                 labelSize: 10
                 radarOpacity: card.condition === "unavailable" ? .6 : 1
+                onNavigated: (lat, lon, spanKm) => card.session.userNavigated(lat, lon, spanKm)
                 onTilesNeeded: (z, x0, y0, x1, y1) => connection.send({type: "tiles_needed", z: z, x0: x0, y0: y0, x1: x1, y1: y1})
                 function applyView() {
                     if (!card.session.hasView) return;
@@ -185,7 +186,7 @@ FocusScope {
                     anchors.centerIn: parent
                     width: parent.width - 32
                     spacing: 10
-                    Label { Layout.fillWidth: true; horizontalAlignment: Text.AlignHCenter; text: "CHOOSE A LOCATION"; font.bold: true; font.pixelSize: 13 }
+                    Label { Layout.fillWidth: true; horizontalAlignment: Text.AlignHCenter; text: card.session.locating ? "FINDING A NEARBY LOCATION" : "CHOOSE A LOCATION"; font.bold: true; font.pixelSize: 13 }
                     Label { Layout.fillWidth: true; horizontalAlignment: Text.AlignHCenter; wrapMode: Text.Wrap; opacity: .7; font.pixelSize: 11
                         text: "Search a town of 5,000+ people, or enter latitude and longitude in the window." }
                     Control { Layout.alignment: Qt.AlignHCenter; text: "CHOOSE A LOCATION"; onClicked: { card.session.requestLocationPicker(); card.expandRequested(); } }

--- a/ui/RadarMap.qml
+++ b/ui/RadarMap.qml
@@ -84,7 +84,11 @@ Item {
     readonly property real viewCenterX: Math.max(width/2*unitsPerPixel, Math.min(1-width/2*unitsPerPixel, wantedX))
     readonly property real viewCenterY: Math.max(height/2*unitsPerPixel, Math.min(1-height/2*unitsPerPixel, wantedY))
     function reset() { center = null; span = Math.min(210, maxSpan); }
-    function zoom(value) { span = Math.max(25, Math.min(maxSpan, value)); }
+    signal navigated(real lat, real lon, real spanKm)
+    function zoom(value, notify) {
+        span = Math.max(25, Math.min(maxSpan, value));
+        if (notify !== false) navigated(centerLat, centerLon, span);
+    }
     function look(mx, my) { center = Qt.point(longitude(mx), latitude(my)); }
     // Centre exactly on a place. Loading frames and radar hand-offs must
     // not call this; the camera is the user's (DESIGN.md, location).
@@ -99,6 +103,7 @@ Item {
     function pan(dx, dy) {
         var stepPixels = Math.max(1, Math.round(Math.min(width, height) / 8)) * unitsPerPixel;
         look(viewCenterX + dx * stepPixels, viewCenterY + dy * stepPixels);
+        navigated(centerLat, centerLon, span);
     }
     readonly property real centerLat: latitude(viewCenterY)
     readonly property real centerLon: longitude(viewCenterX)
@@ -633,14 +638,19 @@ Item {
         property real lastY
         onPressed: mouse => { lastX=mouse.x; lastY=mouse.y; }
         onPositionChanged: mouse => {
-            if(pressed) { map.look(map.viewCenterX - (mouse.x-lastX)*map.unitsPerPixel, map.viewCenterY - (mouse.y-lastY)*map.unitsPerPixel); lastX=mouse.x; lastY=mouse.y; }
+            if(pressed && (mouse.x !== lastX || mouse.y !== lastY)) {
+                map.look(map.viewCenterX - (mouse.x-lastX)*map.unitsPerPixel, map.viewCenterY - (mouse.y-lastY)*map.unitsPerPixel);
+                lastX=mouse.x; lastY=mouse.y;
+                map.navigated(map.centerLat, map.centerLon, map.span);
+            }
         }
         onWheel: wheel => {
             // Zoom about the pointer: the ground under it stays put.
             var mx=map.viewCenterX+(wheel.x-width/2)*map.unitsPerPixel;
             var my=map.viewCenterY+(wheel.y-height/2)*map.unitsPerPixel;
-            map.zoom(Math.min(map.span,map.maxSpan)*(wheel.angleDelta.y>0?.85:1/.85));
+            map.zoom(Math.min(map.span,map.maxSpan)*(wheel.angleDelta.y>0?.85:1/.85), false);
             map.look(mx-(wheel.x-width/2)*map.unitsPerPixel, my-(wheel.y-height/2)*map.unitsPerPixel);
+            map.navigated(map.centerLat, map.centerLon, map.span);
         }
         onDoubleClicked: map.resetRequested()
     }

--- a/ui/RadarWindow.qml
+++ b/ui/RadarWindow.qml
@@ -19,7 +19,8 @@ Item {
         opened = true;
         if (session) session.windowOpen = true;
         applyView();
-        if (store.needsLocation || store.pendingLocationPicker) Qt.callLater(() => locationPicker.show(""));
+        if (store.pendingLocationPicker) Qt.callLater(() => locationPicker.show(""));
+        else maybeOfferLocation();
     }
     function close() {
         if (!opened) return;
@@ -174,9 +175,9 @@ Item {
         }
     }
     function maybeOfferLocation() {
-        if (!opened || !store.needsLocation || locationPicker.open) return;
+        if (!opened || !store.initialized || !store.needsLocation || store.locating || locationPicker.open) return;
         Qt.callLater(() => {
-            if (app.opened && app.store.needsLocation && !locationPicker.open) locationPicker.show("");
+            if (app.opened && app.store.initialized && app.store.needsLocation && !app.store.locating && !locationPicker.open) locationPicker.show("");
         });
     }
     Connections {
@@ -254,7 +255,7 @@ Item {
         function status(): string {
             return JSON.stringify({sheet: sheet.open, menu: treatmentMenu.opened, treatment: app.treatment, weakFloor: app.weakFloor === null ? "off" : app.weakFloor, error: app.configError,
                                    span: Math.round(map.span * 10) / 10, lat: Math.round(map.centerLat * 1000) / 1000, lon: Math.round(map.centerLon * 1000) / 1000,
-                                   locationSource: app.store.locationSource, needsLocation: app.store.needsLocation,
+                                   locationSource: app.store.locationSource, needsLocation: app.store.needsLocation, locating: app.store.locating,
                                    site: app.siteId, locked: app.locked, lockSource: app.store.lockSource, outsideCoverage: app.outsideCoverage});
         }
     }
@@ -281,7 +282,12 @@ Item {
         if (mockGps && mockGps !== "paused") return "GPS";
         var t = app.resetTarget;
         if (t && Location.distanceKm(map.centerLat, map.centerLon, t.lat, t.lon) < 2) return (t.name || "OMARCHY'S LOCATION").toUpperCase();
-        if (app.store.placeName && Location.distanceKm(map.centerLat, map.centerLon, app.store.centerLat, app.store.centerLon) < 2) return app.store.placeName.toUpperCase();
+        if (app.store.placeName && Location.distanceKm(map.centerLat, map.centerLon, app.store.centerLat, app.store.centerLon) < 2) {
+            var name = app.store.placeName.toUpperCase();
+            return app.store.locationSource === "ip" ? "IP NEAR " + name : name;
+        }
+        if (app.store.locationSource === "ip" && Location.distanceKm(map.centerLat, map.centerLon, app.store.centerLat, app.store.centerLon) < 2)
+            return "IP NEAR YOU";
         var lat = map.centerLat, lon = map.centerLon;
         return Math.abs(lat).toFixed(2) + "° " + (lat < 0 ? "S" : "N") + "  " + Math.abs(lon).toFixed(2) + "° " + (lon < 0 ? "W" : "E");
     }
@@ -656,6 +662,7 @@ Item {
                     radarOpacity: app.condition === "unavailable" ? .6 : 1
                     labelSize: win.compact ? 10 : 12
                     locked: app.locked
+                    onNavigated: (lat, lon, spanKm) => app.store.userNavigated(lat, lon, spanKm)
                     // A settled pan hands the centre to the engine, which switches
                     // station while following and unlocked; the camera stays.
                     onViewSettled: (lat, lon) => {
@@ -1014,6 +1021,7 @@ Item {
           }
           LocationPicker {
             id: locationPicker
+            onOpenChanged: if (open) app.store.cancelIpLocation()
             anchors.fill: parent
             theme: app.theme
             engine: engine


### PR DESCRIPTION
When explicit coordinates, a remembered view, and Omarchy weather coordinates are all absent, use approximate IP location to open near the user. On the test machine, a fresh live launch centered near Stamford and selected KOKX automatically. The new location picker and remembered-camera behavior remain available.

ARM packaging/CI is separate in #30. Rebased onto current main (`f77f715`).

The shared session resolves location in this order: explicit center, remembered center, weather, optional IP fallback, then the existing picker. A successful IP view is remembered normally, so reopening restores it without another lookup. Radar locks remain independent of the map center. The initial view is labeled `IP NEAR …`; LOCATION lets the user choose another place.

`ip_location = false` disables the fallback. Lookup happens through the running engine after bootstrap, not in the launcher. The engine uses HTTPS to ipwho.is with a ten-second timeout, a 16 KiB response limit, and an in-memory cache shared by clients (24 hours for success, five minutes for failure). The provider receives the connection's public IP; engine replies contain only city and coordinates. The lookup itself never selects a station or writes state; the UI applies and remembers the view.

Opening the picker, selecting a place/radar, or panning/zooming wins over a late reply. Failures and older engines leave onboarding usable. Archived sessions never locate, and isolated check configurations must explicitly opt in. Disabling lookup does not erase an already remembered view.

The rebase preserves upstream’s slow-hello handling and removes the now-redundant readiness timeout handling. Both PRs retain the delayed-hello regression and retry a launcher child that lost its lock to a stale daemon.

Validation:

- [Native x86_64 and aarch64 CI](https://github.com/scottjones/omastorm/actions/runs/34381151708) passes for exact PR commit `2f80244`: lint, engine/protocol tests, installer checks, optimized builds, and real version/protocol handshakes. This temporary verification workflow stays outside the feature PR.
- Full `mise check --gpu` and ShellCheck pass on native aarch64.
- Local HTTP protocol tests cover on-demand lookup, concurrent caching, failures, and unchanged radar state. QML checks cover precedence, remembered state, independent locks, manual choices, opt-out, archive isolation, invalid weather coordinates, and old-engine timeout.
- End-to-end window tests confirm automatic KOKX selection, manual location/pan preservation across delayed replies, and successful lookup through the real provider.
- Capture review passes across window sizes, all three treatments, and a theme change; live and interaction captures were inspected.

Fresh-checkout validation includes the same reviewed GeoNames snapshot and shared test-harness fixes as #30. The unchanged upstream x86-only installer is tested with native fixture bytes on ARM; execution of its published x86 binary is limited to x86 hosts. This branch does not include ARM installer or release-workflow changes.

Ubuntu CI verifies the unchanged published x86 asset's download and checksum but explicitly omits running it: that Arch-built binary requires glibc 2.44. Newly built native binaries are executed on both runners; ordinary desktop checks still run the pinned release.

**Release prerequisite:** following the release policy on main, keep this combined engine/UI change open until an engine containing `locate_home` is published; land the verified pin and UI together. An older engine falls back to the location picker. No unpublished binary is pinned here.
