### PR TITLE
Ask before estimating first-run location with wttr.in

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -79,9 +79,10 @@ map center in this order:
 4. The location prompt: use approximate location or choose manually.
 
 When the first three sources have no valid center, show two actions in the
-existing prompt, with no additional dialog. "Use approximate location"
-discloses "Uses your public IP via wttr.in." and runs one bounded `curl` to
-`wttr.in/?format=j2` only on click (UI-side; not an engine command). "Choose
+existing prompt, with no additional dialog. "Use approximate location" runs
+one bounded `curl` to `wttr.in/?format=j2` only on click (UI-side; not an
+engine command); the provider and public-IP use are documented, and a
+successful view is labeled `IP NEAR …`. "Choose
 manually" opens the existing search and coordinates.
 Remember a successful estimate like any chosen view. While it is pending,
 manual selection remains available and takes priority over a late reply.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -76,11 +76,18 @@ map center in this order:
 1. Explicit `center_lat` and `center_lon` in `config.toml`.
 2. The last center remembered in `state.json`.
 3. Valid coordinates from Omarchy's weather location (`weather.json`).
-4. A location chosen through Omastorm's location picker.
+4. The location prompt: use approximate location or choose manually.
 
-Only show onboarding when none of the first three sources supplies a valid
-center. The popover offers "Choose a location", opening the expanded
-window's picker. Offer place search and "Enter coordinates", which reveals
+When the first three sources have no valid center, show two actions in the
+existing prompt, with no additional dialog. "Use approximate location"
+discloses "Uses your public IP via wttr.in." and runs one bounded `curl` to
+`wttr.in/?format=j2` only on click (UI-side; not an engine command). "Choose
+manually" opens the existing search and coordinates.
+Remember a successful estimate like any chosen view. While it is pending,
+manual selection remains available and takes priority over a late reply.
+Failures show a short error and allow an explicit retry. There is no IP
+configuration knob; a click is the opt-in. IP never enables GPS or tracking.
+Offer place search and "Enter coordinates", which reveals
 labeled latitude and longitude fields with validation. Place search is an
 engine `search_places` reply over GeoNames cities with population ≥ 5000
 in the network envelope (state/region and country so two Jacksonvilles are
@@ -92,9 +99,10 @@ radar. Choosing a location writes `state.json`, never `config.toml`.
 
 Reuse Omarchy's location when available without requiring its weather plugin.
 Read weather settings only; never write them. Location search is an explicit
-user action handled through the engine. Do not use GeoClue or fetch at launch
-to discover the user's location.
-
+user action handled through the engine. Approximate IP lookup is an explicit
+UI action via wttr.in (`format=j2`, smaller than Omarchy weather's `j1`); the
+launcher and engine perform no IP lookup. Do not use GeoClue. Archived views
+never locate, and checks require the same explicit action as users.
 Resolve the radar separately: an explicit `locked_radar` in config wins,
 otherwise restore a remembered radar lock, otherwise choose the station
 nearest the map center. A radar lock alone does not supply a map center or

--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ sha256 against `engine/release.pin`, and installs it under
 `~/.local/share/omastorm/bin`. Runtime files, cached data, remembered view state, and configuration stay
 inside Omastorm's own directories.
 
-On first use, Omastorm uses your Omarchy weather location when available;
-otherwise it prompts you to search for a place or enter coordinates. To set
+On first use, Omastorm uses your Omarchy weather location when available.
+Otherwise, choose a place manually or click **Use approximate location** to
+estimate your city using your public IP via wttr.in. No IP-location request
+is made before you click. To set
 a fixed launch location, including during agent-assisted installation, see
 [configuration and remembered state](docs/configuration.md).
 
@@ -119,8 +121,7 @@ last map center, zoom, and UI radar lock separately in
 `Shift+H`, or LOCATION, opens the location picker; it writes state, not config.
 
 Explicit center coordinates win on every launch. Without them, Omastorm
-restores your last view, then falls back to the weather location or location
-picker. Radar selection is independent: a configured lock wins, otherwise a
+restores your last view, then falls back to weather or the location prompt. Radar selection is independent: a configured lock wins, otherwise a
 remembered lock is restored, otherwise the nearest radar follows the map.
 
 ```toml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,10 +29,31 @@ Resolve the map center from the first valid source:
 3. Omarchy's weather coordinates in
    `~/.local/state/omarchy/settings/weather.json` (`name`, `latitude`,
    `longitude`). File existence alone is insufficient; coordinates must be valid.
-4. The location picker: search for a place or enter latitude and longitude.
+4. The location prompt: choose manually or use approximate location.
 
-A missing location opens a "Choose a location" prompt in the popover; its
-button opens the expanded window's picker. Accepting a location saves the
+**Use approximate location** runs one `curl` to wttr.in (`?format=j2`) from
+the UI to estimate your city from your public IP. No request happens until
+you click; there is no configuration switch and no engine command. The
+provider receives the connection's public IP. Omastorm never writes Omarchy's
+weather settings. `format=j2` is used because Omarchy weather's `j1` response
+is much larger; both expose `nearest_area`.
+
+The UI remembers a successful view in `state.json`. A reopened app uses that
+view without another lookup. The initial view is labeled `IP NEAR …`;
+coordinates may reflect a VPN or ISP location. Choose manually to correct an
+estimate.
+
+While locating, manual selection remains available. A failed request shows a
+short error and can be retried. Requests time out after ten seconds. Manual
+selection or navigation takes priority over a late response. Archived
+sessions never locate. `OMASTORM_LOCATION_URL` lets tests substitute a local
+URL; isolated checks still need to invoke the explicit action.
+
+IP lookup is a one-time starting position. It never enables GPS or continuous
+camera tracking.
+
+A missing location opens the same choice in the popover and expanded window.
+Choose manually opens the existing search and coordinate fields. Accepting a location saves the
 view in state. Weather-derived initial coordinates are also saved in state.
 Neither route adds coordinate overrides to config. The picker remains
 available through `Shift+H` and LOCATION after onboarding.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -355,7 +355,8 @@ to the engine restores the necessary selection and flags without resetting
 the active camera. A change of frame or station never re-centers the map
 except when the user picks a station in search, which the UI centres on.
 Location picks write state.json. With no location, the popover offers the
-picker instead of inventing a centre.
+prompt if no source supplies a center; approximate IP lookup is a UI `curl` to
+wttr.in after an explicit click, not an engine command.
 
 `hello` additionally includes `pid`, `build` (an opaque fingerprint),
 `sitesSource`, `sitesRetrieved`, and `sitesNotes`. These allow the launcher to

--- a/scripts/capture-demo.sh
+++ b/scripts/capture-demo.sh
@@ -24,7 +24,7 @@ mkdir -p "$XDG_RUNTIME_DIR" "$XDG_CACHE_HOME" "$demo_dir/shaders" "$demo_dir/fra
 jq -r --arg id "$site" '.sites[] | select(.id==$id) | "center_lat = \(.lat)\ncenter_lon = \(.lon)\nlocked_radar = \"\(.id)\""' engine/data/sites.json > "$OMASTORM_CONFIG"
 cleanup() { target/debug/omastorm-engine stop >/dev/null 2>&1 || true; }
 trap cleanup EXIT
-cp ui/Theme.qml ui/Engine.qml ui/RadarMark.qml ui/RadarMap.qml ui/SitePicker.qml ui/Sites.js ui/KeysSheet.qml ui/Keys.js ui/Timeline.js ui/Config.qml ui/Toml.js ui/Location.js ui/LocationPicker.qml ui/Remembered.qml ui/PluginSession.qml ui/qmldir "$demo_dir/"
+cp ui/Theme.qml ui/Engine.qml ui/RadarMark.qml ui/RadarMap.qml ui/SitePicker.qml ui/Sites.js ui/KeysSheet.qml ui/Keys.js ui/Timeline.js ui/Config.qml ui/Toml.js ui/Location.js ui/LocationPicker.qml ui/LocationPrompt.qml ui/Remembered.qml ui/PluginSession.qml ui/qmldir "$demo_dir/"
 cp ui/shaders/*.qsb "$demo_dir/shaders/"
 ruby - "$demo_dir" <<'RUBY'
 dir = ARGV.fetch(0)

--- a/scripts/capture-harness.sh
+++ b/scripts/capture-harness.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 # Harness outside the checkout: Omarchy rejects a shaders symlink in the plugin folder.
 harness=$(mktemp -d /tmp/omastorm-capture-harness.XXXXXX)
-cp ui/shell.qml ui/RadarWindow.qml ui/RadarMark.qml ui/RadarMap.qml ui/SitePicker.qml ui/Sites.js ui/KeysSheet.qml ui/Keys.js ui/Timeline.js ui/Theme.qml ui/Config.qml ui/Toml.js ui/Location.js ui/LocationPicker.qml ui/Remembered.qml ui/PluginSession.qml ui/qmldir "$harness/"
+cp ui/shell.qml ui/RadarWindow.qml ui/RadarMark.qml ui/RadarMap.qml ui/SitePicker.qml ui/Sites.js ui/KeysSheet.qml ui/Keys.js ui/Timeline.js ui/Theme.qml ui/Config.qml ui/Toml.js ui/Location.js ui/LocationPicker.qml ui/LocationPrompt.qml ui/Remembered.qml ui/PluginSession.qml ui/qmldir "$harness/"
 ln -sfn "$PWD/ui/shaders" "$harness/shaders"
 perl -pe 's/^(\s+)state = message;$/$1var override = JSON.parse(Quickshell.env("OMASTORM_STATE_OVERRIDE") || "{}");\n$1for (var key in override) message[key] = override[key] && typeof override[key] === "object" && !Array.isArray(override[key]) && message[key] ? Object.assign(message[key], override[key]) : override[key];\n$1state = message;/' ui/Engine.qml > "$harness/Engine.qml"
 grep -q OMASTORM_STATE_OVERRIDE "$harness/Engine.qml"

--- a/scripts/check-ip-location.sh
+++ b/scripts/check-ip-location.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Consent IP location through the shared session: stub curl, no network,
+# personal configuration, shell bootstrap, or shared daemon.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+scratch=$(mktemp -d /tmp/omastorm-ip-check.XXXXXX)
+trap 'rm -rf "$scratch"' EXIT
+mkdir -p "$scratch/bin" "$scratch/runtime"
+cp -r ui "$scratch/ui"
+sed -i '/Quickshell.execDetached(/c\        return;' "$scratch/ui/PluginSession.qml"
+sed -i 's/connected: true/connected: false/; /running: engine.socket/c\        running: false' "$scratch/ui/Engine.qml"
+
+fixture='{"nearest_area":[{"areaName":[{"value":"Stamford"}],"latitude":"41.05","longitude":"-73.54"}]}'
+printf '%s\n' "$fixture" > "$scratch/ok.json"
+cat > "$scratch/bin/curl" <<EOF
+#!/bin/bash
+echo "\$*" >> "$scratch/curl.log"
+# Last non-flag argument is the URL (OMASTORM_LOCATION_URL or wttr.in).
+url=\${@: -1}
+if [[ \$url == file://* ]]; then
+  cat -- "\${url#file://}"
+else
+  cat -- "$scratch/ok.json"
+fi
+EOF
+chmod +x "$scratch/bin/curl"
+
+cat > "$scratch/ui/Test.qml" <<'QML'
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import "Location.js" as Location
+ShellRoot {
+    id: test
+    Engine {
+        id: fake
+        property var sent: []
+        function send(command) { sent = sent.concat([command]); }
+    }
+    FloatingWindow {
+        visible: true
+        implicitWidth: 308
+        implicitHeight: 260
+        LocationPrompt {
+            id: consent
+            anchors.fill: parent
+            session: PluginSession
+            theme: PluginSession.theme.snapshot
+            onManualChosen: PluginSession.requestLocationPicker()
+        }
+    }
+    property int step: 0
+    function action(name) {
+        for (var child of consent.children)
+            if (child.objectName === name) return child;
+        throw new Error("Missing consent action: " + name);
+    }
+    function assertThat(ok, why) { if (!ok) throw new Error(why); }
+    function fresh(values, saved, weather, source) {
+        var s = PluginSession;
+        if (s.locator.running) s.locator.running = false;
+        fake.state = null;
+        s.initialized = false;
+        s.hasView = false;
+        s.needsLocation = false;
+        s.ipLocationDismissed = true;
+        s.locationPending = false;
+        s.locationError = "";
+        s.appliedExplicit = null;
+        s.config.values = values;
+        s.remembered.parsed = Location.parseState(saved);
+        s.config.location = weather;
+        fake.sent = [];
+        fake.state = {source: source || "live", site: {id: "", locked: false, follow: true}};
+        s.initialize();
+    }
+    function waitSettled(next) {
+        waiter.next = next;
+        waiter.ticks = 0;
+        waiter.start();
+    }
+    Timer {
+        id: waiter
+        property var next
+        property int ticks: 0
+        interval: 20; repeat: true
+        onTriggered: {
+            ticks++;
+            var s = PluginSession;
+            if (s.locationPending && ticks < 100) return;
+            stop();
+            try { next(); } catch (e) { console.error(e); Qt.quit(); }
+        }
+    }
+    Timer {
+        interval: 10; running: true; repeat: true
+        onTriggered: {
+            var s = PluginSession;
+            if (!s.ready) return;
+            stop();
+            try {
+                s.engine = fake;
+                var good = Location.parseWttrHome('{"nearest_area":[{"areaName":[{"value":"Stamford"}],"latitude":"41.05","longitude":"-73.54"}]}');
+                assertThat(good && good.lat === 41.05 && good.name === "Stamford", "parse wttr home");
+                assertThat(Location.parseWttrHome("{}") === null, "reject empty wttr");
+                assertThat(Location.parseWttrHome('{"nearest_area":[{"latitude":"91","longitude":"0"}]}') === null, "reject bad wttr coords");
+
+                fresh({}, "", null);
+                assertThat(!s.locating && s.needsLocation && !s.locationPending, "startup requires consent");
+                s.finishIpLocation(0, '{"nearest_area":[{"areaName":[{"value":"X"}],"latitude":"1","longitude":"2"}]}');
+                assertThat(!s.hasView, "unsolicited finish ignored while dismissed");
+
+                action("approximateLocation").clicked();
+                assertThat(s.locating && s.needsLocation && s.locationPending, "fresh lookup");
+                s.requestIpLocation();
+                assertThat(s.locationPending, "duplicate lookup ignored while pending");
+                waitSettled(afterFirstLookup);
+            } catch (e) { console.error(e); Qt.quit(); }
+        }
+    }
+    function afterFirstLookup() {
+        var s = PluginSession;
+        assertThat(s.hasView && !s.needsLocation && s.locationSource === "ip", "IP view");
+        assertThat(s.centerLat === 41.05 && s.centerLon === -73.54, "IP coordinates");
+        assertThat(s.remembered.lat === 41.05 && s.remembered.lon === -73.54, "remember IP view");
+        assertThat(fake.sent.some(c => c.type === "view_center" && c.lat === 41.05), "nearest radar follows IP center");
+
+        fresh({}, JSON.stringify(s.remembered.parsed), null);
+        assertThat(s.locationSource === "state" && !s.locationPending, "reopen remembered IP without lookup");
+        fresh({center_lat:30, center_lon:-81}, '{"lat":35,"lon":-97}', {lat:36,lon:-79});
+        assertThat(s.locationSource === "config" && s.centerLat === 30, "explicit precedence");
+        fresh({}, '{"lat":35,"lon":-97}', {lat:36,lon:-79});
+        assertThat(s.locationSource === "state" && s.centerLat === 35, "state precedence");
+        fresh({}, "", {lat:36,lon:-79});
+        assertThat(s.locationSource === "weather" && s.centerLat === 36, "weather precedence");
+
+        fresh({locked_radar:"KTLX"}, "", null);
+        s.requestIpLocation();
+        waitSettled(afterLock);
+    }
+    function afterLock() {
+        var s = PluginSession;
+        assertThat(s.lockId === "KTLX" && s.lockWanted && s.centerLat === 41.05, "configured lock independent of IP center");
+
+        fresh({}, "", null);
+        s.requestIpLocation();
+        s.setPlace(30,-81,"Picked");
+        s.finishIpLocation(0, '{"nearest_area":[{"areaName":[{"value":"Late"}],"latitude":"41.05","longitude":"-73.54"}]}');
+        assertThat(s.centerLat === 30 && s.placeName === "Picked", "late reply after picker choice");
+
+        fresh({}, "", null);
+        s.requestIpLocation();
+        s.chooseRadar("KTLX",35,-97,"Radar");
+        s.finishIpLocation(0, '{"nearest_area":[{"areaName":[{"value":"Late"}],"latitude":"41.05","longitude":"-73.54"}]}');
+        assertThat(s.centerLat === 35 && s.lockId === "KTLX", "late reply after radar choice");
+
+        fresh({}, "", null);
+        s.requestIpLocation();
+        s.userNavigated(36,-98,170);
+        s.finishIpLocation(0, '{"nearest_area":[{"areaName":[{"value":"Late"}],"latitude":"41.05","longitude":"-73.54"}]}');
+        assertThat(s.centerLat === 36 && s.span === 170 && !s.needsLocation, "late reply after navigation");
+
+        fresh({}, "", null);
+        s.requestIpLocation();
+        action("manualLocation").clicked();
+        assertThat(s.needsLocation && !s.hasView && !s.locating, "manual picker interrupts lookup");
+
+        fresh({}, "", null);
+        s.locateAttempt += 1;
+        s.activeAttempt = s.locateAttempt;
+        s.ipLocationDismissed = false;
+        s.locationPending = true;
+        s.finishIpLocation(22, "", s.locateAttempt);
+        assertThat(s.needsLocation && !s.locating && !!s.locationError, "failure leaves onboarding available");
+        s.locateAttempt += 1;
+        s.activeAttempt = s.locateAttempt;
+        s.ipLocationDismissed = false;
+        s.locationPending = true;
+        s.locationError = "";
+        s.finishIpLocation(0, '{"nearest_area":[{"areaName":[{"value":"Stamford"}],"latitude":"41.05","longitude":"-73.54"}]}', s.locateAttempt);
+        assertThat(s.hasView && s.locationSource === "ip", "retry accepts successful reply");
+
+        fresh({}, "", null);
+        assertThat(s.needsLocation && !s.locationPending, "no automatic lookup");
+        fresh({}, "", null, "archived");
+        s.requestIpLocation();
+        assertThat(s.needsLocation && !s.locationPending, "archive never locates");
+        assertThat(s.config.parseLocation('{"latitude":null,"longitude":null}') === null, "null weather is not zero");
+        console.log("IP_LOCATION_PASSED");
+        Qt.quit();
+    }
+}
+QML
+
+OMASTORM_CONFIG="$scratch/empty.toml" OMASTORM_STATE="$scratch/state.json" \
+  OMASTORM_LOCATION_URL="file://$scratch/ok.json" \
+  PATH="$scratch/bin:$PATH" \
+  XDG_RUNTIME_DIR="$scratch/runtime" QT_QPA_PLATFORM=offscreen \
+  timeout 20 quickshell -p "$scratch/ui/Test.qml" > "$scratch/log" 2>&1 || { cat "$scratch/log"; exit 1; }
+cat "$scratch/log"
+rg -q IP_LOCATION_PASSED "$scratch/log"
+! rg -q 'ReferenceError|TypeError|Binding loop|Unable to assign' "$scratch/log"

--- a/scripts/check-ip-location.sh
+++ b/scripts/check-ip-location.sh
@@ -104,6 +104,8 @@ ShellRoot {
                 assertThat(good && good.lat === 41.05 && good.name === "Stamford", "parse wttr home");
                 assertThat(Location.parseWttrHome("{}") === null, "reject empty wttr");
                 assertThat(Location.parseWttrHome('{"nearest_area":[{"latitude":"91","longitude":"0"}]}') === null, "reject bad wttr coords");
+                assertThat(Location.parseWttrHome('{"nearest_area":[{"latitude":null,"longitude":null}]}') === null, "reject null wttr coords");
+                assertThat(Location.parseWttrHome('{"nearest_area":[{"latitude":"","longitude":""}]}') === null, "reject blank wttr coords");
 
                 fresh({}, "", null);
                 assertThat(!s.locating && s.needsLocation && !s.locationPending, "startup requires consent");
@@ -179,6 +181,24 @@ ShellRoot {
         s.locationError = "";
         s.finishIpLocation(0, '{"nearest_area":[{"areaName":[{"value":"Stamford"}],"latitude":"41.05","longitude":"-73.54"}]}', s.locateAttempt);
         assertThat(s.hasView && s.locationSource === "ip", "retry accepts successful reply");
+
+        fresh({}, "", null);
+        s.locateAttempt += 1;
+        s.activeAttempt = s.locateAttempt;
+        s.ipLocationDismissed = false;
+        s.locationPending = true;
+        s.config.location = {lat: 36, lon: -79, name: "Stokesdale"};
+        s.finishIpLocation(0, '{"nearest_area":[{"areaName":[{"value":"Late"}],"latitude":"41.05","longitude":"-73.54"}]}', s.locateAttempt);
+        assertThat(s.locationSource === "weather" && s.centerLat === 36 && !s.locationPending, "resolve mid-lookup clears pending");
+
+        fresh({}, "", null);
+        s.locateAttempt += 1;
+        s.activeAttempt = s.locateAttempt;
+        s.ipLocationDismissed = false;
+        s.locationPending = true;
+        fake.state = {source: "archived", site: {id: "", locked: false, follow: true}};
+        s.finishIpLocation(0, '{"nearest_area":[{"areaName":[{"value":"Late"}],"latitude":"41.05","longitude":"-73.54"}]}', s.locateAttempt);
+        assertThat(s.needsLocation && !s.hasView && !s.locationPending, "archive mid-lookup clears pending");
 
         fresh({}, "", null);
         assertThat(s.needsLocation && !s.locationPending, "no automatic lookup");

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -94,7 +94,7 @@ if step build bash scripts/cargo.sh test --offline --locked --no-run; then
   tests & lanes+=($!)
   # check-picker and check-keys select stations for real, so they run last.
   lane window check-engine-ui check-map-sites check-map-network check-location check-picker check-keys & lanes+=($!)
-  lane alone check-bind check-link-plugin check-launcher check-theme check-map-tiles test-engine-pin check-engine-release check-popover & lanes+=($!)
+  lane alone check-ip-location check-bind check-link-plugin check-launcher check-theme check-map-tiles test-engine-pin check-engine-release check-popover & lanes+=($!)
   for pid in "${lanes[@]}"; do wait "$pid" || failed=1; done
   lanes=()
 else

--- a/ui/Config.qml
+++ b/ui/Config.qml
@@ -59,7 +59,8 @@ QtObject {
     function parseLocation(raw) {
         try {
             var json = JSON.parse(raw);
-            var lat = Number(json.latitude), lon = Number(json.longitude);
+            var lat = json.latitude, lon = json.longitude;
+            if (typeof lat !== "number" || typeof lon !== "number") return null;
             if (!isFinite(lat) || !isFinite(lon) || Math.abs(lat) > 90 || Math.abs(lon) > 180) return null;
             return { name: typeof json.name === "string" ? json.name : "", lat: lat, lon: lon };
         } catch (e) { return null; }

--- a/ui/Location.js
+++ b/ui/Location.js
@@ -154,3 +154,26 @@ function resolveReset(explicit, weather) {
         return { lat: weather.lat, lon: weather.lon, name: weather.name || "", source: "weather" };
     return null;
 }
+
+// wttr.in `?format=j2` nearest_area (DESIGN.md, approximate IP location).
+// j2 stays under a small body size; Omarchy's weather `j1` is much larger.
+function parseWttrHome(raw) {
+    try {
+        var json = typeof raw === "string" ? JSON.parse(raw) : raw;
+        var areas = json && json.nearest_area;
+        if (!areas || !areas.length) return null;
+        var area = areas[0];
+        var lat = Number(area.latitude), lon = Number(area.longitude);
+        if (!validPair(lat, lon)) return null;
+        var name = "";
+        var labels = [].concat(area.areaName || [], area.region || []);
+        for (var i = 0; i < labels.length; i++) {
+            var value = labels[i] && labels[i].value;
+            if (typeof value === "string" && value.trim()) {
+                name = value.trim().replace(/[\x00-\x1f\x7f]/g, "").slice(0, 100);
+                break;
+            }
+        }
+        return { name: name, lat: lat, lon: lon };
+    } catch (e) { return null; }
+}

--- a/ui/Location.js
+++ b/ui/Location.js
@@ -157,13 +157,20 @@ function resolveReset(explicit, weather) {
 
 // wttr.in `?format=j2` nearest_area (DESIGN.md, approximate IP location).
 // j2 stays under a small body size; Omarchy's weather `j1` is much larger.
+function parseWttrCoord(value) {
+    // Number(null) and Number("") are 0 — reject those before coercing.
+    if (typeof value === "number") return value;
+    if (typeof value === "string" && value.trim()) return Number(value.trim());
+    return NaN;
+}
+
 function parseWttrHome(raw) {
     try {
         var json = typeof raw === "string" ? JSON.parse(raw) : raw;
         var areas = json && json.nearest_area;
         if (!areas || !areas.length) return null;
         var area = areas[0];
-        var lat = Number(area.latitude), lon = Number(area.longitude);
+        var lat = parseWttrCoord(area.latitude), lon = parseWttrCoord(area.longitude);
         if (!validPair(lat, lon)) return null;
         var name = "";
         var labels = [].concat(area.areaName || [], area.region || []);

--- a/ui/LocationPicker.qml
+++ b/ui/LocationPicker.qml
@@ -10,6 +10,10 @@ Item {
     id: picker
     property var theme
     property var engine
+    property var session: null
+    property bool onboarding: false
+    property bool manual: true
+    signal manualStarted()
     property real centerLat: 0
     property real centerLon: 0
     property bool compact: false
@@ -52,14 +56,17 @@ Item {
         return out;
     }
     visible: open
-    function show(text) {
+    function show(text, offerLocation) {
+        onboarding = offerLocation === true;
+        manual = !onboarding;
+        if (manual) manualStarted();
         field.text = text || "";
         latField.text = "";
         lonField.text = "";
         selected = 0;
         results = [];
         open = true;
-        Qt.callLater(() => { field.cursorPosition = field.length; field.forceActiveFocus(); });
+        Qt.callLater(() => { if (manual) { field.cursorPosition = field.length; field.forceActiveFocus(); } });
         search.restart();
     }
     function close() {
@@ -133,178 +140,197 @@ Item {
             anchors.fill: parent
             anchors.margins: 14
             spacing: 10
-            Rectangle {
+            Loader {
                 Layout.fillWidth: true
-                implicitHeight: 36
-                color: Qt.alpha(picker.theme.foreground, .04)
-                border.width: 1
-                border.color: Qt.alpha(picker.theme.foreground, .4)
-                RowLayout {
-                    anchors.fill: parent
-                    anchors.leftMargin: 10
-                    anchors.rightMargin: 10
-                    spacing: 10
-                    Canvas {
-                        implicitWidth: 16; implicitHeight: 16
-                        property color ink: picker.theme.foreground
-                        onInkChanged: requestPaint()
-                        onPaint: {
-                            var ctx = getContext("2d");
-                            ctx.reset(); ctx.clearRect(0, 0, width, height);
-                            ctx.strokeStyle = ink; ctx.lineWidth = 1.5;
-                            ctx.beginPath(); ctx.arc(6.5, 6.5, 4.5, 0, 2 * Math.PI); ctx.stroke();
-                            ctx.beginPath(); ctx.moveTo(10, 10); ctx.lineTo(14, 14); ctx.stroke();
-                        }
-                    }
-                    TextInput {
-                        id: field
-                        Layout.fillWidth: true
-                        Layout.fillHeight: true
-                        color: picker.theme.foreground
-                        font.family: picker.theme.font
-                        font.pixelSize: 13
-                        verticalAlignment: TextInput.AlignVCenter
-                        clip: true
-                        leftPadding: 0; rightPadding: 0
-                        cursorVisible: false
-                        cursorDelegate: Item {}
-                        Keys.onPressed: event => {
-                            if (event.key === Qt.Key_Escape) { picker.close(); event.accepted = true; }
-                            else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) { picker.accept(); event.accepted = true; }
-                            else if (event.key === Qt.Key_Up) { picker.move(-1); event.accepted = true; }
-                            else if (event.key === Qt.Key_Down) { picker.move(1); event.accepted = true; }
-                            else if (event.key === Qt.Key_Tab || event.key === Qt.Key_Backtab) {
-                                picker.tab(event.key === Qt.Key_Backtab || !!(event.modifiers & Qt.ShiftModifier));
-                                event.accepted = true;
-                            }
-                            else if (event.key === Qt.Key_U && event.modifiers === Qt.ControlModifier) { field.text = ""; event.accepted = true; }
-                        }
-                        Rectangle {
-                            width: 7; height: 15
-                            x: field.cursorRectangle.x
-                            y: Math.round(field.cursorRectangle.y + (field.cursorRectangle.height - height) / 2)
-                            color: picker.theme.foreground
-                            opacity: .9
-                        }
-                    }
-                    Word { text: "place"; font.pixelSize: 10; opacity: .45; visible: !picker.compact }
-                }
-            }
-            RowLayout {
-                Layout.fillWidth: true
-                spacing: 10
-                Word { text: "LAT"; font.pixelSize: 10; opacity: .55; Layout.preferredWidth: 28 }
-                Rectangle {
-                    Layout.fillWidth: true
-                    implicitHeight: 28
-                    color: Qt.alpha(picker.theme.foreground, .04)
-                    border.width: 1
-                    border.color: Qt.alpha(picker.theme.foreground, .4)
-                    TextInput {
-                        id: latField
-                        anchors.fill: parent
-                        anchors.leftMargin: 8
-                        anchors.rightMargin: 8
-                        color: picker.theme.foreground
-                        font.family: picker.theme.font
-                        font.pixelSize: 12
-                        verticalAlignment: TextInput.AlignVCenter
-                        clip: true
-                        Keys.onPressed: event => {
-                            if (event.key === Qt.Key_Escape) { picker.close(); event.accepted = true; }
-                            else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) { picker.accept(); event.accepted = true; }
-                            else if (event.key === Qt.Key_Tab || event.key === Qt.Key_Backtab) {
-                                picker.tab(event.key === Qt.Key_Backtab || !!(event.modifiers & Qt.ShiftModifier));
-                                event.accepted = true;
-                            }
-                        }
-                    }
-                }
-                Word { text: "LON"; font.pixelSize: 10; opacity: .55; Layout.preferredWidth: 28 }
-                Rectangle {
-                    Layout.fillWidth: true
-                    implicitHeight: 28
-                    color: Qt.alpha(picker.theme.foreground, .04)
-                    border.width: 1
-                    border.color: Qt.alpha(picker.theme.foreground, .4)
-                    TextInput {
-                        id: lonField
-                        anchors.fill: parent
-                        anchors.leftMargin: 8
-                        anchors.rightMargin: 8
-                        color: picker.theme.foreground
-                        font.family: picker.theme.font
-                        font.pixelSize: 12
-                        verticalAlignment: TextInput.AlignVCenter
-                        clip: true
-                        Keys.onPressed: event => {
-                            if (event.key === Qt.Key_Escape) { picker.close(); event.accepted = true; }
-                            else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) { picker.accept(); event.accepted = true; }
-                            else if (event.key === Qt.Key_Tab || event.key === Qt.Key_Backtab) {
-                                picker.tab(event.key === Qt.Key_Backtab || !!(event.modifiers & Qt.ShiftModifier));
-                                event.accepted = true;
-                            }
-                        }
+                active: picker.onboarding && !picker.manual
+                visible: active
+                sourceComponent: LocationPrompt {
+                    session: picker.session
+                    theme: picker.theme
+                    onManualChosen: {
+                        picker.manual = true;
+                        picker.manualStarted();
+                        field.forceActiveFocus();
                     }
                 }
             }
             ColumnLayout {
                 Layout.fillWidth: true
-                spacing: 0
-                Repeater {
-                    model: picker.rows
+                visible: picker.manual
+                spacing: 10
+                Rectangle {
+                    Layout.fillWidth: true
+                    implicitHeight: 36
+                    color: Qt.alpha(picker.theme.foreground, .04)
+                    border.width: 1
+                    border.color: Qt.alpha(picker.theme.foreground, .4)
+                    RowLayout {
+                        anchors.fill: parent
+                        anchors.leftMargin: 10
+                        anchors.rightMargin: 10
+                        spacing: 10
+                        Canvas {
+                            implicitWidth: 16; implicitHeight: 16
+                            property color ink: picker.theme.foreground
+                            onInkChanged: requestPaint()
+                            onPaint: {
+                                var ctx = getContext("2d");
+                                ctx.reset(); ctx.clearRect(0, 0, width, height);
+                                ctx.strokeStyle = ink; ctx.lineWidth = 1.5;
+                                ctx.beginPath(); ctx.arc(6.5, 6.5, 4.5, 0, 2 * Math.PI); ctx.stroke();
+                                ctx.beginPath(); ctx.moveTo(10, 10); ctx.lineTo(14, 14); ctx.stroke();
+                            }
+                        }
+                        TextInput {
+                            id: field
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                            color: picker.theme.foreground
+                            font.family: picker.theme.font
+                            font.pixelSize: 13
+                            verticalAlignment: TextInput.AlignVCenter
+                            clip: true
+                            leftPadding: 0; rightPadding: 0
+                            cursorVisible: false
+                            cursorDelegate: Item {}
+                            Keys.onPressed: event => {
+                                if (event.key === Qt.Key_Escape) { picker.close(); event.accepted = true; }
+                                else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) { picker.accept(); event.accepted = true; }
+                                else if (event.key === Qt.Key_Up) { picker.move(-1); event.accepted = true; }
+                                else if (event.key === Qt.Key_Down) { picker.move(1); event.accepted = true; }
+                                else if (event.key === Qt.Key_Tab || event.key === Qt.Key_Backtab) {
+                                    picker.tab(event.key === Qt.Key_Backtab || !!(event.modifiers & Qt.ShiftModifier));
+                                    event.accepted = true;
+                                }
+                                else if (event.key === Qt.Key_U && event.modifiers === Qt.ControlModifier) { field.text = ""; event.accepted = true; }
+                            }
+                            Rectangle {
+                                width: 7; height: 15
+                                x: field.cursorRectangle.x
+                                y: Math.round(field.cursorRectangle.y + (field.cursorRectangle.height - height) / 2)
+                                color: picker.theme.foreground
+                                opacity: .9
+                            }
+                        }
+                        Word { text: "place"; font.pixelSize: 10; opacity: .45; visible: !picker.compact }
+                    }
+                }
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 10
+                    Word { text: "LAT"; font.pixelSize: 10; opacity: .55; Layout.preferredWidth: 28 }
                     Rectangle {
-                        id: row
-                        required property var modelData
-                        required property int index
-                        readonly property bool current: index === picker.selected
-                        readonly property color ink: current ? picker.theme.accent : picker.theme.foreground
                         Layout.fillWidth: true
                         implicitHeight: 28
-                        color: current ? Qt.alpha(picker.theme.foreground, .08) : "transparent"
-                        RowLayout {
+                        color: Qt.alpha(picker.theme.foreground, .04)
+                        border.width: 1
+                        border.color: Qt.alpha(picker.theme.foreground, .4)
+                        TextInput {
+                            id: latField
                             anchors.fill: parent
-                            anchors.leftMargin: 12
-                            anchors.rightMargin: 12
-                            spacing: 12
-                            Word { text: row.modelData.name; font.bold: true; color: row.ink; Layout.fillWidth: true }
-                            Word { text: row.modelData.where; font.pixelSize: 10; color: row.ink; opacity: .6 }
+                            anchors.leftMargin: 8
+                            anchors.rightMargin: 8
+                            color: picker.theme.foreground
+                            font.family: picker.theme.font
+                            font.pixelSize: 12
+                            verticalAlignment: TextInput.AlignVCenter
+                            clip: true
+                            Keys.onPressed: event => {
+                                if (event.key === Qt.Key_Escape) { picker.close(); event.accepted = true; }
+                                else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) { picker.accept(); event.accepted = true; }
+                                else if (event.key === Qt.Key_Tab || event.key === Qt.Key_Backtab) {
+                                    picker.tab(event.key === Qt.Key_Backtab || !!(event.modifiers & Qt.ShiftModifier));
+                                    event.accepted = true;
+                                }
+                            }
                         }
-                        MouseArea {
+                    }
+                    Word { text: "LON"; font.pixelSize: 10; opacity: .55; Layout.preferredWidth: 28 }
+                    Rectangle {
+                        Layout.fillWidth: true
+                        implicitHeight: 28
+                        color: Qt.alpha(picker.theme.foreground, .04)
+                        border.width: 1
+                        border.color: Qt.alpha(picker.theme.foreground, .4)
+                        TextInput {
+                            id: lonField
                             anchors.fill: parent
-                            hoverEnabled: true
-                            onPositionChanged: picker.selected = row.index
-                            onClicked: { picker.selected = row.index; picker.accept(); }
+                            anchors.leftMargin: 8
+                            anchors.rightMargin: 8
+                            color: picker.theme.foreground
+                            font.family: picker.theme.font
+                            font.pixelSize: 12
+                            verticalAlignment: TextInput.AlignVCenter
+                            clip: true
+                            Keys.onPressed: event => {
+                                if (event.key === Qt.Key_Escape) { picker.close(); event.accepted = true; }
+                                else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) { picker.accept(); event.accepted = true; }
+                                else if (event.key === Qt.Key_Tab || event.key === Qt.Key_Backtab) {
+                                    picker.tab(event.key === Qt.Key_Backtab || !!(event.modifiers & Qt.ShiftModifier));
+                                    event.accepted = true;
+                                }
+                            }
                         }
                     }
                 }
-                Word {
-                    visible: !!picker.coordError
-                    text: picker.coordError.toUpperCase()
-                    color: picker.theme.accent
-                    Layout.fillWidth: true; Layout.leftMargin: 12; Layout.preferredHeight: 28; font.letterSpacing: 1
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 0
+                    Repeater {
+                        model: picker.rows
+                        Rectangle {
+                            id: row
+                            required property var modelData
+                            required property int index
+                            readonly property bool current: index === picker.selected
+                            readonly property color ink: current ? picker.theme.accent : picker.theme.foreground
+                            Layout.fillWidth: true
+                            implicitHeight: 28
+                            color: current ? Qt.alpha(picker.theme.foreground, .08) : "transparent"
+                            RowLayout {
+                                anchors.fill: parent
+                                anchors.leftMargin: 12
+                                anchors.rightMargin: 12
+                                spacing: 12
+                                Word { text: row.modelData.name; font.bold: true; color: row.ink; Layout.fillWidth: true }
+                                Word { text: row.modelData.where; font.pixelSize: 10; color: row.ink; opacity: .6 }
+                            }
+                            MouseArea {
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                onPositionChanged: picker.selected = row.index
+                                onClicked: { picker.selected = row.index; picker.accept(); }
+                            }
+                        }
+                    }
+                    Word {
+                        visible: !!picker.coordError
+                        text: picker.coordError.toUpperCase()
+                        color: picker.theme.accent
+                        Layout.fillWidth: true; Layout.leftMargin: 12; Layout.preferredHeight: 28; font.letterSpacing: 1
+                    }
+                    Word {
+                        visible: !picker.coordError && picker.coordEntry.lat !== undefined
+                        text: picker.coordEntry.lat === undefined ? "" : "↵ GO TO " + picker.coordEntry.lat.toFixed(4) + ", " + picker.coordEntry.lon.toFixed(4)
+                        Layout.fillWidth: true; Layout.leftMargin: 12; Layout.preferredHeight: 28; opacity: .55; font.letterSpacing: 1
+                    }
+                    Word {
+                        visible: !picker.coordError && picker.coordEntry.lat === undefined && !picker.rows.length
+                        text: picker.query.trim() ? "NO PLACE MATCHES · TRY COORDINATES" : "TOWNS OF 5,000+ PEOPLE, OR ENTER LATITUDE AND LONGITUDE"
+                        Layout.fillWidth: true; Layout.leftMargin: 12; Layout.preferredHeight: 28; opacity: .55; font.letterSpacing: 1
+                    }
                 }
-                Word {
-                    visible: !picker.coordError && picker.coordEntry.lat !== undefined
-                    text: picker.coordEntry.lat === undefined ? "" : "↵ GO TO " + picker.coordEntry.lat.toFixed(4) + ", " + picker.coordEntry.lon.toFixed(4)
-                    Layout.fillWidth: true; Layout.leftMargin: 12; Layout.preferredHeight: 28; opacity: .55; font.letterSpacing: 1
+                Rectangle { Layout.fillWidth: true; height: 1; color: Qt.alpha(picker.theme.foreground, .17) }
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 14
+                    Word { text: "tab fields"; font.pixelSize: 10; opacity: .55; visible: !picker.compact }
+                    Word { text: "↑ ↓ move"; font.pixelSize: 10; opacity: .55 }
+                    Word { text: "↵ set location"; font.pixelSize: 10; opacity: .55 }
+                    Word { text: "esc close"; font.pixelSize: 10; opacity: .55; visible: !picker.compact }
+                    Item { Layout.fillWidth: true }
+                    Word { text: picker.rows.length ? picker.rows.length + " shown" : ""; font.pixelSize: 10; opacity: .55 }
                 }
-                Word {
-                    visible: !picker.coordError && picker.coordEntry.lat === undefined && !picker.rows.length
-                    text: picker.query.trim() ? "NO PLACE MATCHES · TRY COORDINATES" : "TOWNS OF 5,000+ PEOPLE, OR ENTER LATITUDE AND LONGITUDE"
-                    Layout.fillWidth: true; Layout.leftMargin: 12; Layout.preferredHeight: 28; opacity: .55; font.letterSpacing: 1
-                }
-            }
-            Rectangle { Layout.fillWidth: true; height: 1; color: Qt.alpha(picker.theme.foreground, .17) }
-            RowLayout {
-                Layout.fillWidth: true
-                spacing: 14
-                Word { text: "tab fields"; font.pixelSize: 10; opacity: .55; visible: !picker.compact }
-                Word { text: "↑ ↓ move"; font.pixelSize: 10; opacity: .55 }
-                Word { text: "↵ set location"; font.pixelSize: 10; opacity: .55 }
-                Word { text: "esc close"; font.pixelSize: 10; opacity: .55; visible: !picker.compact }
-                Item { Layout.fillWidth: true }
-                Word { text: picker.rows.length ? picker.rows.length + " shown" : ""; font.pixelSize: 10; opacity: .55 }
             }
         }
     }

--- a/ui/LocationPicker.qml
+++ b/ui/LocationPicker.qml
@@ -123,7 +123,11 @@ Item {
     Rectangle {
         anchors.fill: parent
         color: Qt.alpha(picker.theme.background, .5)
-        MouseArea { anchors.fill: parent; onClicked: if (picker.closeOnScrim) picker.close() }
+        MouseArea {
+            anchors.fill: parent
+            onClicked: if (picker.closeOnScrim) picker.close()
+            onWheel: wheel => { wheel.accepted = true }
+        }
     }
     Rectangle {
         id: card
@@ -134,7 +138,7 @@ Item {
         color: Qt.alpha(picker.theme.background, .95)
         border.width: 1
         border.color: picker.theme.foreground
-        MouseArea { anchors.fill: parent }
+        MouseArea { anchors.fill: parent; onWheel: wheel => { wheel.accepted = true } }
         ColumnLayout {
             id: column
             anchors.fill: parent

--- a/ui/LocationPrompt.qml
+++ b/ui/LocationPrompt.qml
@@ -1,0 +1,60 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+ColumnLayout {
+    id: prompt
+    required property var session
+    required property var theme
+    signal manualChosen()
+    spacing: 10
+    component Word: Text {
+        Layout.fillWidth: true
+        horizontalAlignment: Text.AlignHCenter
+        wrapMode: Text.Wrap
+        textFormat: Text.PlainText
+        color: prompt.theme.foreground
+        font.family: prompt.theme.font
+        font.pixelSize: 12
+    }
+    component Action: Button {
+        Layout.alignment: Qt.AlignHCenter
+        implicitHeight: 30
+        implicitWidth: label.implicitWidth + 20
+        contentItem: Text {
+            id: label
+            text: parent.text
+            color: prompt.theme.foreground
+            font.family: prompt.theme.font
+            font.pixelSize: 12
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+            opacity: parent.enabled ? 1 : .5
+        }
+        background: Rectangle {
+            color: parent.hovered ? Qt.alpha(prompt.theme.accent, .16) : "transparent"
+            border.width: 1
+            border.color: parent.activeFocus ? prompt.theme.accent : Qt.alpha(prompt.theme.foreground, .4)
+        }
+    }
+    Word { text: "Choose your location"; font.bold: true; font.pixelSize: 13 }
+    Action {
+        objectName: "approximateLocation"
+        text: prompt.session.locating ? "Finding your location…" : "Use approximate location"
+        visible: !!prompt.session.engine.state && prompt.session.engine.state.source === "live"
+        enabled: !prompt.session.locationPending
+        onClicked: prompt.session.requestIpLocation()
+    }
+    Word {
+        visible: !!prompt.session.engine.state && prompt.session.engine.state.source === "live"
+        text: "Uses your public IP via wttr.in."
+        font.pixelSize: 11
+        opacity: .7
+    }
+    Word {
+        visible: !prompt.session.ipLocationDismissed && !!prompt.session.locationError
+        text: prompt.session.locationError
+        font.pixelSize: 11
+    }
+    Action { objectName: "manualLocation"; text: "Choose manually"; onClicked: prompt.manualChosen() }
+}

--- a/ui/LocationPrompt.qml
+++ b/ui/LocationPrompt.qml
@@ -46,12 +46,6 @@ ColumnLayout {
         onClicked: prompt.session.requestIpLocation()
     }
     Word {
-        visible: !!prompt.session.engine.state && prompt.session.engine.state.source === "live"
-        text: "Uses your public IP via wttr.in."
-        font.pixelSize: 11
-        opacity: .7
-    }
-    Word {
         visible: !prompt.session.ipLocationDismissed && !!prompt.session.locationError
         text: prompt.session.locationError
         font.pixelSize: 11

--- a/ui/PluginSession.qml
+++ b/ui/PluginSession.qml
@@ -27,6 +27,12 @@ QtObject {
     property bool needsLocation: false
     property string placeName: ""
     property string locationSource: ""
+    property bool ipLocationDismissed: true
+    property bool locationPending: false
+    property string locationError: ""
+    property int locateAttempt: 0
+    property int activeAttempt: 0
+    readonly property bool locating: needsLocation && !ipLocationDismissed && locationPending
     property real centerLat: 0
     property real centerLon: 0
     property real span: Location.DEFAULT_SPAN
@@ -40,8 +46,96 @@ QtObject {
     signal locationPickerRequested()
 
     function requestLocationPicker() {
+        cancelIpLocation();
         pendingLocationPicker = true;
         locationPickerRequested();
+    }
+
+    function cancelIpLocation() {
+        ipLocationDismissed = true;
+        locationPending = false;
+        locateAttempt += 1;
+        if (locator.running) locator.running = false;
+    }
+
+    function userNavigated(lat, lon, spanKm) {
+        if (!Location.validPair(lat, lon)) return;
+        if (needsLocation) {
+            centerLat = lat;
+            centerLon = lon;
+            span = Location.clampSpan(spanKm);
+            locationSource = "state";
+            hasView = true;
+            needsLocation = false;
+            persist();
+            applyRadar();
+        }
+        cancelIpLocation();
+    }
+
+    // One-shot wttr.in estimate (DESIGN.md). UI curl — not the engine.
+    function requestIpLocation() {
+        if (!initialized || !ready || hasView || !needsLocation
+            || locationPending || !engine.state || engine.state.source !== "live") return;
+        locateAttempt += 1;
+        activeAttempt = locateAttempt;
+        ipLocationDismissed = false;
+        locationError = "";
+        locationPending = true;
+        var url = Quickshell.env("OMASTORM_LOCATION_URL") || "https://wttr.in/?format=j2";
+        locator.command = ["curl", "-fsS", "--max-time", "10", "-A",
+            "omastorm (https://omastorm.com)", url];
+        locator.running = true;
+    }
+
+    function acceptIpLocation(place) {
+        if (!ready || hasView || ipLocationDismissed || !place
+            || !engine.state || engine.state.source !== "live") return;
+        // Recheck sources that may have arrived while the lookup was pending.
+        resolve();
+        if (hasView) return;
+        centerLat = place.lat;
+        centerLon = place.lon;
+        placeName = place.name || "";
+        locationSource = "ip";
+        span = Location.clampSpan(remembered.span);
+        hasView = true;
+        needsLocation = false;
+        locationPending = false;
+        persist();
+        viewChanged();
+        applyRadar();
+    }
+
+    function finishIpLocation(exitCode, raw, attempt) {
+        // A cancelled or superseded curl can still report; ignore it.
+        if (attempt !== undefined && attempt !== locateAttempt) return;
+        if (ipLocationDismissed || hasView || !needsLocation) {
+            locationPending = false;
+            return;
+        }
+        if (exitCode !== 0) {
+            locationError = "Couldn’t find your location. Try again or choose manually.";
+            locationPending = false;
+            viewChanged();
+            return;
+        }
+        var place = Location.parseWttrHome(raw);
+        if (!place) {
+            locationError = "Couldn’t find your location. Try again or choose manually.";
+            locationPending = false;
+            viewChanged();
+            return;
+        }
+        acceptIpLocation(place);
+    }
+
+    property Process locator: Process {
+        command: ["true"]
+        stdout: StdioCollector { waitForEnd: true }
+        onExited: function (exitCode) {
+            session.finishIpLocation(exitCode, String(stdout.text || ""), session.activeAttempt);
+        }
     }
 
     function resolve() {
@@ -142,6 +236,7 @@ QtObject {
 
     function setPlace(lat, lon, name) {
         if (!Location.validPair(lat, lon)) return;
+        cancelIpLocation();
         placeName = name || "";
         locationSource = "state";
         needsLocation = false;
@@ -187,6 +282,7 @@ QtObject {
         lat = Number(lat);
         lon = Number(lon);
         if (!id || !Location.validPair(lat, lon)) return;
+        cancelIpLocation();
         placeName = name || id;
         locationSource = "state";
         needsLocation = false;
@@ -258,6 +354,7 @@ QtObject {
     }
 
     property Timer persistTimer: Timer { interval: 400; onTriggered: session.persist() }
+    onLocatingChanged: viewChanged()
     property Connections engineEvents: Connections {
         target: session.engine
         function onStateChanged() {

--- a/ui/PluginSession.qml
+++ b/ui/PluginSession.qml
@@ -55,6 +55,7 @@ QtObject {
         ipLocationDismissed = true;
         locationPending = false;
         locateAttempt += 1;
+        locator.queued = false;
         if (locator.running) locator.running = false;
     }
 
@@ -85,15 +86,29 @@ QtObject {
         var url = Quickshell.env("OMASTORM_LOCATION_URL") || "https://wttr.in/?format=j2";
         locator.command = ["curl", "-fsS", "--max-time", "10", "-A",
             "omastorm (https://omastorm.com)", url];
+        // Bind the attempt to this launch. If a prior curl is still dying after
+        // cancel, queue one restart instead of overwriting its exit attribution.
+        locator.attempt = locateAttempt;
+        if (locator.running) {
+            locator.queued = true;
+            return;
+        }
+        locator.queued = false;
         locator.running = true;
     }
 
     function acceptIpLocation(place) {
         if (!ready || hasView || ipLocationDismissed || !place
-            || !engine.state || engine.state.source !== "live") return;
+            || !engine.state || engine.state.source !== "live") {
+            locationPending = false;
+            return;
+        }
         // Recheck sources that may have arrived while the lookup was pending.
         resolve();
-        if (hasView) return;
+        if (hasView) {
+            locationPending = false;
+            return;
+        }
         centerLat = place.lat;
         centerLon = place.lon;
         placeName = place.name || "";
@@ -131,10 +146,23 @@ QtObject {
     }
 
     property Process locator: Process {
+        property int attempt: 0
+        property bool queued: false
         command: ["true"]
         stdout: StdioCollector { waitForEnd: true }
         onExited: function (exitCode) {
-            session.finishIpLocation(exitCode, String(stdout.text || ""), session.activeAttempt);
+            // A terminate-then-retry left the old curl running; start the queued
+            // launch and ignore this exit's stdout/code.
+            if (queued) {
+                queued = false;
+                if (!session.ipLocationDismissed && session.locationPending
+                    && attempt === session.locateAttempt) {
+                    running = true;
+                    return;
+                }
+                return;
+            }
+            session.finishIpLocation(exitCode, String(stdout.text || ""), attempt);
         }
     }
 

--- a/ui/Popover.qml
+++ b/ui/Popover.qml
@@ -125,6 +125,7 @@ FocusScope {
                 weakFloor: card.session.weakFloor
                 labelSize: 10
                 radarOpacity: card.condition === "unavailable" ? .6 : 1
+                onNavigated: (lat, lon, spanKm) => card.session.userNavigated(lat, lon, spanKm)
                 onTilesNeeded: (z, x0, y0, x1, y1) => connection.send({type: "tiles_needed", z: z, x0: x0, y0: y0, x1: x1, y1: y1})
                 function applyView() {
                     if (!card.session.hasView) return;
@@ -181,14 +182,12 @@ FocusScope {
                     cursorShape: Qt.PointingHandCursor
                     onClicked: { card.session.requestLocationPicker(); card.expandRequested(); }
                 }
-                ColumnLayout {
+                LocationPrompt {
                     anchors.centerIn: parent
                     width: parent.width - 32
-                    spacing: 10
-                    Label { Layout.fillWidth: true; horizontalAlignment: Text.AlignHCenter; text: "CHOOSE A LOCATION"; font.bold: true; font.pixelSize: 13 }
-                    Label { Layout.fillWidth: true; horizontalAlignment: Text.AlignHCenter; wrapMode: Text.Wrap; opacity: .7; font.pixelSize: 11
-                        text: "Search a town of 5,000+ people, or enter latitude and longitude in the window." }
-                    Control { Layout.alignment: Qt.AlignHCenter; text: "CHOOSE A LOCATION"; onClicked: { card.session.requestLocationPicker(); card.expandRequested(); } }
+                    session: card.session
+                    theme: card.theme
+                    onManualChosen: { card.session.requestLocationPicker(); card.expandRequested(); }
                 }
             }
         }

--- a/ui/Popover.qml
+++ b/ui/Popover.qml
@@ -125,6 +125,7 @@ FocusScope {
                 weakFloor: card.session.weakFloor
                 labelSize: 10
                 radarOpacity: card.condition === "unavailable" ? .6 : 1
+                interactive: !card.session.needsLocation
                 onNavigated: (lat, lon, spanKm) => card.session.userNavigated(lat, lon, spanKm)
                 onTilesNeeded: (z, x0, y0, x1, y1) => connection.send({type: "tiles_needed", z: z, x0: x0, y0: y0, x1: x1, y1: y1})
                 function applyView() {
@@ -181,6 +182,7 @@ FocusScope {
                     anchors.fill: parent
                     cursorShape: Qt.PointingHandCursor
                     onClicked: { card.session.requestLocationPicker(); card.expandRequested(); }
+                    onWheel: wheel => { wheel.accepted = true }
                 }
                 LocationPrompt {
                     anchors.centerIn: parent

--- a/ui/RadarMap.qml
+++ b/ui/RadarMap.qml
@@ -84,7 +84,11 @@ Item {
     readonly property real viewCenterX: Math.max(width/2*unitsPerPixel, Math.min(1-width/2*unitsPerPixel, wantedX))
     readonly property real viewCenterY: Math.max(height/2*unitsPerPixel, Math.min(1-height/2*unitsPerPixel, wantedY))
     function reset() { center = null; span = Math.min(210, maxSpan); }
-    function zoom(value) { span = Math.max(25, Math.min(maxSpan, value)); }
+    signal navigated(real lat, real lon, real spanKm)
+    function zoom(value, notify) {
+        span = Math.max(25, Math.min(maxSpan, value));
+        if (notify !== false) navigated(centerLat, centerLon, span);
+    }
     function look(mx, my) { center = Qt.point(longitude(mx), latitude(my)); }
     // Centre exactly on a place. Loading frames and radar hand-offs must
     // not call this; the camera is the user's (DESIGN.md, location).
@@ -99,6 +103,7 @@ Item {
     function pan(dx, dy) {
         var stepPixels = Math.max(1, Math.round(Math.min(width, height) / 8)) * unitsPerPixel;
         look(viewCenterX + dx * stepPixels, viewCenterY + dy * stepPixels);
+        navigated(centerLat, centerLon, span);
     }
     readonly property real centerLat: latitude(viewCenterY)
     readonly property real centerLon: longitude(viewCenterX)
@@ -633,14 +638,19 @@ Item {
         property real lastY
         onPressed: mouse => { lastX=mouse.x; lastY=mouse.y; }
         onPositionChanged: mouse => {
-            if(pressed) { map.look(map.viewCenterX - (mouse.x-lastX)*map.unitsPerPixel, map.viewCenterY - (mouse.y-lastY)*map.unitsPerPixel); lastX=mouse.x; lastY=mouse.y; }
+            if(pressed && (mouse.x !== lastX || mouse.y !== lastY)) {
+                map.look(map.viewCenterX - (mouse.x-lastX)*map.unitsPerPixel, map.viewCenterY - (mouse.y-lastY)*map.unitsPerPixel);
+                lastX=mouse.x; lastY=mouse.y;
+                map.navigated(map.centerLat, map.centerLon, map.span);
+            }
         }
         onWheel: wheel => {
             // Zoom about the pointer: the ground under it stays put.
             var mx=map.viewCenterX+(wheel.x-width/2)*map.unitsPerPixel;
             var my=map.viewCenterY+(wheel.y-height/2)*map.unitsPerPixel;
-            map.zoom(Math.min(map.span,map.maxSpan)*(wheel.angleDelta.y>0?.85:1/.85));
+            map.zoom(Math.min(map.span,map.maxSpan)*(wheel.angleDelta.y>0?.85:1/.85), false);
             map.look(mx-(wheel.x-width/2)*map.unitsPerPixel, my-(wheel.y-height/2)*map.unitsPerPixel);
+            map.navigated(map.centerLat, map.centerLon, map.span);
         }
         onDoubleClicked: map.resetRequested()
     }

--- a/ui/RadarMap.qml
+++ b/ui/RadarMap.qml
@@ -32,6 +32,7 @@ Item {
     property int labelSize: 12
     property real radarOpacity: 1    // the radar layer alone; the basemap keeps its strength
     property bool locked: false      // the accent frame on the active marker and tag (DESIGN.md, markers)
+    property bool interactive: true  // false while location prompt/picker owns the surface
     // A frame with a scan time is radar to draw. The loading placeholder
     // (docs/protocol.md, frame.status: no scan time, one blank row) draws no
     // radar; tiles, labels, markers, and coverage still show, so a station
@@ -86,6 +87,7 @@ Item {
     function reset() { center = null; span = Math.min(210, maxSpan); }
     signal navigated(real lat, real lon, real spanKm)
     function zoom(value, notify) {
+        if (!interactive) return;
         span = Math.max(25, Math.min(maxSpan, value));
         if (notify !== false) navigated(centerLat, centerLon, span);
     }
@@ -101,6 +103,7 @@ Item {
     // The keyboard pan (DESIGN.md, keyboard map): one step is an eighth of
     // the viewport's shorter side, in the given screen direction.
     function pan(dx, dy) {
+        if (!interactive) return;
         var stepPixels = Math.max(1, Math.round(Math.min(width, height) / 8)) * unitsPerPixel;
         look(viewCenterX + dx * stepPixels, viewCenterY + dy * stepPixels);
         navigated(centerLat, centerLon, span);
@@ -633,6 +636,7 @@ Item {
     }
     MouseArea {
         anchors.fill: parent
+        enabled: map.interactive
         cursorShape: pressed ? Qt.ClosedHandCursor : Qt.OpenHandCursor
         property real lastX
         property real lastY

--- a/ui/RadarWindow.qml
+++ b/ui/RadarWindow.qml
@@ -19,7 +19,8 @@ Item {
         opened = true;
         if (session) session.windowOpen = true;
         applyView();
-        if (store.needsLocation || store.pendingLocationPicker) Qt.callLater(() => locationPicker.show(""));
+        if (store.pendingLocationPicker) Qt.callLater(() => locationPicker.show(""));
+        else maybeOfferLocation();
     }
     function close() {
         if (!opened) return;
@@ -174,14 +175,15 @@ Item {
         }
     }
     function maybeOfferLocation() {
-        if (!opened || !store.needsLocation || locationPicker.open) return;
+        if (!opened || !store.initialized || !store.needsLocation || store.locating || locationPicker.open) return;
         Qt.callLater(() => {
-            if (app.opened && app.store.needsLocation && !locationPicker.open) locationPicker.show("");
+            if (app.opened && app.store.initialized && app.store.needsLocation && !app.store.locating && !locationPicker.open) locationPicker.show("", true);
         });
     }
     Connections {
         target: store
         function onViewChanged() {
+            if (locationPicker.open && locationPicker.onboarding && !app.store.needsLocation) locationPicker.close();
             if (app.opened) app.applyView();
             app.maybeOfferLocation();
         }
@@ -254,7 +256,7 @@ Item {
         function status(): string {
             return JSON.stringify({sheet: sheet.open, menu: treatmentMenu.opened, treatment: app.treatment, weakFloor: app.weakFloor === null ? "off" : app.weakFloor, error: app.configError,
                                    span: Math.round(map.span * 10) / 10, lat: Math.round(map.centerLat * 1000) / 1000, lon: Math.round(map.centerLon * 1000) / 1000,
-                                   locationSource: app.store.locationSource, needsLocation: app.store.needsLocation,
+                                   locationSource: app.store.locationSource, needsLocation: app.store.needsLocation, locating: app.store.locating,
                                    site: app.siteId, locked: app.locked, lockSource: app.store.lockSource, outsideCoverage: app.outsideCoverage});
         }
     }
@@ -281,7 +283,12 @@ Item {
         if (mockGps && mockGps !== "paused") return "GPS";
         var t = app.resetTarget;
         if (t && Location.distanceKm(map.centerLat, map.centerLon, t.lat, t.lon) < 2) return (t.name || "OMARCHY'S LOCATION").toUpperCase();
-        if (app.store.placeName && Location.distanceKm(map.centerLat, map.centerLon, app.store.centerLat, app.store.centerLon) < 2) return app.store.placeName.toUpperCase();
+        if (app.store.placeName && Location.distanceKm(map.centerLat, map.centerLon, app.store.centerLat, app.store.centerLon) < 2) {
+            var name = app.store.placeName.toUpperCase();
+            return app.store.locationSource === "ip" ? "IP NEAR " + name : name;
+        }
+        if (app.store.locationSource === "ip" && Location.distanceKm(map.centerLat, map.centerLon, app.store.centerLat, app.store.centerLon) < 2)
+            return "IP NEAR YOU";
         var lat = map.centerLat, lon = map.centerLon;
         return Math.abs(lat).toFixed(2) + "° " + (lat < 0 ? "S" : "N") + "  " + Math.abs(lon).toFixed(2) + "° " + (lon < 0 ? "W" : "E");
     }
@@ -656,6 +663,7 @@ Item {
                     radarOpacity: app.condition === "unavailable" ? .6 : 1
                     labelSize: win.compact ? 10 : 12
                     locked: app.locked
+                    onNavigated: (lat, lon, spanKm) => app.store.userNavigated(lat, lon, spanKm)
                     // A settled pan hands the centre to the engine, which switches
                     // station while following and unlocked; the camera stays.
                     onViewSettled: (lat, lon) => {
@@ -1014,6 +1022,8 @@ Item {
           }
           LocationPicker {
             id: locationPicker
+            session: app.store
+            onManualStarted: app.store.cancelIpLocation()
             anchors.fill: parent
             theme: app.theme
             engine: engine

--- a/ui/RadarWindow.qml
+++ b/ui/RadarWindow.qml
@@ -663,6 +663,7 @@ Item {
                     radarOpacity: app.condition === "unavailable" ? .6 : 1
                     labelSize: win.compact ? 10 : 12
                     locked: app.locked
+                    interactive: !app.store.needsLocation && !locationPicker.open
                     onNavigated: (lat, lon, spanKm) => app.store.userNavigated(lat, lon, spanKm)
                     // A settled pan hands the centre to the engine, which switches
                     // station while following and unlocked; the camera stays.

--- a/ui/qmldir
+++ b/ui/qmldir
@@ -2,6 +2,7 @@ singleton PluginSession 1.0 PluginSession.qml
 Config 1.0 Config.qml
 Engine 1.0 Engine.qml
 LocationPicker 1.0 LocationPicker.qml
+LocationPrompt 1.0 LocationPrompt.qml
 Remembered 1.0 Remembered.qml
 KeysSheet 1.0 KeysSheet.qml
 Panel 1.0 Panel.qml


### PR DESCRIPTION
## Summary
- When config, remembered view, and Omarchy weather are all missing, the existing location prompt offers **Use approximate location** or **Choose manually**.
- Approximate location is one UI `curl` to wttr.in on click—privacy-first, same provider as Omarchy—not an automatic lookup or engine command.
- Successful estimates are remembered like any other view; manual choice / navigation always wins over a late reply. No `ip_location` config knob; IP never enables GPS.

Builds on @scottjones’s work in #31 (precedence, late-reply handling, remembering the view). Co-authored.

## Test plan
- [ ] Fresh launch with no config/state/weather → prompt shows; no network until click
- [ ] **Use approximate location** → centers near you, labeled IP; reopen does not ask again
- [ ] Failure / offline → error message; **Choose manually** still works
- [ ] Config / state / weather still win over the prompt
- [ ] `mise check` / `scripts/check-ip-location.sh`