### PR TITLE
Document the first-time contributor path

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -18,3 +18,6 @@ labels: bug
 **Engine log**
 
 The last lines of `$XDG_RUNTIME_DIR/omastorm/engine.log`, if the engine is involved.
+
+Setup, logs, and how to file a useful report:
+[CONTRIBUTING.md](../../CONTRIBUTING.md#issues).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,4 +114,4 @@ Maintainers: [docs/RELEASING.md](docs/RELEASING.md).
 
 ## Conduct
 
-There is no code of conduct file yet.
+Be kind and treat people well.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,24 @@
 # Contributing
 
 Report bugs and propose work in [GitHub issues](https://github.com/wesleygrimes/omastorm/issues).
-Include reproduction steps, expected behavior, and the logs described in the
-[README](README.md#troubleshooting). Track pending work in issues and projects;
-discuss new features there before implementation.
+Track pending work in issues and projects; discuss new features there before
+implementation.
+
+## Issues
+
+For a bug, use the
+[bug report template](https://github.com/wesleygrimes/omastorm/issues/new?template=bug-report.md).
+Say what happened, what you expected, and your Omarchy version, plugin commit,
+engine, and GPU as the template asks.
+
+`$XDG_RUNTIME_DIR/omastorm/engine.log` is the daemon's stderr: startup,
+`Live {site}: …` feed lines, decode and tile errors. Attach the last screenful
+covering the failure, not a single line. If the engine never installed, attach
+`bootstrap.log` from the same directory too. Paths are in the
+[README](README.md#troubleshooting).
+
+For a feature, open an issue first: what should change on screen, why it belongs
+in this app, and how it fits [DESIGN.md](DESIGN.md). Keep the feature set small.
 
 ## Develop
 
@@ -55,14 +70,30 @@ files apply. `mise restart` stops the daemon first so a check or capture
 leftover is not reused. `mise onboard` starts the window with no weather file
 and no remembered view, so the location picker shows.
 
+## What not to change
+
+Do not bump [engine/release.pin](engine/release.pin) until the named GitHub
+Release exists and its asset is verified. [docs/RELEASING.md](docs/RELEASING.md)
+is the sequence.
+
+[golden/](golden/) is the decoder's answer key. Regenerating it is a
+decoder-contract change: keep the provenance and dates in the JSON, and do not
+rewrite it to match a new decode by accident. Capture scripts write images
+under `review/` for visual review; those stay out of git. Regenerate them when
+the picture changed, and include the captures with the review.
+
+Honor [DESIGN.md](DESIGN.md): actual scan times, no forecasts, chrome from the
+Omarchy theme, radar color only from `frame.palette`.
+
 ## Verify and submit
 
-Keep each change scoped to one issue. Run `mise check` before every commit;
-it uses scratch daemons and leaves the shared daemon alone. Cargo runs
+Branch from `main`. One change per pull request. Run `mise check` before every
+commit; it uses scratch daemons and leaves the shared daemon alone. Cargo runs
 first, then the Rust tests run alongside the UI checks, which proceed in two
 lanes. Scratch and logs live under `target/check/`, never `/tmp`; the daemons
 and runtime files go on every exit, and the logs stay until the next run.
-The checks read `target/debug/`, so leave `CARGO_TARGET_DIR` unset.
+The checks read `target/debug/`, so leave `CARGO_TARGET_DIR` unset. There is no
+GitHub Actions suite yet; a pull request is ready when those local checks pass.
 
 For shader, sampling, or camera changes, also run `mise check --gpu` and
 `bash scripts/capture-review.sh`, inspect the images in `review/`, and include
@@ -72,9 +103,15 @@ tile shaders with `bash scripts/build-shader.sh` and commit their `.qsb` files.
 The GPU checks need a desktop OpenGL context; software Qt Quick is unsupported.
 If the environment cannot run a required check, report that explicitly.
 
-Open a pull request linking the issue, explaining the resulting behavior and
-why it changed, and noting verification. Keep commits small, with a body that
-explains why; omit co-author and tool trailers. Update the relevant docs when
-behavior changes. Document current behavior, not implementation history.
+Open a pull request linking the issue. Subject is a short imperative; the body
+says why the behavior changed and how you verified it. Keep commits small.
+Omit co-author and tool trailers. Update the relevant docs when behavior
+changes. Document current behavior, not implementation history.
 
-Maintainers: [release instructions](docs/RELEASING.md).
+## Releases
+
+Maintainers: [docs/RELEASING.md](docs/RELEASING.md).
+
+## Conduct
+
+There is no code of conduct file yet.

--- a/README.md
+++ b/README.md
@@ -189,8 +189,24 @@ Code: MIT, see [LICENSE](LICENSE).
 
 ## Contributing
 
-Start with [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, checks, and the
-pull request workflow. [DESIGN.md](DESIGN.md) defines the app's visual and
-interaction rules; the [engine guide](engine/README.md) and
-[wire protocol](docs/protocol.md) explain the backend/client boundary.
-Maintainers can follow the [release guide](docs/RELEASING.md).
+This is a beta. Contributions are welcome.
+[CONTRIBUTING.md](CONTRIBUTING.md) is setup, checks, and pull requests.
+Open work that is ready for a first patch is labeled
+[`good first issue`](https://github.com/wesleygrimes/omastorm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+and [`help wanted`](https://github.com/wesleygrimes/omastorm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
+
+A headless Rust engine serves GPU textures over a Unix socket. The
+Quickshell UI is the client. `manifest.json` is the Omarchy plugin.
+
+- `engine/` Rust daemon: NEXRAD decode, cache, and the socket protocol
+- `ui/` Quickshell QML for the bar popover and window
+- `scripts/` setup, checks, captures, install, and release
+- `data/` fixture provenance and checksums (`data/raw/` is downloaded)
+- `golden/` decoder answer key for the archived KTLX scan
+- `docs/` protocol, configuration, and releasing
+- `site/` omastorm.com
+
+Read [DESIGN.md](DESIGN.md) before proposing a product change and
+[docs/protocol.md](docs/protocol.md) before touching the engine/client
+boundary. Maintainers cut releases with
+[docs/RELEASING.md](docs/RELEASING.md).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
CONTRIBUTING.md and a short README Contributing section already existed on main. This fills the remaining gaps from #10 and #12 so a newcomer can go README → CONTRIBUTING → labeled issues without bloating install or use docs.

**README (#12).** Welcome/beta line, links to CONTRIBUTING.md and issues labeled `good first issue` and `help wanted`, a one-line repo map for paths that exist (`engine/`, `ui/`, `scripts/`, `data/`, `golden/`, `docs/`, `site/`), where decisions live (DESIGN.md, docs/protocol.md, docs/RELEASING.md; no PLAN.md), and a short architecture sentence. No status badges (#11). Data and licenses left as the acknowledgements home. Install, Use, Configuration, and Troubleshooting are unchanged.

**CONTRIBUTING.md (#10).** Existing mise flow kept. Adds filing (bug template, what a useful engine.log looks like, feature-request shape), what not to change (`engine/release.pin`, `golden/` plus capture scripts, DESIGN.md constraints), PR shape (branch from main, one change, short imperative subject, why in the body, no co-author/tool trailers), a Releases heading that still points at docs/RELEASING.md, and a one-line Conduct expectation to be kind and treat people well.

The bug template footer points at CONTRIBUTING’s Issues section.

Closes #10
Closes #12
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb076be4-ec2a-4683-a24e-b2f84bab5890?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb076be4-ec2a-4683-a24e-b2f84bab5890&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

