### PR TITLE
Add GitHub release notes configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - question
+      - wontfix
+  categories:
+    - title: Fixes
+      labels:
+        - bug
+    - title: Features
+      labels:
+        - enhancement
+    - title: Accessibility
+      labels:
+        - accessibility
+    - title: Docs
+      labels:
+        - documentation
+    - title: Other changes
+      labels:
+        - "*"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -40,7 +40,11 @@ published asset is wrong, leave the pin unchanged and release a new version.
    [CONTRIBUTING.md](../CONTRIBUTING.md#verify-and-submit). Commit and push
    the release changes to `main`.
 3. Tag that same commit `v<version>` and push the tag. Create a draft GitHub
-   Release for it with user-facing notes. Attach any new
+   Release for it with user-facing notes. Generate release notes against the
+   previous `v*` tag, never an `engine-*` tag (engine releases compare only
+   against the previous `engine-*` tag). GitHub groups pull requests by label
+   per [.github/release.yml](../.github/release.yml); unlabeled ones land under
+   Other changes, and GitHub adds New Contributors itself. Attach any new
    [README media](media/README.md) before publishing; keep media out of git.
 4. Publish the draft. Keep README media URLs pointed at releases containing
    those assets; older demo assets can stay linked.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `.github/release.yml` so GitHub's **Generate release notes** groups pull requests by label:

- Fixes (`bug`), Features (`enhancement`), Accessibility (`accessibility`), Docs (`documentation`)
- Other changes (`*`) catches unlabeled pull requests
- `duplicate`, `invalid`, `question`, and `wontfix` are excluded

The content is the file agreed with Wesley, verbatim. The New Contributors section is GitHub's own and is intentionally not duplicated in the yml. No new labels, `CONTRIBUTORS.md`, or all-contributors tooling.

`docs/RELEASING.md` gains one note under the Plugin steps: generate notes against the previous `v*` tag rather than an `engine-*` tag (engine releases compare only against the previous `engine-*` tag, which `scripts/release-engine.sh` already does), point at the config, and state that unlabeled PRs land under Other changes and New Contributors comes from GitHub.

## Verification

- `.github/release.yml` diffed byte-for-byte against the agreed content and parsed as YAML.
- Doc lines stay within the file's existing 80-column wrap.
- No product code changed; `mise check` (which builds the engine and needs the desktop toolchain) was not run for this docs/config-only change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bcca875-46c8-4d29-b942-1b2b98d1e048?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bcca875-46c8-4d29-b942-1b2b98d1e048&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

