### PR TITLE
docs: add ryrobes, gw7523, and Yani3rt as contributors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -86,6 +86,34 @@
         "test",
         "review"
       ]
+    },
+    {
+      "login": "ryrobes",
+      "name": "Ryan Robitaille",
+      "avatar_url": "https://avatars.githubusercontent.com/u/757387?v=4",
+      "profile": "https://ryrob.es/",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "gw7523",
+      "name": "gw7523",
+      "avatar_url": "https://avatars.githubusercontent.com/u/199144018?v=4",
+      "profile": "https://github.com/gw7523",
+      "contributions": [
+        "code",
+        "bug"
+      ]
+    },
+    {
+      "login": "Yani3rt",
+      "name": "Yaniert Pascual",
+      "avatar_url": "https://avatars.githubusercontent.com/u/170105839?v=4",
+      "profile": "https://github.com/Yani3rt",
+      "contributions": [
+        "userTesting"
+      ]
     }
   ],
   "commitType": "docs"

--- a/README.md
+++ b/README.md
@@ -239,6 +239,9 @@ Thanks to these people
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="http://mrcobas.com"><img src="https://avatars.githubusercontent.com/u/41881817?v=4?s=100" width="100px;" alt="javi"/><br /><sub><b>javi</b></sub></a><br /><a href="https://github.com/wesleygrimes/omastorm/commits?author=mrcobas" title="Tests">⚠️</a> <a href="https://github.com/wesleygrimes/omastorm/pulls?q=is%3Apr+reviewed-by%3Amrcobas" title="Reviewed Pull Requests">👀</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://ryrob.es/"><img src="https://avatars.githubusercontent.com/u/757387?v=4?s=100" width="100px;" alt="Ryan Robitaille"/><br /><sub><b>Ryan Robitaille</b></sub></a><br /><a href="https://github.com/wesleygrimes/omastorm/commits?author=ryrobes" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/gw7523"><img src="https://avatars.githubusercontent.com/u/199144018?v=4?s=100" width="100px;" alt="gw7523"/><br /><sub><b>gw7523</b></sub></a><br /><a href="https://github.com/wesleygrimes/omastorm/commits?author=gw7523" title="Code">💻</a> <a href="https://github.com/wesleygrimes/omastorm/issues?q=author%3Agw7523" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Yani3rt"><img src="https://avatars.githubusercontent.com/u/170105839?v=4?s=100" width="100px;" alt="Yaniert Pascual"/><br /><sub><b>Yaniert Pascual</b></sub></a><br /><a href="#userTesting-Yani3rt" title="User Testing">📓</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Credits the NVIDIA blank-radar fix shipped in v0.1.8 (#62): @ryrobes for the fix (#16), @gw7523 for the independent fix (#22) and the live-poller report (#19), @Yani3rt for confirming on a second NVIDIA GPU.

Generated with `all-contributors-cli add`; replaces the bot's #67, which misparsed the multi-user request and only added @ryrobes.