### PR TITLE
Skip already-catalogued sweeps when a quiet live poller rediscovers

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -108,7 +108,9 @@ Independently, if the poller task has exited, or the newest radial is thirty
 minutes old and discovery has not been tried since, spawn a new poller.
 Reselecting the current station is a no-op while the poller is running; if
 the task has ended, start it again. Cached frames stay on screen through a
-rediscovery.
+rediscovery. A rediscovery that finds only a sweep already in the catalog
+leaves the frame and connection chrome alone; a newer volume still clears
+UNAVAILABLE / OFFLINE.
 
 ## Scope
 

--- a/engine/README.md
+++ b/engine/README.md
@@ -59,10 +59,12 @@ failure, but 90 seconds with no chunk at all (higher cuts of a live volume
 still arrive every 4–12 s) means the iterator is parked on a volume the
 bucket has rotated off, so discovery starts over. Independently, the engine
 respawns a poller whose task has exited, or whose newest radial is thirty
-minutes old and has not been rediscovered since. Reselecting the live
-station is a no-op while the poller is running; if the task has ended, the
-reselect starts it again. A reachable feed becomes stale at ten minutes and
-unavailable at thirty minutes without new radials; an empty station is
+minutes old and has not been rediscovered since. A rediscovery that finds
+only a sweep already in the catalog does not republish it or clear
+unavailable. Reselecting the live station is a no-op while the poller is
+running; if the task has ended, the reselect starts it again. A reachable
+feed becomes stale at ten minutes and unavailable at thirty minutes without
+new radials; an empty station is
 unavailable, and an unreachable bucket is offline. Cached frames remain
 usable under every condition.
 

--- a/engine/src/live.rs
+++ b/engine/src/live.rs
@@ -84,6 +84,13 @@ fn quiet_too_long(since_chunk: Instant, now: Instant) -> bool {
     now.saturating_duration_since(since_chunk) >= QUIET_RESTART
 }
 
+/// A rediscovery (or a respawned poller) that finds only a sweep already
+/// in the catalog must not publish it again. The first join after a
+/// `select_site` still may, so `loading` can clear.
+fn skip_catalogued_replay(skip_known: bool, start_ms: i64, known: &[i64]) -> bool {
+    skip_known && known.contains(&start_ms)
+}
+
 /// What the poller reports to `main.rs`.
 pub enum Event {
     /// An earlier volume's complete lowest cut, fetched on joining: the
@@ -214,11 +221,14 @@ pub fn radials_of(chunk: &Chunk) -> Result<Vec<Radial>, String> {
 
 /// Feed a downloaded chunk to the assembler and report what changed.
 /// `false` when the event channel is closed (the poller was replaced).
+/// `known` is the catalogued (and already-delivered) start times to skip
+/// on a rediscovery; live chunks pass `None` so a growing cut still paints.
 async fn deliver(
     assembler: &mut Assembler,
     site: &str,
     chunk: &DownloadedChunk,
     events: &Sender<Event>,
+    known: Option<&[i64]>,
 ) -> bool {
     let id = &chunk.identifier;
     let volume = format!("{}/{:03}", id.site(), id.volume().as_number());
@@ -231,15 +241,21 @@ async fn deliver(
     };
     let starts = matches!(chunk.chunk, Chunk::Start(_));
     match assembler.feed(starts, &volume, id.name(), radials) {
-        Ok(Some(update)) => events
-            .send(Event::Sweep {
-                site: site.to_owned(),
-                sweep: update.sweep,
-                complete: update.complete,
-                provenance: update.provenance,
-            })
-            .await
-            .is_ok(),
+        Ok(Some(update)) => {
+            if known.is_some_and(|times| skip_catalogued_replay(true, update.sweep.start_ms, times))
+            {
+                return true;
+            }
+            events
+                .send(Event::Sweep {
+                    site: site.to_owned(),
+                    sweep: update.sweep,
+                    complete: update.complete,
+                    provenance: update.provenance,
+                })
+                .await
+                .is_ok()
+        }
         Ok(None) => true,
         Err(e) => {
             live_log(site, format_args!("chunk {}: {e}", id.name()));
@@ -418,10 +434,14 @@ impl Drop for AbortOnDrop {
 
 /// Poll `site` until the task is aborted or the event channel closes.
 /// `cached` holds the start times of the frames already catalogued for the
-/// station, so the backfill does not fetch them again.
-pub async fn poll(site: String, events: Sender<Event>, cached: Vec<i64>) {
+/// station, so the backfill does not fetch them again and a rediscovery
+/// does not republish them. `skip_known` is true when this poller is a
+/// respawn on a station already on screen (cleanup or reselect).
+pub async fn poll(site: String, events: Sender<Event>, cached: Vec<i64>, skip_known: bool) {
     let mut back_off = BACK_OFF;
     let mut backfilling: Option<AbortOnDrop> = None;
+    let mut known = cached;
+    let mut skip_known = skip_known;
     loop {
         let init = match timeout(START_TIMEOUT, ChunkIterator::start(&site)).await {
             Ok(Ok(init)) => init,
@@ -485,17 +505,26 @@ pub async fn poll(site: String, events: Sender<Event>, cached: Vec<i64>) {
                 site.clone(),
                 events.clone(),
                 *newest.identifier.volume(),
-                cached.clone(),
+                known.clone(),
             ))));
         }
         replay.push(newest);
         let mut previous_volume = None;
-        for chunk in &replay {
-            previous_volume = Some(*chunk.identifier.volume());
-            if !deliver(&mut assembler, &site, chunk, &events).await {
-                return;
+        {
+            let replay_known = skip_known.then_some(known.as_slice());
+            for chunk in &replay {
+                previous_volume = Some(*chunk.identifier.volume());
+                if !deliver(&mut assembler, &site, chunk, &events, replay_known).await {
+                    return;
+                }
             }
         }
+        if let Some(start_ms) = assembler.start_ms()
+            && !known.contains(&start_ms)
+        {
+            known.push(start_ms);
+        }
+        skip_known = true;
 
         let mut failures = 0;
         let mut last_chunk = Instant::now();
@@ -512,13 +541,18 @@ pub async fn poll(site: String, events: Sender<Event>, cached: Vec<i64>) {
                         for skipped in
                             earlier_chunks(&site, &iterator, &chunk.identifier, false).await
                         {
-                            if !deliver(&mut assembler, &site, &skipped, &events).await {
+                            if !deliver(&mut assembler, &site, &skipped, &events, None).await {
                                 return;
                             }
                         }
                     }
-                    if !deliver(&mut assembler, &site, &chunk, &events).await {
+                    if !deliver(&mut assembler, &site, &chunk, &events, None).await {
                         return;
+                    }
+                    if let Some(start_ms) = assembler.start_ms()
+                        && !known.contains(&start_ms)
+                    {
+                        known.push(start_ms);
                     }
                 }
                 Ok(Ok(None)) => {
@@ -594,6 +628,23 @@ mod tests {
         assert!(
             QUIET_RESTART < Duration::from_secs(600),
             "must fire before STALE, so a wedged volume is rediscovered while still LIVE"
+        );
+    }
+
+    #[test]
+    fn a_catalogued_replay_is_skipped_after_the_first_join() {
+        let start = 1_367_082_403_000;
+        assert!(
+            !skip_catalogued_replay(false, start, &[start]),
+            "the first join after select_site still publishes, so loading can clear"
+        );
+        assert!(
+            !skip_catalogued_replay(true, start, &[start + 1]),
+            "a newer volume is not in the catalog"
+        );
+        assert!(
+            skip_catalogued_replay(true, start, &[start]),
+            "a rediscovery of the same sweep must not republish it"
         );
     }
 

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -310,6 +310,11 @@ fn should_restart_live(
     evidence_age.is_some_and(|age| age >= UNAVAILABLE_AFTER.as_secs())
         && since_restart >= UNAVAILABLE_AFTER
 }
+/// A sweep already in the catalog may clear `loading` after `select_site`.
+/// Any other status stays put: rediscovery must not flash `ok`.
+fn known_sweep_clears_loading(status: ConnectionStatus) -> bool {
+    status == ConnectionStatus::Loading
+}
 /// A live station's frame from an assembled sweep: the fixture frame's
 /// product, palette, and bounds (the engine's reflectivity vocabulary), the
 /// sweep's geometry and times, and the station table's coordinates. Texture
@@ -585,9 +590,10 @@ impl Shared {
         Some(now_ms().saturating_sub(newest_ms).max(0) as u64 / 1000)
     }
     /// Abort the current poller, if any, and start another on the selected
-    /// station. Timeline and the frame on screen stay; the next sweep
-    /// clears `unavailable` / `offline`.
-    fn restart_live(&mut self, why: &str) {
+    /// station. Timeline and the frame on screen stay; the next *new* sweep
+    /// clears `unavailable` / `offline`. `skip_known` is true on a respawn
+    /// so a catalogued replay is not published again.
+    fn restart_live(&mut self, why: &str, skip_known: bool) {
         let site = self.state.site.id.clone();
         if site.is_empty() || self.state.source != Source::Live {
             return;
@@ -597,7 +603,12 @@ impl Shared {
             task.abort();
         }
         let cached: Vec<i64> = self.timeline.stored.iter().map(|e| e.start_ms).collect();
-        self.live = Some(tokio::spawn(live::poll(site, self.events.clone(), cached)));
+        self.live = Some(tokio::spawn(live::poll(
+            site,
+            self.events.clone(),
+            cached,
+            skip_known,
+        )));
         self.last_live_restart = Instant::now();
     }
     /// Go live on a station: the newest cached frame (or an empty one)
@@ -609,7 +620,7 @@ impl Shared {
     fn select_site(&mut self, id: &str) -> (bool, Option<String>) {
         if id == self.state.site.id && self.state.source == Source::Live {
             if self.live.as_ref().is_none_or(JoinHandle::is_finished) {
-                self.restart_live("poller ended; restarting on reselect");
+                self.restart_live("poller ended; restarting on reselect", true);
             }
             return (false, None);
         }
@@ -660,7 +671,7 @@ impl Shared {
         self.state.site.id = station.id;
         self.state.source = Source::Live;
         self.state.connection.status = ConnectionStatus::Loading;
-        self.restart_live("polling");
+        self.restart_live("polling", false);
         (true, None)
     }
     /// A pan settled with the map centred at `lat`, `lon`. While following and
@@ -703,6 +714,13 @@ impl Shared {
             scan_time: frame.scan_time.clone(),
             start_ms,
         };
+        if self.timeline.stored.iter().any(|e| e.start_ms == start_ms) {
+            if known_sweep_clears_loading(self.state.connection.status) {
+                self.state.connection.status = ConnectionStatus::Ok;
+                self.broadcast();
+            }
+            return Ok(());
+        }
         let following = self.timeline.following();
         self.state.connection.status = ConnectionStatus::Ok;
         let shown = if complete {
@@ -1607,7 +1625,7 @@ fn serve(dir: PathBuf) -> io::Result<()> {
                             shared.evidence_age_secs().unwrap_or(0)
                         )
                     };
-                    shared.restart_live(&why);
+                    shared.restart_live(&why, true);
                 }
             }
         }
@@ -1979,6 +1997,21 @@ mod tests {
             Some(UNAVAILABLE_AFTER.as_secs()),
             cooldown
         ));
+    }
+
+    #[test]
+    fn a_known_sweep_does_not_clear_unavailable() {
+        use ConnectionStatus::*;
+        assert!(
+            known_sweep_clears_loading(Loading),
+            "select_site is still loading until the first join reports"
+        );
+        for held in [Ok, Stale, Unavailable, Offline] {
+            assert!(
+                !known_sweep_clears_loading(held),
+                "{held:?} must not flash ok when rediscovery repeats a catalogued sweep"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Why

#44 restarts discovery when a live iterator sits quiet for 90 seconds. When NOAA has a newer volume, that is the fix. When the station is actually silent and the last volume is still listed, rediscovery replayed that same sweep: `arrived` set `ok`, the next cleanup tick aged it back to `unavailable`, and anyone following the newest frame got the old scan again.

Backfill already skips catalogued `start_ms`. The live replay path did not.

## What

- Skip a catalogued `start_ms` on rediscovery and on a respawned poller (cleanup / reselect).
- The first join after `select_site` can still publish, so `loading` clears.
- `arrived` ignores a sweep already on the timeline unless status is still `loading`, so UNAVAILABLE does not flash LIVE.
- A newer volume still clears UNAVAILABLE / OFFLINE.

Closes #49.

Thanks @mrcobas — this leftover is the one you called out on #44 (a rediscovery that only finds a scan we already have should not republish it).

## Test plan

- [x] `cargo test --bin omastorm-engine` (39 passed), including `a_catalogued_replay_is_skipped_after_the_first_join` and `a_known_sweep_does_not_clear_unavailable`
- [x] `cargo clippy --bin omastorm-engine -- -D warnings`
- [ ] Silent station that still lists its last volume stays UNAVAILABLE (no LIVE flash, no follower republish)
- [ ] A station that actually has a newer volume still recovers, as #44