### PR TITLE
Move map-check harnesses out of the plugin tree

### DIFF
--- a/scripts/capture-harness.sh
+++ b/scripts/capture-harness.sh
@@ -6,8 +6,8 @@
 # shell's path for OMASTORM_QML.
 set -euo pipefail
 cd "$(dirname "$0")/.."
-harness="$PWD/target/capture-harness"
-mkdir -p "$harness"
+# Harness outside the checkout: Omarchy rejects a shaders symlink in the plugin folder.
+harness=$(mktemp -d /tmp/omastorm-capture-harness.XXXXXX)
 cp ui/shell.qml ui/RadarWindow.qml ui/RadarMark.qml ui/RadarMap.qml ui/SitePicker.qml ui/Sites.js ui/KeysSheet.qml ui/Keys.js ui/Timeline.js ui/Theme.qml ui/Config.qml ui/Toml.js ui/Location.js ui/LocationPicker.qml ui/Remembered.qml ui/PluginSession.qml ui/qmldir "$harness/"
 ln -sfn "$PWD/ui/shaders" "$harness/shaders"
 perl -pe 's/^(\s+)state = message;$/$1var override = JSON.parse(Quickshell.env("OMASTORM_STATE_OVERRIDE") || "{}");\n$1for (var key in override) message[key] = override[key] && typeof override[key] === "object" && !Array.isArray(override[key]) && message[key] ? Object.assign(message[key], override[key]) : override[key];\n$1state = message;/' ui/Engine.qml > "$harness/Engine.qml"

--- a/scripts/capture-states.sh
+++ b/scripts/capture-states.sh
@@ -25,6 +25,8 @@ rm -f "$review"/states-*.png
 # real cache; ensure in run.sh finds them by build under XDG_RUNTIME_DIR.
 # The windows read a scratch config.toml naming the station, or none.
 scratch=$(mktemp -d /tmp/omastorm-states.XXXXXX)
+harness_dir=
+trap 'rm -rf "$scratch" ${harness_dir:+"$harness_dir"}' EXIT
 mkdir -p "$scratch/offline" "$scratch/silent" "$scratch/cache"
 config_for() { # station id, or nothing for no configured radar
   local file="$scratch/config-${1:-none}.toml"
@@ -66,6 +68,7 @@ jobs -p | xargs -r kill 2>/dev/null || true
 # The harness shell (scripts/capture-harness.sh): the real UI files with
 # OMASTORM_STATE_OVERRIDE laid over every state.
 harness=$(bash scripts/capture-harness.sh)
+harness_dir=$(dirname "$harness")
 synthetic() { # name, override
   capture "$1" 6000 OMASTORM_QML="$harness" OMASTORM_CONFIG="$(config_for "$site")" OMASTORM_STATE_OVERRIDE="$2"
 }

--- a/scripts/check-map-network.sh
+++ b/scripts/check-map-network.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 cd "$(dirname "$0")/.."
-check_dir="$PWD/target/check-map-network"
-mkdir -p "$check_dir" review
+# Harness outside the checkout: Omarchy rejects a shaders symlink in the plugin folder.
+check_dir=$(mktemp -d /tmp/omastorm-check-map-network.XXXXXX)
+trap 'rm -rf "$check_dir"' EXIT
+mkdir -p review
 rm -f review/network-*.png
 cp ui/RadarMap.qml ui/Engine.qml "$check_dir/"
 cp tests/map-network.qml "$check_dir/shell.qml"

--- a/scripts/check-map-sites.sh
+++ b/scripts/check-map-sites.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 cd "$(dirname "$0")/.."
-check_dir="$PWD/target/check-map-sites"
-mkdir -p "$check_dir" review
+# Harness outside the checkout: Omarchy rejects a shaders symlink in the plugin folder.
+check_dir=$(mktemp -d /tmp/omastorm-check-map-sites.XXXXXX)
+trap 'rm -rf "$check_dir"' EXIT
+mkdir -p review
 rm -f review/site-overlay.png
 cp ui/RadarMap.qml ui/Engine.qml "$check_dir/"
 # Expose the real delegate only in the harness, to check its scene transform.

--- a/scripts/check-map-tiles.sh
+++ b/scripts/check-map-tiles.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 cd "$(dirname "$0")/.."
-check_dir="$PWD/target/check-map-tiles"
-mkdir -p "$check_dir" review
+# Harness outside the checkout: Omarchy rejects a shaders symlink in the plugin folder.
+check_dir=$(mktemp -d /tmp/omastorm-check-map-tiles.XXXXXX)
+trap 'rm -rf "$check_dir"' EXIT
+mkdir -p review
 rm -f review/zoom-held-before.png review/zoom-held-partial.png review/zoom-ready.png
 cp ui/RadarMap.qml "$check_dir/"
 cp tests/map-tiles.qml "$check_dir/shell.qml"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Omarchy's `plugin update` refuses a folder that contains a symlink. A user hit:

```
Symlinks not allowed inside plugin folder. Target/check-map-tiles/shaders
```

That path is created by `scripts/check-map-tiles.sh` (`ln -sfn "$PWD/ui/shaders" "$check_dir/shaders"`). `target/` is gitignored, so a clean clone updates fine — but running the map checks inside a live plugin checkout (`~/.config/omarchy/plugins/com.omastorm.radar`) leaves the symlink behind.

This moves the harnesses that create that shaders symlink to `mktemp -d /tmp/omastorm-…` and removes them on `EXIT`. `review/` PNG outputs stay in `review/`.

- `check-map-tiles.sh`, `check-map-sites.sh`, `check-map-network.sh`: scratch in `/tmp`, trap-clean, same `ln -s` of `ui/shaders` (now outside the plugin tree).
- `capture-harness.sh`: same `/tmp` move (it used `target/capture-harness/shaders`). `capture-states.sh` now removes that harness on exit as well.

Audited the other `check_dir="$PWD/target/check-…"` scripts (`check-engine-ui`, `check-location`, `check-picker`, `check-keys`). They write regular files only, no plugin-tree symlink. `check.sh`'s daemon scratch under `target/check/` is unchanged (that is the suite's log/runtime tree; CONTRIBUTING's "never `/tmp`" note still applies there). `check-link-plugin.sh` still creates a symlink under its own scratch and already trap-cleans it.

The `/tmp` templates are absolute on purpose: `check.sh` sets `TMPDIR` to `target/check/tmp`, and honoring that would put the shaders symlink back under the plugin folder for the duration of `mise check`.

No engine pin or version change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8491bd1-5f08-4b43-ac68-748492237464?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8491bd1-5f08-4b43-ac68-748492237464&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

