### PR TITLE
Export the view on screen in state.json

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,17 +126,29 @@ the machine's own state and weather files are not read unless
   reported the same way. `home_site` and `follow` are unused and named if
   present.
 
-## Remembered state
+## Remembered state and view export
 
 `~/.local/state/omastorm/state.json` is written atomically (a temporary file
-renamed into place). It holds the last map centre, span in kilometres, and
-the UI radar lock when one is set:
+renamed into place). It holds the last map centre, span in kilometres, the UI
+radar lock when one is set, and what is on screen right now:
 
 ```json
-{"lat":30.332,"lon":-81.656,"span":210,"lock":"KJAX","name":"Jacksonville"}
+{"lat":30.332,"lon":-81.656,"span":210,"lock":"KJAX","name":"Jacksonville",
+ "site":"KJAX","scan":"2026-09-10T18:42:11Z","live":true}
 ```
 
-Invalid fields are dropped. A missing file is no remembered view.
-`OMASTORM_LOCATION` names another weather.json (`name`, `latitude`,
-`longitude`, written by the shell's weather panel) for checks; coordinates
-outside ±90/±180 are ignored.
+- `lat`, `lon`, `span`, `lock`, `name`: the remembered view, read back at
+  launch (above). Invalid fields are dropped; a missing file is no remembered
+  view.
+- `site`, `scan`, `live`: the **view export** — the station shown, the
+  RFC 3339 scan time of the frame on screen, and whether that frame is the
+  live head (`false` while stepped back or on an archived scan). Written
+  400 ms after the view, the station, or the frame settles, so the file
+  says what Omastorm is showing now, window open or not. They are for other
+  programs to read — a hand-off to a fuller viewer builds its own deep link
+  from them — and launch never reads them back. Omastorm names no such
+  program and opens none. Absent until the engine has a station.
+
+`OMASTORM_STATE` names another state file for checks. `OMASTORM_LOCATION`
+names another weather.json (`name`, `latitude`, `longitude`, written by the
+shell's weather panel) for checks; coordinates outside ±90/±180 are ignored.

--- a/scripts/check-export.sh
+++ b/scripts/check-export.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# The view export (docs/configuration.md, remembered state and view
+# export) in the real window against the fixture daemon: state.json names
+# the station on screen with the frame's scan time and whether it is the
+# live head; stepping back flips `live` to false and moves `scan` to that
+# frame; jumping to the newest sets it true again. Run through check.sh's
+# window lane.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+check_dir="$PWD/target/check-export"
+mkdir -p "$check_dir"
+rm -f "$check_dir/state.json"
+printf '{\n  "name": "Stokesdale",\n  "latitude": 36.23708,\n  "longitude": -79.97948\n}\n' > "$check_dir/weather.json"
+: > "$check_dir/config.toml"
+export QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME=basic QT_QUICK_BACKEND=rhi QSG_RHI_BACKEND=opengl
+OMASTORM_CONFIG="$check_dir/config.toml" OMASTORM_LOCATION="$check_dir/weather.json" OMASTORM_STATE="$check_dir/state.json" bash run.sh > "$check_dir/log" 2>&1 &
+pid=$!
+trap 'kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true' EXIT
+call() { quickshell ipc --pid "$pid" call keys "$@"; }
+field() { call field "$1"; }
+fail() { printf '%s\n' "$@" >&2; cat "$check_dir/log" >&2; exit 1; }
+expect() { [[ "$3" == "$2" ]] || fail "$1" "Expected: $2" "Actual:   $3"; }
+# `//` would swallow a JSON false, which is the value this check is after.
+exported() { jq -r --arg k "$1" 'if has($k) then (.[$k] | tostring) else empty end' "$check_dir/state.json" 2>/dev/null; }
+# The station the weather location picks is a live one, so stepping to an
+# older frame waits on a real fetch: allow it the time.
+until_export() { # field, wanted
+  for attempt in {1..400}; do [[ $(exported "$1") == "$2" ]] && return; sleep .1; done
+  fail "state.json $1 never became $2" "$(cat "$check_dir/state.json" 2>/dev/null || echo '(no file)')"
+}
+until_field() { # name, wanted
+  for attempt in {1..150}; do [[ $(field "$1") == "$2" ]] && return; sleep .1; done
+  fail "$1 never became $2: $(call status)"
+}
+for attempt in {1..100}; do call status > /dev/null 2>&1 && break; sleep .1; done
+call status > /dev/null || fail "The window's keys IPC never answered"
+
+# The weather location places the view and the nearest station follows;
+# the fixture daemon serves its archive as a live source, so the newest
+# frame is the head: the export names that station, the scan, and live.
+for attempt in {1..150}; do [[ -n $(field site) ]] && break; sleep .1; done
+site=$(field site)
+[[ -n $site ]] || fail "No station ever showed: $(call status)"
+call run newest
+until_export site "$site"
+until_export live true
+head=$(exported scan)
+[[ $head =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || fail "The exported scan is not an RFC 3339 instant: $head"
+
+# Stepping to the oldest frame: not the head, and the scan is that frame's.
+call run oldest
+until_export live false
+older=$(exported scan)
+[[ -n $older && $older != "$head" ]] || fail "The oldest frame's scan did not travel: head $head, now $older"
+
+# Back to the newest: the head again — the same scan, or a newer one if
+# the live station delivered a sweep meanwhile.
+call run newest
+until_export live true
+[[ $(exported scan) > $head || $(exported scan) == "$head" ]] || fail "The head scan went backwards: head $head, now $(exported scan)"
+
+if rg -q 'TypeError|ReferenceError|Unable to assign|is not a function' "$check_dir/log"; then fail "QML errors in the log"; fi
+echo "EXPORT_PASSED"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -93,7 +93,7 @@ if step build bash scripts/cargo.sh test --offline --locked --no-run; then
   export OMASTORM_ARCHIVE="$PWD/data/raw/KTLX20130520_201643_V06.gz"
   tests & lanes+=($!)
   # check-picker and check-keys select stations for real, so they run last.
-  lane window check-engine-ui check-map-sites check-map-network check-location check-picker check-keys & lanes+=($!)
+  lane window check-engine-ui check-map-sites check-map-network check-location check-export check-picker check-keys & lanes+=($!)
   lane alone check-bind check-link-plugin check-launcher check-theme check-map-tiles check-engine-install check-engine-release check-popover & lanes+=($!)
   for pid in "${lanes[@]}"; do wait "$pid" || failed=1; done
   lanes=()

--- a/ui/Location.js
+++ b/ui/Location.js
@@ -121,12 +121,19 @@ function parseState(raw) {
     } catch (e) { return empty; }
 }
 
-function stateObject(viewLat, viewLon, span, lock, name) {
+// The remembered view, plus what is on screen right now (docs/configuration.md,
+// remembered state and view export): `site` is the station shown, `scan` the
+// frame's RFC 3339 time, `live` whether that frame is the live head. Those
+// three are for other programs to read; launch never reads them back.
+function stateObject(viewLat, viewLon, span, lock, name, site, scan, live) {
     var o = {};
     if (validPair(viewLat, viewLon)) { o.lat = viewLat; o.lon = viewLon; }
     if (typeof span === "number" && isFinite(span) && span > 0) o.span = span;
     if (lock) o.lock = lock;
     if (name) o.name = name;
+    if (site) o.site = site;
+    if (scan) o.scan = scan;
+    if (site) o.live = live === true;
     return o;
 }
 

--- a/ui/PluginSession.qml
+++ b/ui/PluginSession.qml
@@ -116,9 +116,22 @@ QtObject {
         }
     }
 
+    // What the engine shows now, for the view export (docs/configuration.md):
+    // the station, the frame's scan time, and whether that frame is the
+    // live head — the newest of a live timeline.
+    readonly property string shownSite: engine.state ? engine.state.site.id : ""
+    readonly property string shownScan: engine.state && engine.state.frame ? engine.state.frame.scanTime || "" : ""
+    readonly property bool shownLive: {
+        if (!engine.state || !engine.state.frame || engine.state.source !== "live") return false;
+        var t = engine.state.timeline || [];
+        return t.length > 0 && t[t.length - 1].id === engine.state.frame.id;
+    }
+    readonly property string shownKey: shownSite + "|" + shownScan + "|" + shownLive
+    onShownKeyChanged: if (initialized && hasView) persistTimer.restart()
+
     function persist() {
         if (!hasView) return;
-        remembered.snapshot(centerLat, centerLon, span, lockWanted ? lockId : "", placeName);
+        remembered.snapshot(centerLat, centerLon, span, lockWanted ? lockId : "", placeName, shownSite, shownScan, shownLive);
     }
 
     function rememberView(lat, lon, spanKm) {

--- a/ui/Remembered.qml
+++ b/ui/Remembered.qml
@@ -29,8 +29,8 @@ QtObject {
         onLoaded: { root.parsed = Location.parseState(text()); root.stateRead = true; }
         onLoadFailed: { root.parsed = Location.parseState(""); root.stateRead = true; }
     }
-    function snapshot(viewLat, viewLon, span, lock, name) {
-        var text = JSON.stringify(Location.stateObject(viewLat, viewLon, span, lock, name));
+    function snapshot(viewLat, viewLon, span, lock, name, site, scan, live) {
+        var text = JSON.stringify(Location.stateObject(viewLat, viewLon, span, lock, name, site, scan, live));
         parsed = Location.parseState(text);
         if (!path) return;
         var slash = path.lastIndexOf("/");


### PR DESCRIPTION
The generic half of what #17 was after, in the shape you proposed there:
Omastorm exposes the view it is showing; whoever wants to hand it to
another viewer does that from outside. Omastorm names no program and
opens none.

`$XDG_STATE_HOME/omastorm/state.json` already carried the view — `lat`,
`lon`, `span`, `lock`, `name` — 400 ms after any move, window open or not.
Two things a hand-off needs were missing, so this adds three fields:

```json
{"lat":30.332,"lon":-81.656,"span":210,"lock":"KJAX","name":"Jacksonville",
 "site":"KJAX","scan":"2026-09-10T18:42:11Z","live":true}
```

- `site` — the station shown. `lock` only names one while locked; when
  following, the file had no station at all.
- `scan` — the RFC 3339 scan time of the frame on screen. Always present
  once the engine has a station.
- `live` — whether that frame is the live head (the newest of a live
  timeline). `false` while stepped back or on an archived scan. A deep
  link built from the file carries the time only when this is false, so
  a live view opens live elsewhere and a stepped-back one opens on that
  scan.

They are written when the view, the station, or the frame settles (the
same 400 ms timer), and launch never reads them back — `parseState` is
untouched. `docs/configuration.md`'s remembered-state section becomes
"Remembered state and view export" and documents the contract as read-only
for other programs.

`scripts/check-export.sh` asserts the file against the real window:
the station on screen with `live` true and an RFC 3339 `scan`; `oldest`
flips `live` to false with that frame's own scan; `newest` restores the
head (or a newer sweep, since the station is live). It runs in `check.sh`'s
window lane.

`scripts/check.sh` on Omarchy (Arch): everything green except `check-bind`,
which fails identically on a clean `main` (README no longer names the
`omarchy plugin add` line it asserts). `check-popover` flaked once under the
parallel lanes on a timing assertion and passes 2/2 alone; not from this
branch.

The consumer exists already: `chase-open` in
[omarchy-chase](https://github.com/joshuaswarren/omarchy-chase) reads this
file and builds HookEcho's `hookecho://goto/` link from it — bound to a
key or pressed in the chase panel, never from inside Omastorm. Zoom is
derived from `span` and a nominal viewport, best-effort ground scale;
`span` stays the viewer-neutral quantity in the export.

Supersedes #17.
