### PR TITLE
Name engine release tasks and lead RELEASING with CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,8 +92,9 @@ commit; it uses scratch daemons and leaves the shared daemon alone. Cargo runs
 first, then the Rust tests run alongside the UI checks, which proceed in two
 lanes. Scratch and logs live under `target/check/`, never `/tmp`; the daemons
 and runtime files go on every exit, and the logs stay until the next run.
-The checks read `target/debug/`, so leave `CARGO_TARGET_DIR` unset. There is no
-GitHub Actions suite yet; a pull request is ready when those local checks pass.
+The checks read `target/debug/`, so leave `CARGO_TARGET_DIR` unset. Engine
+builds CI lints, tests, and packages both Linux architectures; GPU and QML
+checks still run locally. A pull request is ready when `mise check` passes.
 
 For shader, sampling, or camera changes, also run `mise check --gpu` and
 `bash scripts/capture-review.sh`, inspect the images in `review/`, and include

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -30,9 +30,9 @@ Honor the work later with a `v*` tag; generate its notes as Plugin step 3
 describes, from the previous `v*` tag and never an `engine-*` tag.
 
 Engine only: the code may merge to `main`, but users keep the pinned binary
-until a maintainer runs `mise release` and the pin commit lands. Batch engine
-releases; do not release on every merge. Credit the engine author in the
-release notes, which the script generates from commit subjects alone.
+until a maintainer finishes the engine sequence below and the pin commit
+lands. Batch engine releases; do not release on every merge. Credit the
+engine author in the release notes.
 
 Plugin and engine together in one PR: do not merge while the UI needs a
 protocol or feature the published pin does not speak. `mise check` builds the
@@ -46,54 +46,76 @@ Never merge the UI first.
 
 ## Engine
 
-Use a configured checkout with GitHub CLI authentication and release access.
-The implementation is [scripts/release-engine.sh](../scripts/release-engine.sh).
+Prefer CI. Bump the version on `main`, let
+[.github/workflows/engine.yml](../.github/workflows/engine.yml) build both
+Linux architectures, push `engine-<version>`, publish the draft, then verify
+the public bytes before writing the pin.
 
-1. Bump `version` in `engine/Cargo.toml`. Run
-   `mise exec -- cargo build --offline` to update `Cargo.lock`, then
-   `mise check`. Commit both files and push to `main`.
-   The engine workflow builds both Linux architectures natively. Download its
-   `engine-release` artifact into `target/dist/` before running the release
-   command locally, or gather both native outputs and their `.build.json`
-   metadata from this same commit. A missing, stale, or mislabeled build fails
-   packaging before a draft is created.
-2. Run `mise release --dry-run` from clean `main`, even with `origin/main`.
-   It builds the native stripped candidate, verifies both binaries' source
+The workflow runs the mise toolchain's lint, Rust tests, installer checks,
+and release checks on native `ubuntu-24.04` x86_64 and `ubuntu-24.04-arm`
+aarch64 runners. Every native candidate must answer hello with the engine
+version and UI protocol. GPU/QML checks still require an Omarchy desktop.
+PRs, branch pushes, and manual runs produce workflow artifacts. Pushing
+`engine-<version>` (the tag must match Cargo.toml) combines both candidates
+and creates a draft GitHub Release; it refuses to overwrite an existing
+release.
+
+Ubuntu runners execute the newly built native candidates. They verify
+installation and checksums for the existing published pin with
+`--published-install-only`: the Arch-built engine-0.1.2 x86 asset requires
+glibc 2.44, newer than Ubuntu 24.04. Normal desktop checks still require the
+pinned binary to run. Building future releases on Ubuntu also avoids inheriting
+the build machine's newer Arch glibc.
+
+1. Run `mise engine-bump` (next patch) or `mise engine-bump -- <version>`.
+   It writes `engine/Cargo.toml` and `Cargo.lock`. Run `mise check`, commit
+   both files, and push to `main`.
+2. Wait for Engine builds CI on that commit to finish on both architectures.
+3. From clean `main`, even with `origin/main`, run `mise engine-tag`. It
+   pushes an annotated `engine-<version>` tag. CI drafts the GitHub Release
+   with both binaries, build metadata, `SHA256SUMS`, and the candidate pin.
+4. Review the draft and publish it. Never pin a draft or add assets after
+   publishing.
+5. Download the published `release.pin` or the `engine-release` workflow
+   artifact into `target/dist/`. Run `mise engine-verify` to require every
+   public binary to match the candidate checksums. It writes nothing.
+6. Run `mise engine-pin` to write `engine/release.pin`. Run `mise check`,
+   then commit the pin separately and push. Users receive it on their next
+   plugin update.
+
+`mise engine-verify` and `mise engine-pin` call
+[scripts/pin-engine-release.sh](../scripts/pin-engine-release.sh). Neither
+commits. If an already published asset is wrong, leave the pin unchanged and
+release a new version.
+
+### Local fallback
+
+Use a laptop only when CI cannot cut the release. You still need both native
+binaries and their `.build.json` metadata from the same commit: download the
+`engine-release` workflow artifact into `target/dist/`, or gather both native
+outputs. A missing, stale, or mislabeled build fails packaging before a draft
+is created.
+
+`mise release` remains the one-shot local path
+([scripts/release-engine.sh](../scripts/release-engine.sh)). From clean
+`main`, even with `origin/main`, and with GitHub CLI authentication and
+release access:
+
+1. After the version bump is on `main`, run `mise release --dry-run`. It
+   builds the native stripped candidate, verifies both binaries' source
    commit/version/checksums, checks the native candidate's reported version
-   and UI protocol compatibility, and prints the tag, sha256, and release notes.
-   Review these before publishing.
-3. Run `mise release` and confirm publication. It creates `engine-<version>`
-   with both binaries, build metadata, `SHA256SUMS`, and the candidate pin,
-   then verifies every published binary before writing `engine/release.pin`.
-4. Run `mise check` to verify installation from the new pin, then commit the
-   pin separately and push. Users receive it on their next plugin update.
+   and UI protocol compatibility, and prints the tag, sha256, and release
+   notes. Review these before publishing.
+2. Run `mise release` and confirm publication. It creates `engine-<version>`,
+   publishes, verifies every published binary, and writes `engine/release.pin`.
+3. Run `mise check`, then commit the pin separately and push.
 
-`mise build-release` builds a local candidate without publishing. Do not use
-its `--write-pin` option to bypass published-asset verification.
-If release validation fails, resolve the reported precondition. If an already
-published asset is wrong, leave the pin unchanged and release a new version.
+`mise build-release` builds a local candidate without publishing (CI calls
+this per architecture). Do not use its `--write-pin` option to bypass
+published-asset verification. After a local candidate, prefer
+`mise engine-verify` / `mise engine-pin`.
 
-### CI release route
-
-Ubuntu runners execute the newly built native candidates. They verify installation
-and checksums for the existing published pin with `--published-install-only`: the
-Arch-built engine-0.1.2 x86 asset requires glibc 2.44, newer than Ubuntu 24.04.
-Normal desktop checks still require the pinned binary to run. Building future
-releases on Ubuntu also avoids inheriting the build machine's newer Arch glibc.
-
-`.github/workflows/engine.yml` runs the mise toolchain's lint, Rust tests,
-installer checks, and release checks on native `ubuntu-24.04` x86_64 and
-`ubuntu-24.04-arm` aarch64 runners. Every native candidate must answer hello
-with the engine version and UI protocol. GPU/QML checks still require an
-Omarchy desktop. PRs, branch pushes, and manual runs produce workflow artifacts.
-
-Alternatively, push `engine-<version>` on the tested release commit. The tag
-must match Cargo.toml. CI combines both candidates and creates a draft GitHub
-Release; it refuses to overwrite an existing release. Review and publish the
-draft, download its `engine-release` workflow artifact into `target/dist/`,
-then run `bash scripts/pin-engine-release.sh target/dist/release.pin`. That
-verifies the exact public bytes without rebuilding them. Run `mise check`
-and commit the pin afterward. Never pin a draft or add assets after publishing.
+If release validation fails, resolve the reported precondition.
 
 ## Plugin
 

--- a/mise.toml
+++ b/mise.toml
@@ -62,12 +62,28 @@ run = "cargo test --offline --locked"
 description = "Integration suite against a scratch daemon; run before every commit (--gpu adds the rendering test)"
 run = "bash scripts/check.sh"
 
+[tasks.engine-bump]
+description = "Bump engine/Cargo.toml and Cargo.lock to the next patch (or -- <version>); publishes nothing"
+run = "bash scripts/bump-engine-version.sh"
+
+[tasks.engine-tag]
+description = "Push annotated engine-<version> from clean main so CI drafts the GitHub Release"
+run = "bash scripts/tag-engine-release.sh"
+
+[tasks.engine-verify]
+description = "Download published engine assets and require their sha256 to match the candidate pin; writes nothing"
+run = "bash scripts/pin-engine-release.sh --verify-only"
+
+[tasks.engine-pin]
+description = "Verify published engine assets, then write engine/release.pin (does not commit)"
+run = "bash scripts/pin-engine-release.sh"
+
 [tasks.build-release]
 description = "Optimized, stripped engine and SHA256SUMS under target/dist/ as a release candidate; publishes nothing (--write-pin updates engine/release.pin)"
 run = "bash scripts/build-engine-release.sh"
 
 [tasks.release]
-description = "Publish engine-<version> from main: candidate, draft release, publish, verify the published asset, write the pin (--dry-run, --yes)"
+description = "Local fallback: publish engine-<version> from a laptop (candidate, draft, publish, verify, write pin; --dry-run, --yes)"
 run = "bash scripts/release-engine.sh"
 
 [tasks.clean]

--- a/scripts/build-engine-release.sh
+++ b/scripts/build-engine-release.sh
@@ -77,5 +77,5 @@ if (( write_pin )); then
 else
   printf 'Candidate pin: %s (committed pin unchanged).\n' "$candidate"
   printf 'Publish only as a new immutable release with both architectures; follow docs/RELEASING.md.\n'
-  printf 'After publication, verify the candidate with scripts/pin-engine-release.sh.\n'
+  printf 'After publication, verify with mise engine-verify and write the pin with mise engine-pin.\n'
 fi

--- a/scripts/bump-engine-version.sh
+++ b/scripts/bump-engine-version.sh
@@ -1,14 +1,25 @@
 #!/usr/bin/env bash
-# Bump engine/Cargo.toml and refresh Cargo.lock. Publishes nothing and does
-# not touch engine/release.pin. Run as `mise engine-bump` (next patch) or
-# `mise engine-bump -- <version>`.
+# Bump engine/Cargo.toml and the matching Cargo.lock package version.
+# Publishes nothing and does not touch engine/release.pin. Run as
+# `mise engine-bump` (next patch) or `mise engine-bump -- <version>`.
+# Refreshes the lock with `cargo update --offline -p <engine>`; refuses if
+# anything other than that package's version line would change.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
 die() { printf '%s\n' "$@" >&2; exit 1; }
 
+lock_without_engine_version() {
+  awk -v name="$package" '
+    $0 == "name = \"" name "\"" { print; getline; if ($0 ~ /^version = /) { print "version = \"\""; next } }
+    { print }
+  ' "$1"
+}
+
 current=$(awk -F'"' '/^version = /{print $2; exit}' engine/Cargo.toml)
 [[ $current =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "engine/Cargo.toml version is not X.Y.Z: $current"
+package=$(awk -F'"' '/^name = /{print $2; exit}' engine/Cargo.toml)
+[[ -n $package ]] || die 'engine/Cargo.toml is missing name.'
 
 version=${1:-}
 if [[ -z $version ]]; then
@@ -21,19 +32,34 @@ fi
 pinned=$(awk -F= '/^tag=/{print $2}' engine/release.pin)
 [[ $version != "${pinned#engine-}" ]] || die "$version is already the pinned release."
 
-bak=$(mktemp)
-trap 'rm -f -- "$bak"' EXIT
-cp -- engine/Cargo.toml "$bak"
+toml_bak=$(mktemp)
+lock_bak=$(mktemp)
+trap 'rm -f -- "$toml_bak" "$lock_bak"' EXIT
+cp -- engine/Cargo.toml "$toml_bak"
+cp -- Cargo.lock "$lock_bak"
 awk -v v="$version" '
   BEGIN { done = 0 }
   !done && /^version = / { printf "version = \"%s\"\n", v; done = 1; next }
   { print }
-' "$bak" > engine/Cargo.toml
-if ! bash scripts/cargo.sh generate-lockfile --offline; then
-  cp -- "$bak" engine/Cargo.toml
-  die 'cargo generate-lockfile --offline failed; engine/Cargo.toml was left unchanged.'
+' "$toml_bak" > engine/Cargo.toml
+restore() {
+  cp -- "$toml_bak" engine/Cargo.toml
+  cp -- "$lock_bak" Cargo.lock
+}
+if ! bash scripts/cargo.sh update --offline -p "$package"; then
+  restore
+  die "cargo update --offline -p $package failed; engine/Cargo.toml and Cargo.lock were left unchanged."
 fi
-lock_version=$(awk '/^name = "omastorm-engine"$/{getline; print}' Cargo.lock | awk -F'"' '{print $2}')
-[[ $version == "$lock_version" ]] || die "Cargo.lock still says $lock_version after the bump."
+lock_version=$(awk -v name="$package" '
+  $0 == "name = \"" name "\"" { getline; print }
+' Cargo.lock | awk -F'"' '{print $2}')
+if [[ $version != "$lock_version" ]]; then
+  restore
+  die "Cargo.lock still says $lock_version after the bump."
+fi
+if ! cmp -s <(lock_without_engine_version "$lock_bak") <(lock_without_engine_version Cargo.lock); then
+  restore
+  die 'cargo update changed more than the engine version in Cargo.lock; engine/Cargo.toml and Cargo.lock were left unchanged.'
+fi
 
 printf 'Bumped engine to %s. Next: mise check, then commit engine/Cargo.toml and Cargo.lock to main.\n' "$version"

--- a/scripts/bump-engine-version.sh
+++ b/scripts/bump-engine-version.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Bump engine/Cargo.toml and refresh Cargo.lock. Publishes nothing and does
+# not touch engine/release.pin. Run as `mise engine-bump` (next patch) or
+# `mise engine-bump -- <version>`.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+die() { printf '%s\n' "$@" >&2; exit 1; }
+
+current=$(awk -F'"' '/^version = /{print $2; exit}' engine/Cargo.toml)
+[[ $current =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "engine/Cargo.toml version is not X.Y.Z: $current"
+
+version=${1:-}
+if [[ -z $version ]]; then
+  IFS=. read -r major minor patch <<< "$current"
+  version=$major.$minor.$((patch + 1))
+fi
+[[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "Version must be X.Y.Z: $version"
+[[ $version != "$current" ]] || die "engine/Cargo.toml is already $version."
+
+pinned=$(awk -F= '/^tag=/{print $2}' engine/release.pin)
+[[ $version != "${pinned#engine-}" ]] || die "$version is already the pinned release."
+
+bak=$(mktemp)
+trap 'rm -f -- "$bak"' EXIT
+cp -- engine/Cargo.toml "$bak"
+awk -v v="$version" '
+  BEGIN { done = 0 }
+  !done && /^version = / { printf "version = \"%s\"\n", v; done = 1; next }
+  { print }
+' "$bak" > engine/Cargo.toml
+if ! bash scripts/cargo.sh generate-lockfile --offline; then
+  cp -- "$bak" engine/Cargo.toml
+  die 'cargo generate-lockfile --offline failed; engine/Cargo.toml was left unchanged.'
+fi
+lock_version=$(awk '/^name = "omastorm-engine"$/{getline; print}' Cargo.lock | awk -F'"' '{print $2}')
+[[ $version == "$lock_version" ]] || die "Cargo.lock still says $lock_version after the bump."
+
+printf 'Bumped engine to %s. Next: mise check, then commit engine/Cargo.toml and Cargo.lock to main.\n' "$version"

--- a/scripts/check-engine-release.sh
+++ b/scripts/check-engine-release.sh
@@ -3,13 +3,33 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 fail() { printf '%s\n' "$@" >&2; exit 1; }
-scratch=$(mktemp -d /tmp/omastorm-release-check.XXXXXX)
+scratch=$(mktemp -d "${TMPDIR:-/tmp}/omastorm-release-check.XXXXXX")
 trap 'rm -rf "$scratch"' EXIT
+for task in engine-bump engine-tag engine-verify engine-pin build-release release; do
+  rg -q "\[tasks\.$task\]" mise.toml || fail "mise.toml is missing $task"
+done
+toml=$(sha256sum engine/Cargo.toml Cargo.lock)
+current=$(awk -F'"' '/^version = /{print $2; exit}' engine/Cargo.toml)
+if bash scripts/bump-engine-version.sh not-a-version > "$scratch/bump.err" 2>&1; then
+  fail 'bump-engine-version.sh accepted a non X.Y.Z version'
+fi
+rg -q 'Version must be X.Y.Z' "$scratch/bump.err" || fail "unclear bump error: $(cat "$scratch/bump.err")"
+if bash scripts/bump-engine-version.sh "$current" > "$scratch/bump.err" 2>&1; then
+  fail 'bump-engine-version.sh rewrote the current version'
+fi
+rg -q "already $current" "$scratch/bump.err" || fail "unclear current-version bump error: $(cat "$scratch/bump.err")"
+[[ $(sha256sum engine/Cargo.toml Cargo.lock) == "$toml" ]] || fail 'Failed bump changed Cargo.toml or Cargo.lock'
 mkdir -p "$scratch"/{scripts,engine,target/dist,bin,published}
-cp scripts/{engine-pin,package-engine-release,pin-engine-release}.sh "$scratch/scripts/"
+cp scripts/{engine-pin,package-engine-release,pin-engine-release,tag-engine-release}.sh "$scratch/scripts/"
 cp engine/{Cargo.toml,release.pin} "$scratch/engine/"
 git -C "$scratch" init -q
 git -C "$scratch" -c user.name=Fixture -c user.email=fixture@example.invalid -c commit.gpgsign=false commit -qm fixture --allow-empty
+git -C "$scratch" branch -m topic
+if bash "$scratch/scripts/tag-engine-release.sh" > "$scratch/tag.err" 2>&1; then
+  fail 'tag-engine-release.sh tagged from a topic branch'
+fi
+rg -q 'engine tags are pushed from main' "$scratch/tag.err" \
+  || fail "unclear tag refusal: $(cat "$scratch/tag.err")"
 source_commit=$(git -C "$scratch" rev-parse HEAD)
 version=$(awk -F'"' '/^version = /{print $2; exit}' engine/Cargo.toml)
 # Header fixtures exercise architecture checks; these files are never executed.
@@ -64,6 +84,10 @@ if FAIL_ASSET=$arm bash scripts/pin-engine-release.sh > failure.log 2>&1; then f
 [[ $(sha256sum engine/release.pin) == "$before" ]] || fail 'Missing asset changed the tracked pin'
 if CORRUPT_ASSET=$arm bash scripts/pin-engine-release.sh > failure.log 2>&1; then fail 'Pinned a mismatching published asset'; fi
 [[ $(sha256sum engine/release.pin) == "$before" ]] || fail 'Wrong checksum changed the tracked pin'
+if FAIL_ASSET=$arm bash scripts/pin-engine-release.sh --verify-only > failure.log 2>&1; then fail 'Verified a missing published asset'; fi
+[[ $(sha256sum engine/release.pin) == "$before" ]] || fail 'Failed verify-only changed the tracked pin'
+bash scripts/pin-engine-release.sh --verify-only
+[[ $(sha256sum engine/release.pin) == "$before" ]] || fail 'verify-only changed the tracked pin'
 bash scripts/pin-engine-release.sh
 cmp engine/release.pin target/dist/release.pin
 echo 'Engine release: both architectures, ELF labels, exact checksums, and publication gate PASS'

--- a/scripts/check-engine-release.sh
+++ b/scripts/check-engine-release.sh
@@ -19,6 +19,68 @@ if bash scripts/bump-engine-version.sh "$current" > "$scratch/bump.err" 2>&1; th
 fi
 rg -q "already $current" "$scratch/bump.err" || fail "unclear current-version bump error: $(cat "$scratch/bump.err")"
 [[ $(sha256sum engine/Cargo.toml Cargo.lock) == "$toml" ]] || fail 'Failed bump changed Cargo.toml or Cargo.lock'
+# Success and upgrade-refusal paths use a stub cargo so this check does not
+# need the mise toolchain or a registry. The stub must only rewrite the
+# engine package version; a stub that touches another lock line must fail.
+package=$(awk -F'"' '/^name = /{print $2; exit}' engine/Cargo.toml)
+IFS=. read -r major minor patch <<< "$current"
+next=$major.$minor.$((patch + 1))
+write_bump_tree() {
+  local root=$1
+  mkdir -p "$root"/{engine,scripts}
+  cp Cargo.toml Cargo.lock "$root/"
+  cp engine/Cargo.toml engine/release.pin "$root/engine/"
+  cp scripts/bump-engine-version.sh "$root/scripts/"
+  cat > "$root/scripts/cargo.sh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+package=$(awk -F'"' '/^name = /{print $2; exit}' engine/Cargo.toml)
+version=$(awk -F'"' '/^version = /{print $2; exit}' engine/Cargo.toml)
+[[ $1 == update ]] || exit 1
+extra=
+[[ -f scripts/cargo.extra ]] && extra=$(cat scripts/cargo.extra)
+awk -v name="$package" -v v="$version" -v extra="$extra" '
+  $0 == "name = \"" name "\"" { print; getline; if ($0 ~ /^version = /) { printf "version = \"%s\"\n", v; next } }
+  extra != "" && /^version = / && !done { printf "version = \"%s\"\n", extra; done = 1; next }
+  { print }
+' Cargo.lock > Cargo.lock.next
+mv -- Cargo.lock.next Cargo.lock
+STUB
+  chmod +x "$root/scripts/cargo.sh"
+}
+write_bump_tree "$scratch/bump-ok"
+if ! bash "$scratch/bump-ok/scripts/bump-engine-version.sh" "$next" > "$scratch/bump-ok.log" 2>&1; then
+  fail "bump-engine-version.sh failed a version-only lock refresh: $(cat "$scratch/bump-ok.log")"
+fi
+[[ $(awk -F'"' '/^version = /{print $2; exit}' "$scratch/bump-ok/engine/Cargo.toml") == "$next" ]] \
+  || fail 'Successful bump did not write engine/Cargo.toml'
+ok_lock=$(awk -v name="$package" '
+  $0 == "name = \"" name "\"" { getline; print }
+' "$scratch/bump-ok/Cargo.lock" | awk -F'"' '{print $2}')
+[[ $ok_lock == "$next" ]] || fail "Successful bump did not write the $package version in Cargo.lock"
+toml_changed=$(diff -u engine/Cargo.toml "$scratch/bump-ok/engine/Cargo.toml" | awk '/^[+-][^+-]/ {c++} END {print c+0}' || true)
+lock_changed=$(diff -u Cargo.lock "$scratch/bump-ok/Cargo.lock" | awk '/^[+-][^+-]/ {c++} END {print c+0}' || true)
+[[ $toml_changed == 2 && $lock_changed == 2 ]] \
+  || fail "Successful bump must change only the engine version lines (toml=$toml_changed lock=$lock_changed)"
+rg -q "^-version = \"$current\"\$" <(diff -u engine/Cargo.toml "$scratch/bump-ok/engine/Cargo.toml") \
+  || fail 'Successful bump did not replace the Cargo.toml version line'
+rg -q "^\+version = \"$next\"\$" <(diff -u engine/Cargo.toml "$scratch/bump-ok/engine/Cargo.toml") \
+  || fail 'Successful bump did not write the new Cargo.toml version'
+rg -q "^-version = \"$current\"\$" <(diff -u Cargo.lock "$scratch/bump-ok/Cargo.lock") \
+  || fail 'Successful bump did not replace the Cargo.lock version line'
+rg -q "^\+version = \"$next\"\$" <(diff -u Cargo.lock "$scratch/bump-ok/Cargo.lock") \
+  || fail 'Successful bump did not write the new Cargo.lock version'
+write_bump_tree "$scratch/bump-bad"
+printf '9.9.9\n' > "$scratch/bump-bad/scripts/cargo.extra"
+before_bad=$(sha256sum "$scratch/bump-bad/engine/Cargo.toml" "$scratch/bump-bad/Cargo.lock")
+if bash "$scratch/bump-bad/scripts/bump-engine-version.sh" "$next" > "$scratch/bump-bad.log" 2>&1; then
+  fail 'bump-engine-version.sh accepted a lock refresh that upgraded another package'
+fi
+rg -q 'more than the engine version' "$scratch/bump-bad.log" \
+  || fail "unclear extra-lock-change error: $(cat "$scratch/bump-bad.log")"
+[[ $(sha256sum "$scratch/bump-bad/engine/Cargo.toml" "$scratch/bump-bad/Cargo.lock") == "$before_bad" ]] \
+  || fail 'Rejected bump left Cargo.toml or Cargo.lock dirty'
 mkdir -p "$scratch"/{scripts,engine,target/dist,bin,published}
 cp scripts/{engine-pin,package-engine-release,pin-engine-release,tag-engine-release}.sh "$scratch/scripts/"
 cp engine/{Cargo.toml,release.pin} "$scratch/engine/"

--- a/scripts/package-engine-release.sh
+++ b/scripts/package-engine-release.sh
@@ -26,7 +26,7 @@ for arch in x86_64 aarch64; do
     || die "Build metadata does not match $asset, engine $version, and commit $source_commit"
 done
 {
-  printf '# Verify published assets with scripts/pin-engine-release.sh before committing.\n'
+  printf '# Verify published assets with mise engine-pin before committing.\n'
   printf 'tag=engine-%s\nrepo=%s\n' "$version" "$repo"
   for arch in x86_64 aarch64; do
     printf 'asset_%s=%s\nsha256_%s=%s\n' "$arch" "${assets[$arch]}" "$arch" "${hashes[$arch]}"

--- a/scripts/pin-engine-release.sh
+++ b/scripts/pin-engine-release.sh
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
 # Pin already-built CI/local assets only after verifying their public release.
+# Run as `mise engine-pin`. `mise engine-verify` is `--verify-only`.
+#   --verify-only  require published bytes; leave engine/release.pin unchanged
 set -euo pipefail
 cd "$(dirname "$0")/.."
 die() { printf '%s\n' "$@" >&2; exit 1; }
 source scripts/engine-pin.sh
-candidate=${1:-target/dist/release.pin}
+verify_only=0
+candidate=target/dist/release.pin
+for arg in "$@"; do
+  case $arg in
+    --verify-only) verify_only=1 ;;
+    -*) die "Unknown option: $arg (use --verify-only)" ;;
+    *) candidate=$arg ;;
+  esac
+done
 work=$(mktemp -d "${TMPDIR:-/tmp}/omastorm-release.XXXXXX")
 trap 'rm -rf "$work"' EXIT
 cp -- "$candidate" "$work/release.pin"
@@ -18,5 +28,9 @@ for arch in x86_64 aarch64; do
   [[ $got == "${hashes[$arch]}" ]] \
     || die "Published ${assets[$arch]} does not match the candidate checksum; engine/release.pin was not changed."
 done
+if (( verify_only )); then
+  printf 'Verified published assets; engine/release.pin unchanged.\n'
+  exit 0
+fi
 cp -- "$work/release.pin" engine/release.pin
 printf 'Verified published assets and updated engine/release.pin\n'

--- a/scripts/release-engine.sh
+++ b/scripts/release-engine.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Publish an engine release from main (DESIGN.md, distribution). Run it as
+# Local fallback: publish an engine release from a laptop (docs/RELEASING.md).
+# Prefer `mise engine-tag` after CI builds both architectures. Run this as
 # `mise release`. Refuses unless on main, clean, and even with origin/main,
 # and unless engine/Cargo.toml names a version with no tag or release yet.
 # Builds the candidate, requires it to answer hello with that version and the

--- a/scripts/tag-engine-release.sh
+++ b/scripts/tag-engine-release.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Push engine-<version> from main so CI drafts the GitHub Release.
+# Run as `mise engine-tag`. Does not publish, verify assets, or write the pin.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+die() { printf '%s\n' "$@" >&2; exit 1; }
+
+command -v git > /dev/null 2>&1 || die 'Need git on PATH; run this as mise engine-tag.'
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+[[ $branch == main ]] || die "On $branch; engine tags are pushed from main."
+[[ -z $(git status --porcelain) ]] || die 'The working tree is not clean.'
+git fetch -q origin main
+[[ $(git rev-parse HEAD) == $(git rev-parse origin/main) ]] \
+  || die 'main is not even with origin/main; push or pull first so the tag names a commit everyone has.'
+
+command -v gh > /dev/null 2>&1 || die 'Need gh on PATH; run this as mise engine-tag.'
+gh auth status > /dev/null 2>&1 || die 'gh is not logged in (gh auth login).'
+
+version=$(awk -F'"' '/^version = /{print $2; exit}' engine/Cargo.toml)
+lock_version=$(awk '/^name = "omastorm-engine"$/{getline; print}' Cargo.lock | awk -F'"' '{print $2}')
+[[ $version == "$lock_version" ]] \
+  || die "engine/Cargo.toml says $version but Cargo.lock says $lock_version; run mise engine-bump and commit the lock."
+tag=engine-$version
+pinned=$(awk -F= '/^tag=/{print $2}' engine/release.pin)
+[[ $tag != "$pinned" ]] || die "$tag is already the pinned release; bump with mise engine-bump first."
+! git rev-parse -q --verify "refs/tags/$tag" > /dev/null || die "Tag $tag already exists locally."
+! git ls-remote --exit-code --tags origin "refs/tags/$tag" > /dev/null 2>&1 || die "Tag $tag already exists on origin."
+! gh release view "$tag" -R wesleygrimes/omastorm > /dev/null 2>&1 \
+  || die "Release $tag already exists. Releases are immutable; bump the version instead of replacing it."
+
+# Annotated: CI's gh release create --verify-tag rejects a lightweight tag.
+git tag -a "$tag" -m "$tag"
+git push origin "refs/tags/$tag"
+printf 'Pushed %s. Engine builds CI will draft the GitHub Release; publish it, then mise engine-verify and mise engine-pin.\n' "$tag"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up after #30. Names the engine release happy path and makes CI the documented route. No release semantics change and no new engine release.

**Happy path** (now first in `docs/RELEASING.md`):

1. `mise engine-bump` — next patch, or `mise engine-bump -- <version>`
2. Push to `main`; Engine builds CI packages both architectures
3. `mise engine-tag` — annotated `engine-<version>` so CI drafts the GitHub Release
4. Publish the draft
5. `mise engine-verify` — published bytes must match the candidate pin
6. `mise engine-pin` — write `engine/release.pin` only after that check, then commit the pin separately

These map onto the existing scripts. `mise engine-verify` / `mise engine-pin` call `scripts/pin-engine-release.sh` (`--verify-only` leaves the tracked pin alone). `mise release` stays as the laptop fallback; `mise build-release` is unchanged so Engine builds CI keeps working.

CONTRIBUTING now mentions that engine CI exists; GPU/QML checks still run locally.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1c1c29d-48d5-41fb-b884-984054e5dccb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1c1c29d-48d5-41fb-b884-984054e5dccb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

