### PR TITLE
Document the four release paths in RELEASING.md

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -9,6 +9,33 @@ Published releases are immutable. Prepare assets in a draft; a mistake after
 publication requires a new version. Never pin an unpublished or unverified
 binary.
 
+## Release paths
+
+Users run `main`: a merged change reaches them on their next plugin update. A
+`v*` tag is the thank-you note for that work, not the thing users wait for.
+The engine they run is whatever `engine/release.pin` names. A maintainer
+decides when an engine release happens; nothing here publishes one on its own.
+Every change takes one of four paths.
+
+Plugin or UI only (QML, copy, docs, README): merge anytime. No engine release.
+Honor the work later with a `v*` tag; generate its notes as Plugin step 3
+describes, from the previous `v*` tag and never an `engine-*` tag.
+
+Engine only: the code may merge to `main`, but users keep the pinned binary
+until a maintainer runs `mise release` and the pin commit lands. Batch engine
+releases; do not release on every merge. Credit the engine author in the
+release notes, which the script generates from commit subjects alone.
+
+Plugin and engine together in one PR: do not merge while the UI needs a
+protocol or feature the published pin does not speak. `mise check` builds the
+PR's own engine, so a green check proves nothing about the pin. Leave the PR
+open until the engine binary is published, then land the pin and the UI in
+the same push so an update never puts the UI ahead of the binary.
+
+Split PRs: merge the engine PR first; the plugin on `main` must still speak
+the current pin. Publish the engine and land the pin. Then merge the UI PR.
+Never merge the UI first.
+
 ## Engine
 
 Use a configured checkout with GitHub CLI authentication and release access.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a "Release paths" section to `docs/RELEASING.md`, between the existing setup paragraphs and the Engine steps, so a contributor can tell which path a change is on and what not to merge:

- `main` is what users get; a `v*` tag is the thank-you note; the engine users run is whatever `engine/release.pin` names; a maintainer decides when an engine release happens.
- Plugin/UI only: merge anytime, no engine release, honor later with a `v*` tag (points at Plugin step 3 for the tag-comparison rule from #34 rather than repeating it).
- Engine only: may merge, but users keep the pinned binary until `mise release` and the pin commit land; batch releases; credit the engine author.
- Plugin and engine in one PR: do not merge while the UI needs something the published pin does not speak; `mise check` builds the PR's own engine, so green is not proof; land pin and UI in the same push.
- Split PRs: engine PR first, publish and pin, then the UI PR; never the UI first.

The Engine and Plugin step lists are unchanged. Only `docs/RELEASING.md` is touched; the `CONTRIBUTING.md` cross-link still reads correctly. All lines wrap at 80 columns.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5038028a-628c-4e80-95c6-a141a682af87?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5038028a-628c-4e80-95c6-a141a682af87&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

