### PR TITLE
Bump engine to 0.1.3 for the first two-architecture release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "omastorm-engine"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "geo-types",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omastorm-engine"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 rust-version = "1.89"
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bump `omastorm-engine` from 0.1.2 to 0.1.3 so Engine builds CI can package both Linux architectures for the first ARM-capable engine release.

This is **only step 1** of the happy path from #39:

1. `mise engine-bump` (this PR)
2. Merge to `main` → Engine builds CI packages x86_64 and aarch64
3. `mise engine-tag` → CI drafts the GitHub Release
4. Publish the draft
5. `mise engine-verify`
6. `mise engine-pin`

**Not in this PR:** no `engine-*` tag, no publish, no `engine/release.pin` change. The pin stays at `engine-0.1.2` (`asset_x86_64` only) until after publish and verify. Related to #4; this bump does not close it.

## Changes

- `engine/Cargo.toml` and `Cargo.lock`: `omastorm-engine` 0.1.2 → 0.1.3 only
- Ran `bash scripts/bump-engine-version.sh` (next patch). `cargo update --offline -p omastorm-engine` updated that package version and nothing else.

## Verify

- Confirmed `engine/Cargo.toml` and the `omastorm-engine` entry in `Cargo.lock` both say `0.1.3`
- Confirmed `engine/release.pin` is unchanged (`tag=engine-0.1.2`)
- Diff is two version lines
- `cargo fmt --check`, `clippy --offline --locked --all-targets -- -D warnings`, and `cargo test --offline --locked` passed (43 tests; 2 GPU rendering tests ignored)
- `bash scripts/check-engine-release.sh` passed (bump/tag/pin gates, both-arch bundle)

Full `mise check` was not run: this environment has no mise/Omarchy desktop. Engine builds CI on this PR will lint, test, and package both arches.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01acc362-83d5-48c9-b3c8-a17ee50c7170?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01acc362-83d5-48c9-b3c8-a17ee50c7170&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

