### PR TITLE
Bump jdx/mise-action to v4.3.0 for the Node 24 runtime

### DIFF
--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential cmake pkg-config binutils socat
-      - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |


### PR DESCRIPTION
Both native Engine builds jobs warn that `jdx/mise-action` targets Node 20 and is being forced onto Node 24 ([latest main run](https://github.com/wesleygrimes/omastorm/actions/runs/34542158362)).

This pins the action to v4.3.0 (`c2a87611a18de5b3828c5652fe268e992400cb5c`), which runs on Node 24. The v4.0.0 release notes list the runtime as the only breaking change, and this workflow passes the action no inputs, so mise installs and runs the same toolchain as before. The pin stays a full commit SHA.

On my fork ([run](https://github.com/shieldsworks/omastorm/actions/runs/34560435668)) both native jobs pass with no Node 20 annotation. I didn't run `mise check` locally, since it doesn't exercise this workflow; the run above covers the workflow's own `mise lint` and `mise test` steps.

Closes #41.
