### PR TITLE
Omastorm 0.1.6: dual-arch install + plugin bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ client: it displays those textures in the bar popover and full window.
 
 ## Install
 
-Omarchy 4 on x86_64.
+Omarchy 4 on x86_64 and aarch64.
 
 ```sh
 omarchy plugin add https://github.com/wesleygrimes/omastorm.git --enable
@@ -70,18 +70,6 @@ bash ~/.config/omarchy/plugins/com.omastorm.radar/scripts/install-launcher.sh
 ```
 
 Update with `omarchy plugin update com.omastorm.radar`.
-
-ARM64 (`aarch64`) release packaging is prepared, but its binary is not yet
-published and pinned. Until then, build the engine in the installed plugin
-directory using the contributor toolchain:
-
-```sh
-cd ~/.config/omarchy/plugins/com.omastorm.radar
-mise install
-mise setup
-```
-
-Then open the popover again; it uses the checkout's native engine.
 
 ## Use
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,12 +2,15 @@
   "schemaVersion": 1,
   "id": "com.omastorm.radar",
   "name": "Omastorm",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": "Wes Grimes",
   "license": "MIT",
   "homepage": "https://omastorm.com",
   "description": "Live NEXRAD radar for the Omarchy desktop",
-  "kinds": ["bar-widget", "panel"],
+  "kinds": [
+    "bar-widget",
+    "panel"
+  ],
   "entryPoints": {
     "barWidget": "ui/RadarBar.qml",
     "panel": "ui/Panel.qml"


### PR DESCRIPTION
## Summary
- Bump `manifest.json` to `0.1.6` so `omarchy plugin update` picks up the dual-arch `engine-0.1.3` pin from #42.
- Document Install for Omarchy 4 on `x86_64` and `aarch64`.
- Remove the temporary ARM64 `mise setup` workaround block from the README.

## Test plan
- [ ] CI green (`Native x86_64`, `Native aarch64`, `bundle`)
- [ ] After merge + `v0.1.6` tag: `omarchy plugin update com.omastorm.radar` on x86_64 and aarch64 uses pinned `0.1.3` without a local mise build