### PR TITLE
Mark and explain holes in the tick strip

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -42,7 +42,10 @@ the ids and comments in `ui/RadarWindow.qml`.
 | **legend** | dBZ scale directly under the map |
 | **transport** | Playback buttons |
 | **tick strip** | Frame ticks on the timeline |
+| **break marker** | Dashed yellow mark between two frames a hole in the scans separates |
+| **break note** | Card over a hovered or focused break marker: the bounding times and the length of the hole |
 | **strip stamp** | Date / time / zone above the tick strip |
+| **break notice** | `Skipped 26h · no scans available` beside the stamp after the playhead crosses a hole |
 | **frame index** | `N / total` above the strip, right-aligned; counts available frames only |
 
 **Bottom chrome order.** Map stage, then legend, then transport + tick
@@ -62,7 +65,30 @@ only (empty pads need room or they read as a dotted cliff). An extra live
 sweep beyond 60 completed scans adds a selectable tick and is included in
 the frame count. Available frames fill from the left; unused positions are
 faint, short, and cannot be sought. Each available tick represents one
-frame, without extra gap ticks or a baseline.
+frame, with no baseline and no proportional spacing.
+
+**Breaks.** Neighbouring ticks are equal steps, so a hole in the catalog
+(an outage, sparse history) would otherwise read as even time. A break
+marker sits between two frames whose interval is longer than thirty
+minutes (the silence that shows UNAVAILABLE while live) and longer than
+three usual intervals, the usual interval being the median of those under
+thirty minutes. Trailing pads are room to fill, never missing time. On the
+catalogs of nineteen stations (September 2026) ordinary cadence ran 3.3 to
+8.8 minutes, a VCP change moved one station from 4.5 to 7.1 minutes inside
+one history, and single missed volumes left 17 to 18 minute intervals; none
+of those is a break. The holes were 35 minutes to 26 hours, and all are.
+The marker is a position in the strip, not a frame: it is not counted, not
+sought by a scrub, and not a stop for stepping. Hovering or focusing it
+(Tab) shows the break note: `No scans available between these times`, the
+two stamps, and the length. When the frame on screen moves across a hole by
+a step, a scrub, or playback, the break notice names the jump beside the
+stamp for four seconds: `Skipped 26h · no scans available`, `Back 26h · no
+scans available`, shortened to `Skipped 26h` where the row is narrow. The
+loop wrapping to the oldest frame, the oldest and newest keys, and a new
+sweep arriving after a silence are not crossings and show no notice.
+Wording stays neutral: the scans are unavailable, and the app does not say
+why. The popover strip carries the same markers and note and the short
+notice.
 
 ## Location, onboarding, and map
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -82,8 +82,10 @@ sought by a scrub, and not a stop for stepping. Hovering or focusing it
 (Tab) shows the break note: `No scans available between these times`, the
 two stamps, and the length. When the frame on screen moves across a hole by
 a step, a scrub, or playback, the break notice names the jump beside the
-stamp for four seconds: `Skipped 26h · no scans available`, `Back 26h · no
-scans available`, shortened to `Skipped 26h` where the row is narrow. The
+stamp: `Skipped 26h · no scans available`, `Back 26h · no scans
+available`, shortened to `Skipped 26h` where the row is narrow. It clears
+when the frame changes again, but stays at least a second and a half so
+the loop's pace cannot flash it, and at most four seconds while paused. The
 loop wrapping to the oldest frame, the oldest and newest keys, and a new
 sweep arriving after a silence are not crossings and show no notice.
 Wording stays neutral: the scans are unavailable, and the app does not say

--- a/scripts/capture-gaps.sh
+++ b/scripts/capture-gaps.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# The tick strip's breaks (DESIGN.md, time) at full and compact widths, as
+# review/gaps-full.png and review/gaps-compact.png with strip crops. The
+# harness shell lays a KAKQ-shaped timeline over the archived state: 21
+# frames at 7 minutes to 09/10 4:56 PM EDT, a 26 h hole, 16 frames at 5.5
+# minutes; the playhead steps across the hole three seconds in, so the
+# notice is up, and the break marker is focused so its note shows.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+mkdir -p review
+export OMASTORM_ARCHIVE=${OMASTORM_ARCHIVE:-$PWD/data/raw/KTLX20130520_201643_V06.gz}
+export QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME=basic QT_QUICK_BACKEND=rhi QSG_RHI_BACKEND=opengl
+export TZ=America/New_York
+harness=$(bash scripts/capture-harness.sh)
+harness_dir=$(dirname "$harness")
+trap 'rm -rf "$harness_dir"' EXIT
+timeline=$(jq -cn '
+  def iso: todate;
+  [range(0; 21) | {id: ("f" + tostring), scanTime: ((1789065360 + . * 420) | iso), status: "complete"}]
+  + [range(21; 37) | {id: ("f" + tostring), scanTime: ((1789167060 + (. - 21) * 330) | iso), status: "complete"}]')
+before=$(jq -cn --argjson t "$timeline" '{source: "live", connection: {status: "ok", ageSeconds: 130}, timeline: $t, frame: {id: "f20", scanTime: $t[20].scanTime}}')
+after=$(jq -cn --argjson t "$timeline" '{source: "live", connection: {status: "ok", ageSeconds: 130}, timeline: $t, frame: {id: "f21", scanTime: $t[21].scanTime}}')
+config="$harness_dir/config.toml"
+jq -r '.sites[] | select(.id=="KTLX") | "center_lat = \(.lat)\ncenter_lon = \(.lon)\nlocked_radar = \"\(.id)\""' engine/data/sites.json > "$config"
+capture() { # name, width, height, note (focus the break marker so its note shows)
+  local name=$1 out="$PWD/review/gaps-$1.png"
+  rm -f "$out"
+  OMASTORM_QML="$harness" OMASTORM_CONFIG="$config" OMASTORM_WIDTH="$2" OMASTORM_HEIGHT="$3" \
+    OMASTORM_STATE_OVERRIDE="$before" OMASTORM_STATE_OVERRIDE_THEN="$after" OMASTORM_STATE_OVERRIDE_THEN_MS=3000 \
+    OMASTORM_CAPTURE_DELAY=6000 OMASTORM_CAPTURE="$out" bash run.sh > /dev/null 2>&1 &
+  local pid=$!
+  if [[ ${4:-} == note ]]; then
+    sleep 4
+    quickshell ipc --pid "$pid" call keys gap 0
+  fi
+  wait "$pid" || true
+  [[ -s $out ]] || { echo "No capture for $name" >&2; exit 1; }
+  echo "review/gaps-$name.png"
+}
+capture full 960 680
+capture full-note 960 680 note
+capture compact 400 420
+capture compact-note 400 420 note
+for name in full full-note; do magick "review/gaps-$name.png" -gravity south -crop 960x120+0+0 +repage "review/gaps-$name-strip.png"; done
+for name in compact compact-note; do magick "review/gaps-$name.png" -gravity south -crop 400x110+0+0 +repage "review/gaps-$name-strip.png"; done
+echo "review/gaps-*-strip.png"

--- a/scripts/capture-harness.sh
+++ b/scripts/capture-harness.sh
@@ -2,7 +2,10 @@
 # The harness shell for captures of states the real feed cannot be asked
 # for: the real UI files, and an Engine that lays OMASTORM_STATE_OVERRIDE (a
 # JSON object) over every state it receives, one level deep, so a `frame`
-# or `connection` field can change while the rest stays real. Prints the
+# or `connection` field can change while the rest stays real. With
+# OMASTORM_STATE_OVERRIDE_THEN set, that override replaces the first after
+# OMASTORM_STATE_OVERRIDE_THEN_MS (default 3000) and the last state is
+# received again, so a change the UI reacts to can be captured. Prints the
 # shell's path for OMASTORM_QML.
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -10,6 +13,7 @@ cd "$(dirname "$0")/.."
 harness=$(mktemp -d /tmp/omastorm-capture-harness.XXXXXX)
 cp ui/shell.qml ui/RadarWindow.qml ui/RadarMark.qml ui/RadarMap.qml ui/SitePicker.qml ui/Sites.js ui/KeysSheet.qml ui/Keys.js ui/Timeline.js ui/Theme.qml ui/Config.qml ui/Toml.js ui/Location.js ui/LocationPicker.qml ui/LocationPrompt.qml ui/Remembered.qml ui/PluginSession.qml ui/qmldir "$harness/"
 ln -sfn "$PWD/ui/shaders" "$harness/shaders"
-perl -pe 's/^(\s+)state = message;$/$1var override = JSON.parse(Quickshell.env("OMASTORM_STATE_OVERRIDE") || "{}");\n$1for (var key in override) message[key] = override[key] && typeof override[key] === "object" && !Array.isArray(override[key]) && message[key] ? Object.assign(message[key], override[key]) : override[key];\n$1state = message;/' ui/Engine.qml > "$harness/Engine.qml"
-grep -q OMASTORM_STATE_OVERRIDE "$harness/Engine.qml"
+perl -pe 's/^(\s+)state = message;$/$1engine.lastState = data;\n$1var override = JSON.parse(Quickshell.env(engine.then ? "OMASTORM_STATE_OVERRIDE_THEN" : "OMASTORM_STATE_OVERRIDE") || "{}");\n$1for (var key in override) message[key] = override[key] && typeof override[key] === "object" && !Array.isArray(override[key]) && message[key] ? Object.assign(message[key], override[key]) : override[key];\n$1state = message;/;
+  s/^(\s+)property bool incompatible: false$/$1property bool incompatible: false\n$1property bool then: false\n$1property string lastState: ""\n$1property Timer thenTimer: Timer { interval: Number(Quickshell.env("OMASTORM_STATE_OVERRIDE_THEN_MS")) || 3000; running: !!Quickshell.env("OMASTORM_STATE_OVERRIDE_THEN"); onTriggered: { engine.then = true; if (engine.lastState) engine.receive(engine.lastState); } }/' ui/Engine.qml > "$harness/Engine.qml"
+grep -q OMASTORM_STATE_OVERRIDE_THEN "$harness/Engine.qml"
 echo "$harness/shell.qml"

--- a/scripts/check-popover.sh
+++ b/scripts/check-popover.sh
@@ -55,9 +55,10 @@ call capture "$PWD/review/popover-archived.png"
 for _ in {1..50}; do [[ -s review/popover-archived.png ]] && break; sleep .1; done
 sock="$XDG_RUNTIME_DIR/omastorm/engine.sock"
 tell() { printf '%s\n' "$@" | socat -t0.2 - "UNIX-CONNECT:$sock" >/dev/null; }
-# Three deterministic complete frames, using the archived fixture's metadata
+# Four deterministic complete frames, using the archived fixture's metadata
 # and PNGs, exercise the real catalog/transport without waiting volumes:
-# two five minutes apart and a third 26 hours on, a hole like KAKQ's (#65).
+# two five minutes apart, a third 26 hours on (a hole like KAKQ's, #65),
+# and a fourth five minutes after that.
 timeout 2 socat -t0.2 - "UNIX-CONNECT:$sock" < /dev/null | jq -c 'select(.type == "state")' | head -n1 > "$scratch/engine-state.json"
 ruby - "$scratch" <<'RUBY_SEED'
 require 'json'
@@ -70,7 +71,7 @@ dir = "#{scratch}/cache/omastorm/frames"
 FileUtils.mkdir_p("#{dir}/KTLX")
 sql = []
 start = 1369080600 # 2013-05-20T20:10:00Z
-[0, 5 * 60, 5 * 60 + 26 * 3600].each_with_index do |offset, i|
+[0, 5 * 60, 5 * 60 + 26 * 3600, 10 * 60 + 26 * 3600].each_with_index do |offset, i|
   f = Marshal.load(Marshal.dump(frame))
   f['id'] = "popover-test-#{i}"
   f['scanTime'] = Time.at(start + offset).utc.strftime('%Y-%m-%dT%H:%M:%SZ')
@@ -100,14 +101,24 @@ call step 1
 until_status '.frame == "popover-test-1" and .windowFrame == "popover-test-1"'
 # The 26 h hole: one break marker on both strips, no notice for the step
 # that did not cross it, a notice on each surface for the step that did,
-# worded for the direction, and none for a step back before the hole.
+# worded for the direction; it outlives the next frame change for its
+# 1.5 s hold and then clears well before the 4 s cap it has while paused.
 until_status '.gaps == 1 and .notice == "" and .windowNotice == ""'
 call step 1
 until_status '.frame == "popover-test-2" and .windowNotice == "Skipped 26h · no scans available" and .notice == "Skipped 26h"'
+call step 1
+until_status '.frame == "popover-test-3"'
+[[ $(status | jq -r .windowNotice) == "Skipped 26h · no scans available" ]] || fail 'The notice went before its hold'
+sleep 2
+[[ $(status | jq -r '.windowNotice + .notice') == "" ]] || fail 'The notice stayed past the frame that followed the hole'
+# An explicit seek back: test-3 may be the newest entry, which follows the
+# feed, and a live sweep can have taken the frame on when the network is up.
+tell '{"type":"seek","id":"popover-test-2"}'
+until_status '.frame == "popover-test-2"'
 call step -1
 until_status '.frame == "popover-test-1" and .windowNotice == "Back 26h · no scans available" and .notice == "Back 26h"'
 sleep 4.5
-[[ $(status | jq -r .windowNotice) == "" ]] || fail 'The break notice did not clear'
+[[ $(status | jq -r .windowNotice) == "" ]] || fail 'The break notice did not clear while paused'
 tell '{"type":"seek","id":"popover-test-0"}'
 until_status '.frame == "popover-test-0"'
 [[ $(status | jq -r .windowNotice) == "" ]] || fail 'A seek that crossed no hole showed a notice'

--- a/scripts/check-popover.sh
+++ b/scripts/check-popover.sh
@@ -55,28 +55,31 @@ call capture "$PWD/review/popover-archived.png"
 for _ in {1..50}; do [[ -s review/popover-archived.png ]] && break; sleep .1; done
 sock="$XDG_RUNTIME_DIR/omastorm/engine.sock"
 tell() { printf '%s\n' "$@" | socat -t0.2 - "UNIX-CONNECT:$sock" >/dev/null; }
-# Two deterministic complete frames, using the archived fixture's metadata
-# and PNGs, exercise the real catalog/transport without waiting two volumes.
+# Three deterministic complete frames, using the archived fixture's metadata
+# and PNGs, exercise the real catalog/transport without waiting volumes:
+# two five minutes apart and a third 26 hours on, a hole like KAKQ's (#65).
 timeout 2 socat -t0.2 - "UNIX-CONNECT:$sock" < /dev/null | jq -c 'select(.type == "state")' | head -n1 > "$scratch/engine-state.json"
 ruby - "$scratch" <<'RUBY_SEED'
 require 'json'
 require 'fileutils'
 require 'open3'
+require 'time'
 scratch = ARGV.fetch(0)
 frame = JSON.parse(File.read("#{scratch}/engine-state.json")).fetch('frame')
 dir = "#{scratch}/cache/omastorm/frames"
 FileUtils.mkdir_p("#{dir}/KTLX")
 sql = []
-2.times do |i|
+start = 1369080600 # 2013-05-20T20:10:00Z
+[0, 5 * 60, 5 * 60 + 26 * 3600].each_with_index do |offset, i|
   f = Marshal.load(Marshal.dump(frame))
   f['id'] = "popover-test-#{i}"
-  f['scanTime'] = "2013-05-20T20:#{10+i*5}:00Z"
+  f['scanTime'] = Time.at(start + offset).utc.strftime('%Y-%m-%dT%H:%M:%SZ')
   f['sweepEnd'] = f['scanTime']
   tex = "KTLX/test-#{i}-sweep.png"; lut = "KTLX/test-#{i}-lut.png"
   FileUtils.cp("#{scratch}/r/omastorm/#{frame['texture']}", "#{dir}/#{tex}")
   FileUtils.cp("#{scratch}/r/omastorm/#{frame['azimuthLut']}", "#{dir}/#{lut}")
   f['texture'] = ''; f['azimuthLut'] = ''
-  values = [f['id'], 'KTLX', 'REF', f['elevationDeg'], 1369080600000+i*300000,
+  values = [f['id'], 'KTLX', 'REF', f['elevationDeg'], (start + offset) * 1000,
             f['scanTime'], f['sweepEnd'], 'synthetic popover lifecycle test', 0, JSON.generate(f), tex, lut]
   sql << "INSERT INTO frames VALUES (#{values.map { |v| v.is_a?(Numeric) ? v.to_s : "'" + v.gsub("'", "''") + "'" }.join(',')});"
 end
@@ -95,6 +98,21 @@ tell '{"type":"select_site","id":"KTLX"}' '{"type":"lock","enabled":true}' '{"ty
 until_status '.frame == "popover-test-0"'
 call step 1
 until_status '.frame == "popover-test-1" and .windowFrame == "popover-test-1"'
+# The 26 h hole: one break marker on both strips, no notice for the step
+# that did not cross it, a notice on each surface for the step that did,
+# worded for the direction, and none for a step back before the hole.
+until_status '.gaps == 1 and .notice == "" and .windowNotice == ""'
+call step 1
+until_status '.frame == "popover-test-2" and .windowNotice == "Skipped 26h · no scans available" and .notice == "Skipped 26h"'
+call step -1
+until_status '.frame == "popover-test-1" and .windowNotice == "Back 26h · no scans available" and .notice == "Back 26h"'
+sleep 4.5
+[[ $(status | jq -r .windowNotice) == "" ]] || fail 'The break notice did not clear'
+tell '{"type":"seek","id":"popover-test-0"}'
+until_status '.frame == "popover-test-0"'
+[[ $(status | jq -r .windowNotice) == "" ]] || fail 'A seek that crossed no hole showed a notice'
+tell '{"type":"seek","id":"popover-test-1"}'
+until_status '.frame == "popover-test-1"'
 call play
 until_status '.playing and .windowPlaying'
 # Expand while playing forwards the shared position instead of seek/pause.

--- a/scripts/check-timeline.sh
+++ b/scripts/check-timeline.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Break detection and crossing (ui/Timeline.js) on synthetic timelines
+# shaped like the catalogs: the KAKQ 26 h hole, ordinary cadence jitter, a
+# VCP change, missed volumes, the loop wrapping. Needs no daemon.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+check_dir="$PWD/target/check-timeline"
+mkdir -p "$check_dir"
+cp ui/Timeline.js "$check_dir/Timeline.js"
+cat > "$check_dir/shell.qml" <<'QML'
+import QtQuick
+import Quickshell
+import "Timeline.js" as Strip
+ShellRoot {
+    function check(ok, message) { if (!ok) throw new Error(message); }
+    function eq(actual, expected, message) { check(JSON.stringify(actual) === JSON.stringify(expected), message + ": " + JSON.stringify(actual) + " != " + JSON.stringify(expected)); }
+    // Frames from `start` at `minutes` per step; `offsets` (minutes) override the rhythm.
+    function series(start, offsets) {
+        var t0 = Date.parse(start);
+        return offsets.map((m, i) => ({ id: "f" + i, scanTime: new Date(t0 + m * 60000).toISOString(), status: "complete" }));
+    }
+    function cumulative(intervals) { var out = [0]; intervals.forEach(d => out.push(out[out.length - 1] + d)); return out; }
+    Component.onCompleted: {
+        var H = 60, D = 24 * H;
+        // KAKQ, 2026-09-10/11: 4.5-7.1 minute cadence with a VCP change and a 1549 minute hole.
+        var kakq = [4.5, 4.5, 4.5, 5.2, 5.2, 5.2, 5.2, 5.3, 5.4, 5.4, 5.4, 5.4, 5.4, 5.5, 5.5, 5.5, 5.5, 5.5, 5.5, 5.5, 1549.1, 7.0, 7.0, 7.1, 7.1, 7.1, 7.1, 7.1, 7.1, 7.1, 7.1, 7.1, 7.1, 7.1, 7.1, 7.1, 7.1, 7.1, 7.1];
+        var frames = series("2026-09-10T18:36:16Z", cumulative(kakq));
+        eq(frames.length, 40, "KAKQ frame count");
+        var gaps = Strip.gaps(frames);
+        eq(gaps.length, 1, "KAKQ has one break");
+        eq(gaps[0].after, 20, "KAKQ break follows frame 20");
+        eq(Math.round(gaps[0].ms / 60000), 1549, "KAKQ break length");
+        eq(Strip.elapsed(gaps[0].ms), "26h", "KAKQ break reads as 26h");
+        // Ordinary variation is not a break: jitter, a VCP change, one or two missed volumes.
+        eq(Strip.gaps(series("2026-09-11T18:00:00Z", cumulative([3.3, 3.4, 3.6, 4.3, 4.5, 4.7, 5.5, 8.7, 8.8]))).length, 0, "Cadence jitter");
+        eq(Strip.gaps(series("2026-09-11T18:00:00Z", cumulative([4.4, 4.4, 4.4, 6.7, 6.8, 7.1, 7.1]))).length, 0, "A VCP change");
+        eq(Strip.gaps(series("2026-09-11T18:00:00Z", cumulative([8.7, 8.7, 8.7, 17.5, 8.7, 8.7]))).length, 0, "One missed volume at a slow cadence");
+        eq(Strip.gaps(series("2026-09-11T18:00:00Z", cumulative([3.5, 3.5, 17.5, 17.9, 3.5]))).length, 0, "Missed volumes under thirty minutes");
+        eq(Strip.gaps(series("2026-09-11T18:00:00Z", cumulative([12, 12, 12, 35, 12, 12]))).length, 0, "Two missed volumes at a 12 minute cadence stay under three usual intervals");
+        eq(Strip.gaps(series("2026-09-11T18:00:00Z", cumulative([3.5, 3.5, 35.2, 3.5, 85.1, 3.5]))).length, 2, "KTLX: 35 and 85 minute holes are breaks");
+        // Two frames a day apart still show the hole; a placeholder without a time never does.
+        eq(Strip.gaps(series("2026-09-10T20:56:00Z", [0, 26 * H])).length, 1, "A two-frame history with a hole");
+        var loading = series("2026-09-11T18:00:00Z", cumulative([4.5, 4.5])).concat([{ id: "KAKQ-loading", scanTime: "", status: "partial" }]);
+        eq(Strip.gaps(loading).length, 0, "A placeholder has no time and no break");
+        eq(Strip.gaps([]).length, 0, "Empty timeline");
+        eq(Strip.gaps([frames[0]]).length, 0, "Single frame");
+        // The strip: a break marker is a position, not a frame or a seek target; pads fill to the capacity in frames.
+        var wide = Strip.slots(frames, 60), narrow = Strip.slots(frames, 0);
+        eq(wide.filter(s => s.id).length, 40, "Ticks equal frames");
+        eq(wide.filter(s => s.gap).length, 1, "One break marker");
+        eq(wide.filter(s => s.empty).length, 20, "Pads fill to sixty frames");
+        eq(wide.length, 61, "Sixty positions plus the break");
+        eq(wide[21].gap && wide[20].id === "f20" && wide[22].id === "f21", true, "The marker sits between the frames it separates");
+        eq(wide.filter(s => s.gap || s.empty).every(s => s.id === ""), true, "Breaks and pads carry no id");
+        eq(narrow.length, 41, "Compact: ticks plus the break, no pads");
+        // Crossing: one step over the hole either way, a scrub across it, and the moves that are not a crossing.
+        var t = frames;
+        eq(Strip.crossing(t, "f20", "f21", false, t), { ms: gaps[0].ms, backward: false }, "Step forward across the hole");
+        eq(Strip.crossing(t, "f21", "f20", false, t), { ms: gaps[0].ms, backward: true }, "Step back across the hole");
+        eq(Strip.crossing(t, "f5", "f30", false, t), { ms: gaps[0].ms, backward: false }, "A scrub across the hole");
+        eq(Strip.crossing(t, "f5", "f6", false, t), null, "A step with no hole");
+        eq(Strip.crossing(t, "f5", "f5", false, t), null, "No move");
+        eq(Strip.crossing(t, "f39", "f0", true, t), null, "The loop wrapping");
+        eq(Strip.crossing(t, "f39", "f0", false, t), null, "The oldest key");
+        eq(Strip.crossing(t, "f0", "f39", false, t), null, "The newest key");
+        eq(Strip.crossing(t, "f20", "f21", true, t), { ms: gaps[0].ms, backward: false }, "Playback crossing forward");
+        eq(Strip.crossing(t, "", "f21", false, t), null, "No previous frame");
+        eq(Strip.crossing(t, "f20", "elsewhere", false, t), null, "An id outside the timeline");
+        eq(Strip.crossing(t, "f20", "f21", false, t.slice(0, 21)), null, "A frame new to the timeline: the feed moved");
+        var two = series("2026-09-10T20:56:00Z", [0, 26 * H]);
+        eq(Strip.crossing(two, "f0", "f1", false, two), { ms: 26 * H * 60000, backward: false }, "Two frames: the step is the crossing");
+        eq(Strip.crossing(two, "f1", "f0", true, two), null, "Two frames: the loop wrapping");
+        // Words.
+        eq(Strip.elapsed(35.2 * 60000), "35 min", "Minutes");
+        eq(Strip.elapsed(85.1 * 60000), "1h 25m", "Hours and minutes under three hours");
+        eq(Strip.elapsed(2 * H * 60000), "2h", "Whole hours under three");
+        eq(Strip.elapsed(113.2 * 60000), "1h 53m", "KRLX");
+        eq(Strip.elapsed(896.5 * 60000), "15h", "KJAX");
+        eq(Strip.elapsed(1272.9 * 60000), "21h", "KTLX");
+        eq(Strip.elapsed(50 * H * 60000), "2d 2h", "Days and hours");
+        eq(Strip.elapsed(3 * D * 60000), "3d", "Whole days");
+        eq(Strip.notice({ ms: gaps[0].ms, backward: false }, "full"), "Skipped 26h · no scans available", "Forward notice");
+        eq(Strip.notice({ ms: gaps[0].ms, backward: true }, "full"), "Back 26h · no scans available", "Backward notice");
+        eq(Strip.notice({ ms: gaps[0].ms, backward: false }, "short"), "Skipped 26h · no scans", "Short notice");
+        eq(Strip.notice({ ms: gaps[0].ms, backward: true }, "bare"), "Back 26h", "Bare notice");
+        eq(Strip.notice(null, "full"), "", "No crossing, no notice");
+        console.log("TIMELINE_PASSED");
+        Qt.quit();
+    }
+    Timer { interval: 5000; running: true; onTriggered: Qt.quit() }
+}
+QML
+QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME=basic quickshell -p "$check_dir/shell.qml" > "$check_dir/result.log" 2>&1 || true
+cat "$check_dir/result.log"
+rg -q TIMELINE_PASSED "$check_dir/result.log"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -94,7 +94,7 @@ if step build bash scripts/cargo.sh test --offline --locked --no-run; then
   tests & lanes+=($!)
   # check-picker and check-keys select stations for real, so they run last.
   lane window check-engine-ui check-map-sites check-map-network check-location check-picker check-keys & lanes+=($!)
-  lane alone check-ip-location check-bind check-link-plugin check-launcher check-theme check-map-tiles test-engine-pin check-engine-release check-popover & lanes+=($!)
+  lane alone check-timeline check-ip-location check-bind check-link-plugin check-launcher check-theme check-map-tiles test-engine-pin check-engine-release check-popover & lanes+=($!)
   for pid in "${lanes[@]}"; do wait "$pid" || failed=1; done
   lanes=()
 else

--- a/ui/Popover.qml
+++ b/ui/Popover.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import "Keys.js" as KeyMap
+import "Timeline.js" as Strip
 
 FocusScope {
     id: card
@@ -12,14 +13,27 @@ FocusScope {
     readonly property var scan: state ? state.frame : null
     readonly property var frames: state ? state.timeline : []
     // Popover is too narrow for the window's fixed 60 empties. One tick per
-    // frame, no gap stubs, pixel-snapped — same language, denser strip.
-    readonly property var slots: {
-        var result = [];
-        for (var j = 0; j < frames.length; j++)
-            result.push({id: frames[j].id, partial: frames[j].status === "partial"});
-        return result;
+    // frame plus break markers, pixel-snapped — same language, denser strip.
+    readonly property var slots: Strip.slots(frames, 0)
+    readonly property int currentSlot: scan ? slots.findIndex(s => s.id && s.id === scan.id) : -1
+    property int hoveredGap: -1
+    property string gapNotice: ""
+    property string shownId: ""
+    property var shownTimeline: []
+    Timer { id: gapNoticeTimer; interval: 4000; onTriggered: card.gapNotice = "" }
+    onStateChanged: {
+        var id = state && state.frame ? state.frame.id : "", timeline = state ? state.timeline : [];
+        if (id !== shownId) {
+            var crossed = Strip.crossing(timeline, shownId, id, !!state && state.playing, shownTimeline);
+            shownId = id;
+            if (crossed) { gapNotice = Strip.notice(crossed, "bare"); gapNoticeTimer.restart(); }
+        }
+        shownTimeline = timeline;
     }
-    readonly property int currentSlot: scan ? slots.findIndex(s => s.id === scan.id) : -1
+    function stamp(iso) {
+        var loc = Qt.locale(), d = new Date(iso);
+        return Qt.formatDateTime(d, loc.dateFormat(Locale.ShortFormat) + " " + loc.timeFormat(Locale.ShortFormat));
+    }
     readonly property string condition: state ? state.source === "archived" ? "archived" : state.connection.status : "offline"
     readonly property color statusColor: condition === "stale" ? theme.yellow
         : condition === "offline" || condition === "unavailable" ? theme.red : theme.accent
@@ -153,6 +167,12 @@ FocusScope {
                 }
                 Item { Layout.fillWidth: true }
                 Rectangle {
+                    implicitWidth: notice.implicitWidth + 10; implicitHeight: 20
+                    visible: card.gapNotice !== ""
+                    color: Qt.alpha(card.theme.background, .92)
+                    Label { id: notice; anchors.centerIn: parent; font.pixelSize: 10; color: card.theme.yellow; text: card.gapNotice }
+                }
+                Rectangle {
                     implicitWidth: time.implicitWidth + 10; implicitHeight: 20
                     color: Qt.alpha(card.theme.background, .92)
                     Label { id: time; anchors.centerIn: parent; font.pixelSize: 10; opacity: .8
@@ -211,21 +231,53 @@ FocusScope {
                     id: strip
                     Layout.fillWidth: true
                     implicitHeight: 14
+                    readonly property real span: Math.max(1, width - 3)
+                    function slotX(i) { return card.slots.length > 1 ? Math.round(1.5 + i * span / (card.slots.length - 1)) : Math.round(width / 2); }
                     Repeater {
                         model: card.slots
-                        Rectangle {
+                        Item {
+                            id: slot
                             required property var modelData
                             required property int index
-                            readonly property bool current: index === card.currentSlot
-                            x: card.slots.length > 1 ? Math.round(index * (strip.width - width) / (card.slots.length - 1)) : Math.round((strip.width - width) / 2)
-                            y: Math.round((strip.height - height) / 2)
-                            width: current || modelData.partial ? 3 : 2
-                            height: current || modelData.partial ? 14 : 10
-                            color: current ? card.theme.accent : modelData.partial ? "transparent"
-                                : Qt.alpha(card.theme.foreground, .40)
-                            border.width: modelData.partial && !current ? 1 : 0
-                            border.color: card.theme.accent
+                            readonly property bool current: !!modelData.id && index === card.currentSlot
+                            readonly property bool tall: current || modelData.partial
+                            x: strip.slotX(index) - Math.round(width / 2)
+                            width: tall ? 3 : 2
+                            height: strip.height
+                            Rectangle {
+                                visible: !slot.modelData.gap
+                                anchors.horizontalCenter: parent.horizontalCenter
+                                y: Math.round((strip.height - height) / 2)
+                                width: slot.width
+                                height: slot.tall ? 14 : 10
+                                color: slot.current ? card.theme.accent : slot.modelData.partial ? "transparent"
+                                    : Qt.alpha(card.theme.foreground, .40)
+                                border.width: slot.modelData.partial && !slot.current ? 1 : 0
+                                border.color: card.theme.accent
+                            }
+                            Column {
+                                visible: slot.modelData.gap
+                                anchors.centerIn: parent
+                                spacing: 2
+                                Repeater {
+                                    model: 3
+                                    Rectangle { width: 2; height: 3; color: card.theme.yellow; opacity: card.hoveredGap === slot.index ? 1 : .8 }
+                                }
+                            }
                         }
+                    }
+                    MouseArea {
+                        anchors.fill: parent
+                        anchors.topMargin: -4
+                        anchors.bottomMargin: -4
+                        hoverEnabled: true
+                        acceptedButtons: Qt.NoButton
+                        onPositionChanged: mouse => {
+                            var n = card.slots.length;
+                            var i = n < 2 ? -1 : Math.round(Math.max(0, Math.min(1, (mouse.x - 1.5) / strip.span)) * (n - 1));
+                            card.hoveredGap = i >= 0 && card.slots[i].gap && Math.abs(mouse.x - strip.slotX(i)) <= 6 ? i : -1;
+                        }
+                        onExited: card.hoveredGap = -1
                     }
                 }
                 RowLayout {
@@ -243,6 +295,27 @@ FocusScope {
             opacity: .5
             elide: Text.ElideRight
             text: map.osmOnScreen ? "NOAA · © OpenStreetMap" : "NOAA · Natural Earth"
+        }
+    }
+    Rectangle {
+        id: breakNote
+        readonly property var slot: card.hoveredGap >= 0 && card.hoveredGap < card.slots.length ? card.slots[card.hoveredGap] : null
+        readonly property point anchor: slot ? strip.mapToItem(card, strip.slotX(card.hoveredGap), 0) : Qt.point(0, 0)
+        visible: !!slot && slot.gap
+        x: Math.round(Math.max(0, Math.min(card.width - width, anchor.x - width / 2)))
+        y: Math.round(anchor.y - height - 6)
+        width: noteRows.implicitWidth + 16
+        height: noteRows.implicitHeight + 12
+        color: Qt.alpha(card.theme.background, .96)
+        border.width: 1
+        border.color: Qt.alpha(card.theme.foreground, .45)
+        ColumnLayout {
+            id: noteRows
+            anchors.centerIn: parent
+            spacing: 2
+            Label { text: "No scans available between these times"; font.pixelSize: 10; opacity: .8 }
+            Label { text: breakNote.slot ? card.stamp(breakNote.slot.from) + " → " + card.stamp(breakNote.slot.to) : ""; font.pixelSize: 10 }
+            Label { text: breakNote.slot ? Strip.elapsed(breakNote.slot.ms) : ""; color: card.theme.yellow; font.pixelSize: 10 }
         }
     }
 }

--- a/ui/Popover.qml
+++ b/ui/Popover.qml
@@ -18,15 +18,25 @@ FocusScope {
     readonly property int currentSlot: scan ? slots.findIndex(s => s.id && s.id === scan.id) : -1
     property int hoveredGap: -1
     property string gapNotice: ""
+    property bool gapNoticeStale: false
     property string shownId: ""
     property var shownTimeline: []
     Timer { id: gapNoticeTimer; interval: 4000; onTriggered: card.gapNotice = "" }
+    Timer { id: gapNoticeHold; interval: 1500; onTriggered: if (card.gapNoticeStale) card.gapNotice = "" }
     onStateChanged: {
         var id = state && state.frame ? state.frame.id : "", timeline = state ? state.timeline : [];
         if (id !== shownId) {
             var crossed = Strip.crossing(timeline, shownId, id, !!state && state.playing, shownTimeline);
             shownId = id;
-            if (crossed) { gapNotice = Strip.notice(crossed, "bare"); gapNoticeTimer.restart(); }
+            if (crossed) {
+                gapNotice = Strip.notice(crossed, "bare");
+                gapNoticeStale = false;
+                gapNoticeTimer.restart();
+                gapNoticeHold.restart();
+            } else if (gapNotice) {
+                if (gapNoticeHold.running) gapNoticeStale = true;
+                else gapNotice = "";
+            }
         }
         shownTimeline = timeline;
     }

--- a/ui/PopoverHarness.qml
+++ b/ui/PopoverHarness.qml
@@ -51,6 +51,7 @@ ShellRoot {
                 connected: popover.engine.socket.connected, retry: popover.engine.reconnect.running, transport: popover.engine.error, condition: popover.condition, text: popover.statusText, expanded: harness.expanded,
                 window: panel.opened, windowSite: panel.siteId, windowFrame: panel.scan ? panel.scan.id : "",
                 windowPlaying: panel.playing, windowTreatment: panel.treatment, error: session.startupError,
+                notice: popover.gapNotice, windowNotice: panel.gapNotice, gaps: popover.slots.filter(s => s.gap).length,
                 needsLocation: session.needsLocation, lat: session.centerLat, lon: session.centerLon});
         }
         function capture(path: string): void { picture.grabToImage(result => result.saveToFile(path)); }

--- a/ui/RadarWindow.qml
+++ b/ui/RadarWindow.qml
@@ -6,6 +6,7 @@ import Quickshell.Io
 import "Sites.js" as Sites
 import "Keys.js" as KeyMap
 import "Location.js" as Location
+import "Timeline.js" as Strip
 
 Item {
     id: app
@@ -101,17 +102,31 @@ Item {
     }
     // History fills 60 positions from the left when the strip is wide enough.
     // Compact widths drop the empty pads — at ~5 px/slot they read as a
-    // dotted cliff after the playhead instead of "room to fill."
-    readonly property var slots: {
-        var result = [];
-        for (var j = 0; j < frames.length; j++)
-            result.push({id: frames[j].id, partial: frames[j].status === "partial", empty: false});
-        if (!win.compact) {
-            for (var i = frames.length; i < 60; i++) result.push({empty: true, partial: false});
-        }
-        return result;
+    // dotted cliff after the playhead instead of "room to fill." A break
+    // marker sits between frames a hole separates (Timeline.js).
+    readonly property var slots: Strip.slots(frames, win.compact ? 0 : 60)
+    readonly property int currentSlot: scan ? slots.findIndex(s => s.id && s.id === scan.id) : -1
+    // The break note: the hovered or focused marker's slot, -1 for none.
+    property int hoveredGap: -1
+    property int focusedGap: -1
+    readonly property int notedGap: hoveredGap >= 0 ? hoveredGap : focusedGap
+    // The break notice: set when the frame on screen moved across a hole;
+    // the longest wording that fits beside the stamp.
+    property var gapCrossed: null
+    property string shownId: ""
+    property var shownTimeline: []
+    readonly property string gapNotice: breakNotice.text
+    Timer { id: gapNoticeTimer; interval: 4000; onTriggered: app.gapCrossed = null }
+    function noteCrossing() {
+        var id = state && state.frame ? state.frame.id : "", timeline = state ? state.timeline : [];
+        if (id === shownId) { shownTimeline = timeline; return; }
+        var crossed = Strip.crossing(timeline, shownId, id, !!state && state.playing, shownTimeline);
+        shownId = id;
+        shownTimeline = timeline;
+        if (!crossed) return;
+        gapCrossed = crossed;
+        gapNoticeTimer.restart();
     }
-    readonly property int currentSlot: scan ? slots.findIndex(s => !s.empty && s.id === scan.id) : -1
     function togglePlay() { if (frames.length > 1) engine.send({type: playing ? "pause" : "play"}); }
     function step(delta) { if (frames.length > 1) engine.send({type: "step", delta: delta}); }
     function jump(toNewest) { if (frames.length > 1) engine.send({type: "seek", id: frames[toNewest ? frames.length - 1 : 0].id}); }
@@ -167,6 +182,7 @@ Item {
     }
     property bool viewApplied: false
     onStateChanged: {
+        noteCrossing();
         if (!state) viewApplied = false;
         else {
             store.initialize();
@@ -252,9 +268,11 @@ Item {
         function bindings(): string { return JSON.stringify(app.bindings); }
         function errors(): string { return JSON.stringify(app.configErrors); }
         function menu(open: bool): void { if (open) treatmentMenu.show(); else treatmentMenu.close(); }
+        function gap(index: int): void { strip.focusGap(index); }
         function field(name: string): string { var value = JSON.parse(status())[name]; return value === undefined ? "" : String(value); }
         function status(): string {
             return JSON.stringify({sheet: sheet.open, menu: treatmentMenu.opened, treatment: app.treatment, weakFloor: app.weakFloor === null ? "off" : app.weakFloor, error: app.configError,
+                                   gaps: app.slots.filter(s => s.gap).length, notedGap: app.notedGap, notice: app.gapNotice,
                                    span: Math.round(map.span * 10) / 10, lat: Math.round(map.centerLat * 1000) / 1000, lon: Math.round(map.centerLon * 1000) / 1000,
                                    locationSource: app.store.locationSource, needsLocation: app.store.needsLocation, locating: app.store.locating,
                                    site: app.siteId, locked: app.locked, lockSource: app.store.lockSource, outsideCoverage: app.outsideCoverage});
@@ -521,7 +539,10 @@ Item {
             //   transport     — playback buttons
             //   tick strip    — frame ticks
             //   strip stamp   — date/time/zone above the tick strip
+            //   break notice  — "Skipped 26h · no scans available" beside the stamp
             //   frame index   — N / available frames above the strip
+            //   break marker  — dashed yellow mark between frames a hole separates
+            //   break note    — card over a hovered or focused break marker
             RowLayout {
                 id: brandRow
                 Layout.fillWidth: true
@@ -890,13 +911,31 @@ Item {
                         spacing: 8
                         LabelText {
                             id: stripStamp
-                            Layout.fillWidth: true
                             visible: !!app.scan && !!app.scan.scanTime
                             text: app.scan ? app.stamp(app.scan.scanTime) : ""
                             font.pixelSize: 10
                             opacity: .65
                             horizontalAlignment: Text.AlignLeft
                             elide: Text.ElideRight
+                        }
+                        // break notice — the hole the playhead just crossed
+                        LabelText {
+                            id: breakNotice
+                            Layout.fillWidth: true
+                            text: {
+                                if (!app.gapCrossed) return "";
+                                var forms = ["full", "short", "bare"];
+                                for (var i = 0; i < forms.length - 1; i++) {
+                                    var candidate = Strip.notice(app.gapCrossed, forms[i]);
+                                    if (candidate.length * noticeMetrics.advanceWidth <= width) return candidate;
+                                }
+                                return Strip.notice(app.gapCrossed, "bare");
+                            }
+                            color: app.theme.yellow
+                            font.pixelSize: 10
+                            horizontalAlignment: Text.AlignLeft
+                            elide: Text.ElideRight
+                            TextMetrics { id: noticeMetrics; font.family: app.theme.font; font.pixelSize: 10; text: "0" }
                         }
                         LabelText {
                             visible: !win.compact && app.frameIndex >= 0
@@ -910,45 +949,81 @@ Item {
                         id: strip
                         Layout.fillWidth: true
                         implicitHeight: 14
+                        readonly property real span: Math.max(1, width - 3)
+                        function slotAt(mx) {
+                            var n = app.slots.length;
+                            return n < 2 ? -1 : Math.round(Math.max(0, Math.min(1, (mx - 1.5) / span)) * (n - 1));
+                        }
+                        function slotX(i) { return app.slots.length > 1 ? Math.round(1.5 + i * span / (app.slots.length - 1)) : Math.round(width / 2); }
+                        function focusGap(n) {
+                            var seen = -1;
+                            for (var i = 0; i < app.slots.length; i++)
+                                if (app.slots[i].gap && ++seen === n) { markers.itemAt(i).forceActiveFocus(); return; }
+                        }
                         Repeater {
+                            id: markers
                             model: app.slots
-                            Rectangle {
+                            Item {
+                                id: slot
                                 required property var modelData
                                 required property int index
-                                readonly property bool current: !modelData.empty && index === app.currentSlot
+                                readonly property bool current: !!modelData.id && index === app.currentSlot
                                 readonly property bool tall: current || modelData.partial
-                                x: app.slots.length > 1 ? Math.round(index * (strip.width - width) / (app.slots.length - 1)) : Math.round((strip.width - width) / 2)
-                                y: Math.round((strip.height - height) / 2)
+                                x: strip.slotX(index) - Math.round(width / 2)
                                 width: tall ? 3 : 2
-                                height: modelData.empty ? 3 : tall ? 14 : 8
-                                // Compact (no empty pads): even weight so a mid-loop
-                                // playhead does not cliff into dimmer stubs.
-                                color: current ? app.theme.accent : modelData.partial ? "transparent"
-                                    : Qt.alpha(app.theme.foreground, modelData.empty ? .10
-                                        : win.compact ? .40
-                                        : index > app.currentSlot ? .28 : .42)
-                                border.width: modelData.partial && !current ? 1 : 0
-                                border.color: app.theme.accent
+                                height: strip.height
+                                activeFocusOnTab: modelData.gap
+                                onActiveFocusChanged: if (modelData.gap) app.focusedGap = activeFocus ? index : app.focusedGap === index ? -1 : app.focusedGap
+                                Rectangle {
+                                    visible: !slot.modelData.gap
+                                    anchors.horizontalCenter: parent.horizontalCenter
+                                    y: Math.round((strip.height - height) / 2)
+                                    width: slot.width
+                                    height: slot.modelData.empty ? 3 : slot.tall ? 14 : 8
+                                    // Compact (no empty pads): even weight so a mid-loop
+                                    // playhead does not cliff into dimmer stubs.
+                                    color: slot.current ? app.theme.accent : slot.modelData.partial ? "transparent"
+                                        : Qt.alpha(app.theme.foreground, slot.modelData.empty ? .10
+                                            : win.compact ? .40
+                                            : slot.index > app.currentSlot ? .28 : .42)
+                                    border.width: slot.modelData.partial && !slot.current ? 1 : 0
+                                    border.color: app.theme.accent
+                                }
+                                // break marker — three dashes; never a seek target
+                                Column {
+                                    visible: slot.modelData.gap
+                                    anchors.centerIn: parent
+                                    spacing: 2
+                                    Repeater {
+                                        model: 3
+                                        Rectangle { width: 2; height: 3; color: app.theme.yellow; opacity: app.notedGap === slot.index ? 1 : .8 }
+                                    }
+                                }
                             }
                         }
                         // Dragging scrubs: the nearest frame under the pointer is sought
-                        // once per frame change; the engine pauses on a seek.
+                        // once per frame change; the engine pauses on a seek. Breaks and
+                        // pads are skipped. Hovering a break shows its note.
                         MouseArea {
                             anchors.fill: parent
                             anchors.topMargin: -6
                             anchors.bottomMargin: -18
-                            enabled: app.frames.length > 1
+                            hoverEnabled: true
+                            enabled: app.frames.length > 0
                             property string target: ""
                             function scrub(mx) {
-                                var n = app.slots.length;
-                                if (n < 2) return;
-                                var i = Math.round(Math.max(0, Math.min(1, mx / strip.width)) * (n - 1));
-                                if (app.slots[i].empty) return;
+                                var i = strip.slotAt(mx);
+                                if (i < 0) return;
                                 var id = app.slots[i].id;
                                 if (id && id !== target) { target = id; engine.send({type: "seek", id: id}); }
                             }
-                            onPressed: mouse => { target = ""; scrub(mouse.x); }
-                            onPositionChanged: mouse => { if (pressed) scrub(mouse.x); }
+                            function hover(mx) {
+                                var i = strip.slotAt(mx);
+                                app.hoveredGap = i >= 0 && app.slots[i].gap && Math.abs(mx - strip.slotX(i)) <= 6 ? i : -1;
+                            }
+                            onPressed: mouse => { target = ""; if (app.frames.length > 1) scrub(mouse.x); }
+                            onPositionChanged: mouse => { hover(mouse.x); if (pressed && app.frames.length > 1) scrub(mouse.x); }
+                            onExited: app.hoveredGap = -1
                         }
                     }
                 }
@@ -1107,6 +1182,31 @@ Item {
                         }
                     }
                 }
+            }
+          }
+          // break note — above the hovered or focused break marker
+          Rectangle {
+            id: breakNote
+            readonly property var slot: app.notedGap >= 0 && app.notedGap < app.slots.length ? app.slots[app.notedGap] : null
+            readonly property point anchor: slot ? strip.mapToItem(surface, strip.slotX(app.notedGap), 0) : Qt.point(0, 0)
+            visible: !!slot && slot.gap
+            x: Math.round(Math.max(6, Math.min(surface.width - width - 6, anchor.x - width / 2)))
+            y: Math.round(anchor.y - height - 8)
+            width: noteRows.implicitWidth + 20
+            height: noteRows.implicitHeight + 14
+            color: Qt.alpha(app.theme.background, .96)
+            border.width: 1
+            border.color: Qt.alpha(app.theme.foreground, .45)
+            ColumnLayout {
+                id: noteRows
+                anchors.centerIn: parent
+                spacing: 3
+                LabelText { text: "No scans available between these times"; font.pixelSize: 10; opacity: .8 }
+                LabelText {
+                    text: breakNote.slot ? app.stamp(breakNote.slot.from) + "  →  " + app.stamp(breakNote.slot.to) : ""
+                    font.pixelSize: 10
+                }
+                LabelText { text: breakNote.slot ? Strip.elapsed(breakNote.slot.ms) : ""; color: app.theme.yellow; font.pixelSize: 10 }
             }
           }
           // The `?` sheet over everything, below the map's top edge.

--- a/ui/RadarWindow.qml
+++ b/ui/RadarWindow.qml
@@ -112,20 +112,30 @@ Item {
     readonly property int notedGap: hoveredGap >= 0 ? hoveredGap : focusedGap
     // The break notice: set when the frame on screen moved across a hole;
     // the longest wording that fits beside the stamp.
+    // It clears when the frame changes again, but stays at least 1.5 s so
+    // the loop's pace cannot flash it, and at most 4 s while paused.
     property var gapCrossed: null
+    property bool gapNoticeStale: false
     property string shownId: ""
     property var shownTimeline: []
     readonly property string gapNotice: breakNotice.text
     Timer { id: gapNoticeTimer; interval: 4000; onTriggered: app.gapCrossed = null }
+    Timer { id: gapNoticeHold; interval: 1500; onTriggered: if (app.gapNoticeStale) app.gapCrossed = null }
     function noteCrossing() {
         var id = state && state.frame ? state.frame.id : "", timeline = state ? state.timeline : [];
         if (id === shownId) { shownTimeline = timeline; return; }
         var crossed = Strip.crossing(timeline, shownId, id, !!state && state.playing, shownTimeline);
         shownId = id;
         shownTimeline = timeline;
-        if (!crossed) return;
-        gapCrossed = crossed;
-        gapNoticeTimer.restart();
+        if (crossed) {
+            gapCrossed = crossed;
+            gapNoticeStale = false;
+            gapNoticeTimer.restart();
+            gapNoticeHold.restart();
+        } else if (gapCrossed) {
+            if (gapNoticeHold.running) gapNoticeStale = true;
+            else gapCrossed = null;
+        }
     }
     function togglePlay() { if (frames.length > 1) engine.send({type: playing ? "pause" : "play"}); }
     function step(delta) { if (frames.length > 1) engine.send({type: "step", delta: delta}); }

--- a/ui/Timeline.js
+++ b/ui/Timeline.js
@@ -1,15 +1,85 @@
 .pragma library
-// Frame ticks and up to three stubs for missing scan intervals.
-function slots(frames) {
-    var out = [], n = frames.length;
-    if (!n) return out;
-    var gaps = [];
-    for (var i = 1; i < n; i++) gaps.push(Date.parse(frames[i].scanTime) - Date.parse(frames[i - 1].scanTime));
-    var sorted = gaps.slice().sort((a, b) => a - b), median = sorted.length ? sorted[Math.floor(sorted.length / 2)] : 0;
-    for (var j = 0; j < n; j++) {
-        var missing = j > 0 && median > 0 ? Math.min(3, Math.round(gaps[j - 1] / median) - 1) : 0;
-        for (var k = 0; k < missing; k++) out.push({ id: "", stub: true, partial: false });
-        out.push({ id: frames[j].id, stub: false, partial: frames[j].status === "partial" });
+// Breaks in the tick strip (DESIGN.md, time): an interval over thirty
+// minutes and over three usual intervals (median of those under thirty).
+var MIN_GAP_MS = 30 * 60 * 1000;
+var CADENCE_FACTOR = 3;
+
+function scanMs(frame) {
+    var t = frame && frame.scanTime ? Date.parse(frame.scanTime) : NaN;
+    return isNaN(t) ? null : t;
+}
+
+function cadence(frames) {
+    var usual = [];
+    for (var i = 1; i < frames.length; i++) {
+        var a = scanMs(frames[i - 1]), b = scanMs(frames[i]);
+        if (a === null || b === null) continue;
+        var d = b - a;
+        if (d > 0 && d <= MIN_GAP_MS) usual.push(d);
+    }
+    if (!usual.length) return 0;
+    usual.sort((x, y) => x - y);
+    return usual[Math.floor(usual.length / 2)];
+}
+
+function threshold(frames) {
+    return Math.max(MIN_GAP_MS, CADENCE_FACTOR * cadence(frames));
+}
+
+function gaps(frames) {
+    var out = [], limit = threshold(frames);
+    for (var i = 1; i < frames.length; i++) {
+        var a = scanMs(frames[i - 1]), b = scanMs(frames[i]);
+        if (a === null || b === null || b - a <= limit) continue;
+        out.push({ after: i - 1, from: frames[i - 1].scanTime, to: frames[i].scanTime, ms: b - a });
     }
     return out;
+}
+
+// Ticks, break markers, and pads up to `capacity` frames. Only ticks carry an id.
+function slots(frames, capacity) {
+    var out = [], breaks = gaps(frames), g = 0;
+    for (var i = 0; i < frames.length; i++) {
+        out.push({ id: frames[i].id, partial: frames[i].status === "partial", empty: false, gap: false });
+        if (g < breaks.length && breaks[g].after === i) {
+            out.push({ id: "", partial: false, empty: false, gap: true, from: breaks[g].from, to: breaks[g].to, ms: breaks[g].ms });
+            g++;
+        }
+    }
+    for (var p = frames.length; p < (capacity || 0); p++) out.push({ id: "", partial: false, empty: true, gap: false });
+    return out;
+}
+
+// Breaks between the frame that was shown and the one that is, or null: a
+// frame new to `previous` (the feed moved), a backward move while playing
+// (the loop wrapped), or an end-to-end jump of more than one step.
+function crossing(frames, fromId, toId, playing, previous) {
+    if (!fromId || !toId || fromId === toId) return null;
+    var i = frames.findIndex(f => f.id === fromId), j = frames.findIndex(f => f.id === toId);
+    if (i < 0 || j < 0) return null;
+    if (previous && previous.findIndex(f => f.id === toId) < 0) return null;
+    if (playing && j < i) return null;
+    var lo = Math.min(i, j), hi = Math.max(i, j);
+    if (lo === 0 && hi === frames.length - 1 && hi - lo > 1) return null;
+    var total = 0;
+    gaps(frames).forEach(g => { if (g.after >= lo && g.after < hi) total += g.ms; });
+    return total > 0 ? { ms: total, backward: j < i } : null;
+}
+
+function elapsed(ms) {
+    var minutes = Math.round(ms / 60000);
+    if (minutes < 60) return minutes + " min";
+    var h = Math.floor(minutes / 60), m = minutes % 60;
+    if (h < 3) return m ? h + "h " + m + "m" : h + "h";
+    var hours = Math.round(minutes / 60);
+    if (hours < 48) return hours + "h";
+    var d = Math.floor(hours / 24);
+    return hours % 24 ? d + "d " + (hours % 24) + "h" : d + "d";
+}
+
+// "Skipped 26h · no scans available", or shorter forms for narrow rows.
+function notice(crossed, form) {
+    if (!crossed) return "";
+    var jump = (crossed.backward ? "Back " : "Skipped ") + elapsed(crossed.ms);
+    return form === "bare" ? jump : form === "short" ? jump + " · no scans" : jump + " · no scans available";
 }


### PR DESCRIPTION
Closes #65.

## Why

The tick strip places one evenly spaced tick per available frame, so two neighbours a day apart read as one ordinary step: the stamp and the map jump while the playhead moves one position, and a quiet → rain cut looks like a glitch. Trailing pads are "room to fill" and cannot also stand for missing time.

## What changed

**Break marker.** A dashed yellow mark (three 2×3 px dashes, the strip's height) sits between two frames whose interval is a hole. It is a position in the strip, not a frame: it is not counted in `N / total`, a scrub skips over it, stepping does not stop on it, and it carries no id. Yellow is the cue the chrome already uses for "not what you expect" (stale light, lock outside coverage), and the dashed form keeps it apart from solid frame ticks and the faint 3 px pads.

**Break note.** Hovering the marker, or focusing it with Tab, shows a card above it: `No scans available between these times`, the two bounding stamps in the strip stamp's format, and the length. Neutral wording: the scans are unavailable; the app does not guess why.

**Break notice.** When the frame on screen moves across a hole by a step, a scrub, or playback, the stamp row shows `Skipped 26h · no scans available` (or `Back 26h …` going the other way) in yellow. It clears when the frame changes again, after a 1.5 s hold so the loop's pace cannot flash it, and after four seconds at most while paused. The longest of three wordings that fits the row is used, so compact widths read `Skipped 26h` instead of an ellipsis. Not crossings, and so silent: the loop wrapping to the oldest frame (a backward move while playing), the oldest and newest keys (an end-to-end jump), and a new sweep arriving after a silence (the frame is new to the timeline — the feed moved, not the user).

**Threshold.** An interval is a hole when it exceeds thirty minutes (the silence that shows UNAVAILABLE while live, `docs/protocol.md`) *and* three usual intervals, the usual interval being the median of those under thirty minutes. Chosen against this machine's catalog for nineteen stations (September 2026):

| Observed | Example | Break? |
|---|---|---|
| Ordinary cadence | 3.3 – 8.8 min | no |
| VCP change inside one history | KAKQ 4.5 → 7.1 min, KVWX 4.4 → 6.8 min | no |
| One missed volume | KRAX, KTLX 17.5 – 17.9 min | no |
| Two missed volumes at a slow cadence | 35 min at a 12 min cadence | no (under 3× cadence) |
| Holes | KTLX 35 and 85 min, KRLX 113 min, KJAX 15 h, KTLX 21 h, **KAKQ 1549 min ≈ 26 h** | yes |

The popover strip carries the same markers and note and the bare notice (`Skipped 26h`) in a chip beside the time, since its row is narrower.

`ui/Timeline.js` was an unused stub; it now holds the gap logic as pure functions shared by the window and popover (`gaps`, `slots`, `crossing`, `elapsed`, `notice`), so it can be driven from a check without a daemon.

## Screenshots

Synthetic KAKQ-shaped history laid over the archived state (`scripts/capture-gaps.sh`): 21 frames at 7 min to 09/10 4:56 PM EDT, a 26 h hole, then 16 frames at 5.5 min; the playhead steps across the hole three seconds in.

Full width (960 px), notice up after crossing:

![Full width after crossing the hole](https://github.com/user-attachments/assets/a2eedc50-f51b-4c5d-8b23-522a944567f7)

Full width, break marker focused:

![Full width with the break note](https://github.com/user-attachments/assets/47cc8c2b-5303-41ff-86b1-1bb067d75f24)

Compact (400 px), notice shortened to fit:

![Compact after crossing the hole](https://github.com/user-attachments/assets/65be065c-0e4b-4ff5-8933-e0e0fec53687)

Compact, break marker focused:

![Compact with the break note](https://github.com/user-attachments/assets/de6a07d3-6342-45f3-be0e-07ea03a00d77)

## Validation

`mise check` passes (20 steps). New and extended coverage:

- **`scripts/check-timeline.sh`** (new, in the `alone` lane, no daemon): drives `Timeline.js` over the real KAKQ interval sequence (one break after frame 20, 1549 min, reads "26h"); cadence jitter, a VCP change, one and two missed volumes produce no break; KTLX's 35 and 85 min holes do; a two-frame history with a hole; the loading placeholder without a time; empty and single-frame timelines. Slots: ticks equal frames, one marker, pads fill to 60 *frames*, marker sits between the frames it separates, breaks and pads carry no id, compact has no pads. Crossing: forward and backward step, a scrub across, a step with no hole, the loop wrapping, the oldest and newest keys, playback forward across, an id outside the timeline, a frame new to the timeline, and the two-frame wrap. Wording for minutes, hours, days, and the three notice forms.
- **`scripts/check-popover.sh`** (extended): the seeded catalog now has a third frame 26 h after the second. Against the real engine and both surfaces: one marker on each strip, no notice for the step that did not cross, `Skipped 26h · no scans available` on the window and `Skipped 26h` on the popover for the step that did, `Back 26h …` stepping back, the notice outliving the next frame change for its hold and then clearing, the four-second cap while paused, and no notice for a seek that crossed no hole.
- **`scripts/capture-harness.sh`** gained `OMASTORM_STATE_OVERRIDE_THEN[_MS]`, a second override applied after a delay, so a change the UI reacts to can be captured. **`scripts/capture-gaps.sh`** is new and writes the captures above into `review/`.

No engine, protocol, fetching, or playback-pacing changes. Frame counts and seeking stay tied to available frames.