### PR TITLE
Drop sudo/pacman hint from mise setup missing-package message

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -16,7 +16,7 @@ need socat socat
 [[ -x ${QSB:-/usr/lib/qt6/bin/qsb} ]] || missing+=(qt6-shadertools)
 if (( ${#missing[@]} )); then
   printf 'Missing desktop packages: %s\n' "${missing[*]}" >&2
-  printf 'Install them, for example: sudo pacman -S --needed %s\n' "${missing[*]}" >&2
+  printf 'Install these packages, then re-run mise setup.\n' >&2
   exit 1
 fi
 command -v magick > /dev/null 2>&1 || echo 'Optional: imagemagick (captures) is not installed.' >&2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Omarchy marketplace issue [omacom/omarchy-plugin-marketplace#5970](https://github.com/omacom/omarchy-plugin-marketplace/issues/5970) flagged `scripts/setup.sh` at commit `090a753` for privilege + package-manager because the missing-package path printed:

```
Install them, for example: sudo pacman -S --needed …
```

That line was only a hint. `setup.sh` never runs `sudo` or `pacman`. Ordinary plugin launch never calls `setup.sh`.

## Change

When quickshell, socat, or qt6-shadertools (`qsb`) are missing, the script still:

1. Prints `Missing desktop packages: …` with the package names
2. Exits 1

The sudo/pacman example is replaced with a plain reminder to install those packages and re-run `mise setup`. No other scripts under `scripts/` printed a sudo/pacman hint without actually invoking a package manager. Install scripts and docs are unchanged.

## Verify

```
QSB=/definitely-not-qsb PATH="/usr/bin:/bin" bash scripts/setup.sh
# Missing desktop packages: quickshell socat qt6-shadertools
# Install these packages, then re-run mise setup.
# exit=1
```

`scripts/setup.sh` contains neither `sudo` nor `pacman`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d14bb0f-e297-4b18-bd7d-b5301d7bc3d1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d14bb0f-e297-4b18-bd7d-b5301d7bc3d1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

