### PR TITLE
Follow a GPS receiver when gpsd = true

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -81,6 +81,15 @@ selected radar" when that radar's coverage is outside the view. UI navigation
 and unlocking can change the active session; explicit config applies again
 on launch.
 
+A GPS receiver is a map centre that moves on its own. With `gpsd = true`,
+each fix from the local gpsd that has moved more than 100 m becomes the
+centre, and the radar follows it by the same nearest-with-hysteresis
+hand-off a pan gets; the chip reads `FOLLOWING · GPS`. A lock still holds
+the radar while the map follows. The fix is remembered like any centre, so
+a relaunch opens where the receiver last was, and a lost fix moves
+nothing. Nothing is drawn at the fix: a position marker is its own
+decision, against the overlay's collision layout.
+
 A station with no frame yet is the map without radar. Show no loading animation.
 Display one radar station’s sweep at a time.
 

--- a/README.md
+++ b/README.md
@@ -120,12 +120,15 @@ Explicit center coordinates win on every launch. Without them, Omastorm
 restores your last view, then falls back to the weather location or location
 picker. Radar selection is independent: a configured lock wins, otherwise a
 remembered lock is restored, otherwise the nearest radar follows the map.
+With a GPS receiver on a running `gpsd`, `gpsd = true` makes the map follow
+the receiver instead, handing the radar off as you drive.
 
 ```toml
 # Optional: always open here. Omit both to remember the last map position.
 center_lat = 36.23708
 center_lon = -79.97948
 # locked_radar = "KFCX" # optional radar override; coordinates do not imply a lock
+# gpsd = true           # optional: follow a GPS receiver on the local gpsd
 
 treatment = "GLYPHS" # PIXELS, GLYPHS, or STIPPLE at launch
 weak_floor = 5       # dBZ; false draws every measured return

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,6 +60,10 @@ center_lon = -79.97948
 # Omit to restore the UI lock, or select automatically when no lock is remembered.
 # locked_radar = "KFCX"
 
+# Optional: follow a GPS receiver on the local gpsd. The map centre tracks the
+# fix and the radar hands off as you drive; a lock still holds.
+# gpsd = true
+
 treatment = "GLYPHS" # PIXELS, GLYPHS, or STIPPLE at launch; Glyphs when omitted
 weak_floor = 5       # dBZ; false draws every measured return
 
@@ -81,6 +85,16 @@ zoom_in = "+ ="
   the map. Unlocking in the UI affects the session and remembered lock;
   config applies again on launch. Remove this setting and unlock in the UI
   to keep automatic selection across launches.
+- `gpsd`: `true` relays the local gpsd through `gpspipe -w` (part of the
+  gpsd package). While a receiver has a 2D-or-better fix, each fix that has
+  moved more than 100 m becomes the map centre — the source reads `gps`,
+  the chip `FOLLOWING · GPS` — and the engine's ordinary hand-off picks
+  the nearest radar, with its own hysteresis, exactly as a pan would. A
+  lock holds the radar while the map keeps following. The remembered view
+  is written like any other centre, so the last fix is where a relaunch
+  opens. A lost fix leaves the view where the receiver last was; gpsd not
+  answering is retried every five seconds while the key is on. Off when
+  omitted.
 
 A Jacksonville map center with `locked_radar = "KFCX"` is valid. Honor both
 settings even when the sweep is outside the view. Show the selected station

--- a/scripts/check-gps.sh
+++ b/scripts/check-gps.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# gpsd follow (DESIGN.md, gpsd follow as built) in the real window against
+# the fixture daemon: with `gpsd = true` a stand-in `gpspipe` on PATH
+# streams gpsd JSON, and the map follows each fix — a Dallas fix centres
+# the map there, names GPS as the source and hands the radar off to KFWS;
+# a fix in Oklahoma City hands off to KTLX; a parked receiver's jitter
+# moves nothing; a lock holds the radar while the map still follows; a
+# lost fix leaves the view where it was. Run through check.sh's window
+# lane, whose scratch daemon it leaves on KTLX.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+check_dir="$PWD/target/check-gps"
+mkdir -p "$check_dir/bin"
+# The stand-in replays whatever fixes.txt holds, one line a second, then
+# waits, so the check drives the position by appending to the file.
+cat > "$check_dir/bin/gpspipe" <<EOF
+#!/bin/sh
+while :; do
+  if [ -s "$check_dir/fixes.txt" ]; then
+    while IFS= read -r line; do printf '%s\n' "\$line"; sleep 1; done < "$check_dir/fixes.txt"
+    : > "$check_dir/fixes.txt"
+  fi
+  sleep .5
+done
+EOF
+chmod +x "$check_dir/bin/gpspipe"
+: > "$check_dir/fixes.txt"
+rm -f "$check_dir/state.json"
+printf '{\n  "name": "Stokesdale",\n  "latitude": 36.23708,\n  "longitude": -79.97948\n}\n' > "$check_dir/weather.json"
+printf 'gpsd = true\n' > "$check_dir/config.toml"
+export QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME=basic QT_QUICK_BACKEND=rhi QSG_RHI_BACKEND=opengl
+PATH="$check_dir/bin:$PATH" OMASTORM_CONFIG="$check_dir/config.toml" OMASTORM_LOCATION="$check_dir/weather.json" OMASTORM_STATE="$check_dir/state.json" bash run.sh > "$check_dir/log" 2>&1 &
+pid=$!
+trap 'kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true' EXIT
+call() { quickshell ipc --pid "$pid" call keys "$@"; }
+field() { call field "$1"; }
+fail() { printf '%s\n' "$@" >&2; cat "$check_dir/log" >&2; exit 1; }
+expect() { [[ "$3" == "$2" ]] || fail "$1" "Expected: $2" "Actual:   $3"; }
+near() { awk -v a="$1" -v b="$2" 'BEGIN { d = a - b; exit !(d < .002 && d > -.002) }'; }
+until_field() { # name, wanted
+  for attempt in {1..150}; do [[ $(field "$1") == "$2" ]] && return; sleep .1; done
+  fail "$1 never became $2: $(call status)"
+}
+fix() { printf '{"class":"TPV","mode":3,"lat":%s,"lon":%s}\n' "$1" "$2" >> "$check_dir/fixes.txt"; }
+for attempt in {1..100}; do call status > /dev/null 2>&1 && break; sleep .1; done
+call status > /dev/null || fail "The window's keys IPC never answered"
+
+# No fix yet: the weather location places the view, as without gpsd.
+until_field locationSource weather
+until_field site KFCX
+
+# A Dallas fix: the map centres on it, GPS is the source, KFWS takes over.
+fix 32.99 -96.60
+until_field locationSource gps
+until_field site KFWS
+near "$(field lat)" 32.99 && near "$(field lon)" -96.60 || fail "The map did not centre on the fix: $(field lat) $(field lon)"
+
+# Driving to Oklahoma City hands off to KTLX.
+fix 35.47 -97.33
+until_field site KTLX
+near "$(field lat)" 35.47 || fail "The map did not follow to Oklahoma City: $(field lat)"
+
+# A parked receiver's jitter (well under 100 m) moves nothing.
+fix 35.4703 -97.3302
+sleep 2
+expect 'Jitter left the centre alone' "$(field lat)" "35.47"
+
+# A lock holds the radar while the map keeps following.
+call run lock
+until_field locked true
+fix 33.00 -96.60
+sleep 3
+expect 'The lock held KTLX through a Dallas fix' KTLX "$(field site)"
+near "$(field lat)" 33.00 || fail "The map stopped following under a lock: $(field lat)"
+call run lock
+until_field locked false
+until_field site KFWS
+
+# Losing the fix leaves the view where the receiver last was.
+printf '{"class":"TPV","mode":1}\n' >> "$check_dir/fixes.txt"
+sleep 3
+near "$(field lat)" 33.00 || fail "A lost fix moved the map: $(field lat)"
+
+if rg -q 'TypeError|ReferenceError|Unable to assign|is not a function' "$check_dir/log"; then fail "QML errors in the log"; fi
+echo "GPS_PASSED"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -92,8 +92,8 @@ if step build bash scripts/cargo.sh test --offline --locked --no-run; then
   # OMASTORM_ARCHIVE names the volume (a shipped daemon starts with no frame).
   export OMASTORM_ARCHIVE="$PWD/data/raw/KTLX20130520_201643_V06.gz"
   tests & lanes+=($!)
-  # check-picker and check-keys select stations for real, so they run last.
-  lane window check-engine-ui check-map-sites check-map-network check-location check-picker check-keys & lanes+=($!)
+  # check-picker, check-keys and check-gps select stations for real, so they run last.
+  lane window check-engine-ui check-map-sites check-map-network check-location check-picker check-keys check-gps & lanes+=($!)
   lane alone check-bind check-link-plugin check-launcher check-theme check-map-tiles check-engine-install check-engine-release check-popover & lanes+=($!)
   for pid in "${lanes[@]}"; do wait "$pid" || failed=1; done
   lanes=()

--- a/ui/Config.qml
+++ b/ui/Config.qml
@@ -40,6 +40,31 @@ QtObject {
     // { name, lat, lon } from weather.json, or null when the file is
     // missing, unreadable, or has no coordinates.
     property var location: null
+    // The live fix from gpsd while `gpsd = true` and a receiver has one
+    // (DESIGN.md, gpsd follow as built), or null. gpspipe -w relays gpsd's
+    // JSON stream; a TPV with a 2D-or-better fix is a position, mode 1 is
+    // a receiver with none. The relay exits when gpsd is not answering and
+    // comes back every five seconds until it is, or until the key is off.
+    readonly property bool gpsd: values.gpsd === true
+    property var fix: null
+    property Process gps: Process {
+        running: root.gpsd
+        command: ["gpspipe", "-w"]
+        stdout: SplitParser {
+            onRead: line => {
+                try {
+                    var msg = JSON.parse(line);
+                    if (msg.class !== "TPV") return;
+                    var lat = Number(msg.lat), lon = Number(msg.lon);
+                    if (msg.mode >= 2 && isFinite(lat) && isFinite(lon)) root.fix = { lat: lat, lon: lon };
+                    else if (msg.mode !== undefined && msg.mode < 2) root.fix = null;
+                } catch (e) {}
+            }
+        }
+        onExited: { root.fix = null; if (root.gpsd) gpsRetry.restart(); }
+    }
+    property Timer gpsRetry: Timer { interval: 5000; onTriggered: if (root.gpsd && !root.gps.running) root.gps.running = true }
+    onGpsdChanged: { if (!gpsd) { gps.running = false; fix = null; } }
     property FileView file: FileView {
         path: root.path
         watchChanges: true

--- a/ui/PluginSession.qml
+++ b/ui/PluginSession.qml
@@ -221,6 +221,29 @@ QtObject {
             engine.send({type: "select_site", id: id});
     }
 
+    // A GPS fix (DESIGN.md, gpsd follow as built) is a view centre that
+    // moves on its own: the map goes to it, and the engine's ordinary
+    // hand-off — nearest radar to the centre, with its own hysteresis —
+    // picks the station, exactly as a pan would. A lock still holds: the
+    // chaser who pinned a radar keeps it while the map follows the car. The
+    // receiver's jitter while parked is under 100 m; nothing moves for it.
+    property var appliedFix: null
+    function followFix(fix) {
+        if (!fix) { appliedFix = null; return; }
+        if (appliedFix && Location.distanceKm(fix.lat, fix.lon, appliedFix.lat, appliedFix.lon) < 0.1) return;
+        appliedFix = fix;
+        placeName = "GPS";
+        locationSource = "gps";
+        needsLocation = false;
+        pendingLocationPicker = false;
+        centerLat = fix.lat;
+        centerLon = fix.lon;
+        hasView = true;
+        persist();
+        viewChanged();
+        applyRadar();
+    }
+
     function applyRadar() {
         if (!engine.state || !ready) return;
         if (needsLocation) return;
@@ -242,6 +265,8 @@ QtObject {
         resolve();
         applyRadar();
         persist();
+        // A receiver that had a fix before the engine answered.
+        if (config.fix) followFix(config.fix);
     }
 
     function applyTreatment() {
@@ -263,6 +288,7 @@ QtObject {
         function onReadyChanged() { session.resolve(); session.initialize(); }
         function onValuesChanged() { if (session.initialized) { session.resolve(); session.applyRadar(); } }
         function onLocationChanged() { if (!session.hasView) session.resolve(); if (session.initialized) session.applyRadar(); }
+        function onFixChanged() { if (session.initialized) session.followFix(session.config.fix); }
         function onTreatmentChanged() { session.applyTreatment(); }
         function onWeakFloorChanged() { session.applyTreatment(); }
     }

--- a/ui/RadarWindow.qml
+++ b/ui/RadarWindow.qml
@@ -460,7 +460,8 @@ Item {
                     readonly property color ink: app.locked ? app.theme.accent : Qt.alpha(app.theme.foreground, .55)
                     Glyph { glyph: app.locked ? "lock" : "follow"; ink: siteChip.ink }
                     LabelText {
-                        text: app.locked && app.outsideCoverage ? "LOCKED · OUTSIDE COVERAGE" : app.locked ? "LOCKED" : "FOLLOWING"
+                        text: app.locked && app.outsideCoverage ? "LOCKED · OUTSIDE COVERAGE" : app.locked ? "LOCKED"
+                            : app.store.locationSource === "gps" ? "FOLLOWING · GPS" : "FOLLOWING"
                         visible: !win.compact; color: siteChip.ink; font.pixelSize: 10; font.letterSpacing: 1
                     }
                 }


### PR DESCRIPTION
A GPS receiver is a map centre that moves on its own. This adds one config
key for that and nothing else:

```toml
gpsd = true   # follow a GPS receiver on the local gpsd
```

Rebased onto v0.1.6's location model, and it got simpler for it:

- `Config.qml` relays the local gpsd through `gpspipe -w` (ships with gpsd).
  A TPV with a 2D-or-better fix becomes `config.fix`; mode 1 clears it.
- `PluginSession.followFix()` makes each fix that has moved more than 100 m
  the session's centre — the same path a pan or the location picker takes
  (`persist`, `viewChanged`, `applyRadar`). The engine's ordinary hand-off
  then picks the nearest radar **with its own hysteresis**, so there is no
  client-side rule to keep in step; the previous version of this PR carried
  one, and it is gone.
- A lock still holds: the chaser who pinned a radar keeps it while the map
  follows the car. The 100 m floor keeps a parked receiver's jitter from
  moving anything.
- The fix is remembered like any centre, so a relaunch opens where the
  receiver last was. A lost fix moves nothing. gpsd not answering is retried
  every five seconds while the key is on. Off when omitted — nothing changes
  for anyone who does not set it.
- The chip reads `FOLLOWING · GPS`; `locationSource` reads `gps` over IPC.
- Deliberately **no marker** at the fix. A dot at the position deserves its
  own decision against the overlay's collision layout; noted in DESIGN.md.

`scripts/check-gps.sh` puts a stand-in `gpspipe` on PATH that replays a
fixes file, in the shape of check-keys' stand-in: the weather location
places the view; a Dallas fix centres the map, names GPS, hands off to
KFWS; Oklahoma City hands off to KTLX; parked jitter moves nothing; a lock
holds KTLX through a Dallas fix while the map still follows; a lost fix
leaves the view where it was. It runs in `check.sh`'s window lane. Docs:
configuration.md, README, DESIGN.md's location section.

`scripts/check.sh` on Omarchy (Arch): everything green except `check-bind`,
which fails the same way on a clean `main` (README no longer names the
`omarchy plugin add` line it asserts) — not from this branch.

Context: the "where the machine is" half of
[omarchy-chase](https://github.com/joshuaswarren/omarchy-chase) step 2, one
GPS source for every viewer; HookEcho's half is d4vid87/hookecho#322
(merged). No viewer is named in this PR.
