### PR TITLE
feat: add live DWD radar for Germany via DX single-site sweeps

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -33,7 +33,7 @@ the ids and comments in `ui/RadarWindow.qml`.
 | **brand row** | Mark, OMASTORM, status light, LIVE / ARCHIVED |
 | **site row** | Station title, radar lock (yellow when the camera is outside that radar's rings) |
 | **product stack** | Right column: product line + meta line |
-| **product line** | Product name / tilt and NOAA NEXRAD |
+| **product line** | Product name / tilt and radar source |
 | **meta line** | Age, right-aligned under the product line |
 | **map stage** | Radar map frame |
 | **follow chip** | Crosshair on the map (place follow); hidden until GPS is wired |
@@ -49,7 +49,7 @@ the ids and comments in `ui/RadarWindow.qml`.
 strip, with the strip stamp left-aligned and frame index right-aligned
 on one row above the ticks. Playback buttons align with the track at the bottom.
 
-**Product stack.** Compact product line (name, then NOAA NEXRAD). The meta
+**Product stack.** Compact product line (name, then the radar source from the frame). The meta
 line is the age only, right-aligned under that row.
 
 **Time.** Age on the meta line is how stale the frame on screen is. The

--- a/README.md
+++ b/README.md
@@ -187,7 +187,9 @@ This is a beta. Bugs, rough edges, and ideas go to
 
 ## Data and licenses
 
-Radar: NOAA NEXRAD Level II via the NOAA Open Data program on AWS. Basemap: ©
+Radar: NOAA NEXRAD Level II via the NOAA Open Data program on AWS; DWD DX
+single-site sweeps via the [DWD Open Data Server](https://opendata.dwd.de)
+(radar: © Deutscher Wetterdienst). Basemap: ©
 OpenStreetMap contributors, [ODbL](https://opendatacommons.org/licenses/odbl/1-0/),
 tiles by [OpenFreeMap](https://openfreemap.org); Natural Earth, public domain.
 Location search: [GeoNames](https://www.geonames.org/),

--- a/data/README.md
+++ b/data/README.md
@@ -21,8 +21,8 @@ Natural Earth coastline, lakes, country boundary lines on land, and
 state/province lines at 1:10m and 1:50m, plus 1:10m populated places, from
 [natural-earth-vector](https://github.com/nvkelso/natural-earth-vector) master.
 Made with Natural Earth; [public domain](https://www.naturalearthdata.com/about/terms-of-use/).
-`engine/build.rs` embeds them as polylines (the 1:10m set clipped to the NEXRAD
-network envelope) and the engine strokes them into `ne` tiles at any zoom
+`engine/build.rs` embeds them as polylines (the 1:10m set clipped to the
+station envelope: NEXRAD network plus Germany) and the engine strokes them into `ne` tiles at any zoom
 (`docs/protocol.md`, tiles). Roads and place labels at closer zooms come from
 OpenMapTiles vector tiles served by OpenFreeMap, © OpenStreetMap contributors
 (ODbL), fetched by the engine at run time and attributed in the UI.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -20,7 +20,7 @@ travel over this protocol; they go to the GPU as texture files.
 ```json
 {"type":"hello","v":1,"engine":"0.1.1",
  "sites":[{"id":"KTLX","name":"Oklahoma City","state":"OK",
-           "lat":35.33306,"lon":-97.27748,"altM":388.0}]}
+           "lat":35.33306,"lon":-97.27748,"altM":388.0,"source":"nexrad"}]}
 ```
 
 `state` is the complete current state, re-sent whenever anything in it changes.
@@ -93,8 +93,11 @@ It is small (a few KB) so clients replace rather than merge.
   one rule: the engine refuses to publish a path that breaks it, and the UI
   rejects a `state` whose path breaks it.
 - `frame.product` is the code commands use; `frame.productName` is its display
-  name. The engine owns product, unit, and site vocabulary; the UI only cases
+  name; `frame.source` names the network on screen (`NOAA NEXRAD`, `DWD
+  DX`). The engine owns product, unit, source, and site vocabulary; the UI only cases
   and lays out what it receives, and looks the site name up in `hello.sites`.
+  `hello.sites[].source` is `nexrad` or `dwd` and tells clients which
+  poller serves the station.
 - `frame.palette` has one color per class, in class order, and `frame.bounds`
   has one more entry than `palette`: class `i` covers `bounds[i]` up to
   `bounds[i+1]` in `units`. The UI uploads `palette` to the GPU as a
@@ -188,7 +191,8 @@ when `osm` becomes available. `labels` are the tile's places for the overlay.
   ±180 is answered with an `error`. `lock` and `follow` are shared flags;
   releasing the lock hands off on the next settle, not at once.
 - `search_places` ranks the embedded gazetteer (GeoNames populated places
-  with population ≥ 5000, clipped to the NEXRAD network envelope) for the
+  with population ≥ 5000, clipped to the station envelope: NEXRAD network
+  plus Germany) for the
   location picker and is answered with `places` to the sender only, like
   `tile_ready`. Map labels stay on Natural Earth. `query` is required;
   optional `lat` and `lon` order nearer matches first. Word-start matches
@@ -316,7 +320,7 @@ Current fixture `ktlx-20130520`: 720 × 1832, first gate 2125 m, 250 m spacing,
 
 ## Live frames
 
-A live frame is the lowest cut (elevation number 1) of the current volume of
+A live NEXRAD frame is the lowest cut (elevation number 1) of the current volume of
 the selected station, reflectivity, assembled from the real-time chunk bucket
 as chunks arrive: `id` is `<SITE>-<scanTime compact>-e0`, `scanTime` and
 `sweepEnd` are the collection times of the cut's first and last radial so
@@ -330,6 +334,13 @@ station; the UI never reads it). Selecting a station shows its newest
 catalogued frame while the poller replays the current volume's lowest cut
 from the bucket, so a picture arrives within seconds and the next volume
 paints live.
+
+A live DWD frame is the station's DX sweep (0.8°, 360 rays of 128 1 km
+gates), one complete file per 5 minutes from `opendata.dwd.de`: the poller
+backfills the newest catalogued-missing files on join, then follows the
+`-latest-` file. DX dBZ maps onto the same NEXRAD-style codes (`scale` 2.0,
+`offset` 66.0), so `product`, `palette`, and `bounds` are shared; `source`
+is `DWD DX` and there are no `partial` frames or range-folded gates.
 
 ## Configuration
 
@@ -361,7 +372,7 @@ wttr.in after an explicit click, not an engine command.
 `hello` additionally includes `pid`, `build` (an opaque fingerprint),
 `sitesSource`, `sitesRetrieved`, and `sitesNotes`. These allow the launcher to
 identify an existing build and preserve the station snapshot's provenance.
-The 163-site snapshot includes archived/test sites, not an availability list.
+The 180-site snapshot (163 NEXRAD, 17 DWD) includes archived/test sites, not an availability list.
 `frame.site` retains the scan's measured coordinates.
 
 On disconnect the UI hides radar and retries; on an unknown version it

--- a/engine/README.md
+++ b/engine/README.md
@@ -45,6 +45,11 @@ and `nexrad-model` dependencies. It reads through the lowest cut, sorts rays
 stably by azimuth, and publishes a polar sweep texture and azimuth lookup.
 The UI samples these directly; radar arrays never enter JSON or QML JavaScript.
 
+`src/dwd.rs` decodes DWD DX single-site sweeps (0.8°, 360x128, RLE uint16
+over HTTPS) into the same `Sweep` by mapping dBZ onto NEXRAD-style codes, and
+polls each station's `-latest-` file with a listing backfill. No new
+dependencies; DX frames are always complete and never range-folded.
+
 `src/live.rs` polls the real-time chunk bucket through `ChunkIterator`,
 replays the current volume's lowest cut, and assembles incoming radials.
 Each chunk that grows the cut publishes a partial frame; the cut's final
@@ -84,7 +89,8 @@ availability. An archived scan retains its measured coordinates.
 `build.rs` converts Natural Earth lines to a compact polyline blob and embeds
 populated places for map labels. GeoNames cities with population ≥ 5000,
 clipped to the same envelope, are the location-picker gazetteer. The 1:50m
-set is global; the 1:10m set is clipped to the NEXRAD network envelope. `src/tiles.rs` rasterizes these with `tiny-skia`,
+set is global; the 1:10m set is clipped to the station envelope (NEXRAD
+network plus Germany). `src/tiles.rs` rasterizes these with `tiny-skia`,
 using 1:50m below z5 and 1:10m from z5. Segments outside a tile are skipped.
 
 `src/osm.rs` serves OpenMapTiles vector data from z7 through z14, with Natural

--- a/engine/build.rs
+++ b/engine/build.rs
@@ -1,7 +1,7 @@
 //! Converts the Natural Earth GeoJSON that `scripts/extract-fixtures.sh`
 //! extracts into the geography the binary embeds (DESIGN.md, basemap tiles,
 //! shipped geography): one polyline blob holding the 1:50m world set and the
-//! 1:10m set clipped to the NEXRAD network envelope, and the populated places
+//! 1:10m set clipped to the station envelope, and the populated places
 //! for low-zoom labels. GeoNames cities with population ≥ 5000, clipped to
 //! the same envelope, become the location-picker gazetteer. Reruns only when
 //! an input changes.
@@ -24,9 +24,11 @@ const THEMES: [(&str, usize); 4] = [
     ("lakes", 1),
 ];
 /// Everything the site table reaches (DESIGN.md): 5–75° N, west of 20° W or
-/// east of 120° E, holding Lajes, Guam, Kunsan, and Kadena with their range.
+/// east of 120° E, holding Lajes, Guam, Kunsan, and Kadena with their range;
+/// plus Germany (5–16° E, 47–56° N) for the DWD network.
 fn in_envelope(lon: f64, lat: f64) -> bool {
-    (5.0..=75.0).contains(&lat) && (lon <= -20.0 || lon >= 120.0)
+    ((5.0..=75.0).contains(&lat) && (lon <= -20.0 || lon >= 120.0))
+        || ((47.0..=56.0).contains(&lat) && (5.0..=16.0).contains(&lon))
 }
 const SCALE: f64 = 1e5;
 
@@ -144,7 +146,7 @@ fn main() {
     write_gazetteer(&raw, Path::new(&out));
 }
 
-/// GeoNames `cities5000` clipped to the NEXRAD envelope, for the location
+/// GeoNames `cities5000` clipped to the station envelope, for the location
 /// picker only. Map labels stay on Natural Earth (`places.json`).
 fn write_gazetteer(raw: &Path, out: &Path) {
     let mut admin1 = std::collections::HashMap::new();

--- a/engine/data/dwd_sites.json
+++ b/engine/data/dwd_sites.json
@@ -1,0 +1,160 @@
+{
+  "source": "https://www.dwd.de/DE/derdwd/messnetz/atmosphaerenbeobachtung/_functions/HaeufigGesucht/koordinaten-radarverbund.pdf",
+  "retrieved": "2026-09-12",
+  "notes": "DWD radar network: 17 C-band sites. Coordinates from the DWD radar-network sheet (wradlib mirrors them); altM is antenna height above sea level. Live DX reflectivity (0.8°, 360x128) is published per site under https://opendata.dwd.de/weather/radar/sites/dx/. State is the ISO 3166-2:DE Bundesland code. No live availability implied.",
+  "sites": [
+    {
+      "id": "ASB",
+      "name": "BORKUM",
+      "state": "NI",
+      "lat": 53.564011,
+      "lon": 6.748292,
+      "altM": 36.0,
+      "source": "dwd"
+    },
+    {
+      "id": "BOO",
+      "name": "BOOSTEDT",
+      "state": "SH",
+      "lat": 54.00438,
+      "lon": 10.04687,
+      "altM": 124.56,
+      "source": "dwd"
+    },
+    {
+      "id": "DRS",
+      "name": "DRESDEN",
+      "state": "SN",
+      "lat": 51.12465,
+      "lon": 13.76865,
+      "altM": 263.36,
+      "source": "dwd"
+    },
+    {
+      "id": "EIS",
+      "name": "EISBERG",
+      "state": "BY",
+      "lat": 49.54066,
+      "lon": 12.40278,
+      "altM": 798.79,
+      "source": "dwd"
+    },
+    {
+      "id": "ESS",
+      "name": "ESSEN",
+      "state": "NW",
+      "lat": 51.40563,
+      "lon": 6.96712,
+      "altM": 185.1,
+      "source": "dwd"
+    },
+    {
+      "id": "FBG",
+      "name": "FELDBERG",
+      "state": "BW",
+      "lat": 47.87361,
+      "lon": 8.00361,
+      "altM": 1516.1,
+      "source": "dwd"
+    },
+    {
+      "id": "FLD",
+      "name": "FLECHTDORF",
+      "state": "HE",
+      "lat": 51.3112,
+      "lon": 8.802,
+      "altM": 627.88,
+      "source": "dwd"
+    },
+    {
+      "id": "HNR",
+      "name": "HANNOVER",
+      "state": "NI",
+      "lat": 52.46008,
+      "lon": 9.69452,
+      "altM": 97.66,
+      "source": "dwd"
+    },
+    {
+      "id": "ISN",
+      "name": "ISEN",
+      "state": "BY",
+      "lat": 48.1747,
+      "lon": 12.10177,
+      "altM": 677.77,
+      "source": "dwd"
+    },
+    {
+      "id": "MEM",
+      "name": "MEMMINGEN",
+      "state": "BY",
+      "lat": 48.04214,
+      "lon": 10.21924,
+      "altM": 724.4,
+      "source": "dwd"
+    },
+    {
+      "id": "NEU",
+      "name": "NEUHAUS",
+      "state": "TH",
+      "lat": 50.50012,
+      "lon": 11.13504,
+      "altM": 878.04,
+      "source": "dwd"
+    },
+    {
+      "id": "NHB",
+      "name": "NEUHEILENBACH",
+      "state": "RP",
+      "lat": 50.10965,
+      "lon": 6.54853,
+      "altM": 585.84,
+      "source": "dwd"
+    },
+    {
+      "id": "OFT",
+      "name": "OFFENTHAL",
+      "state": "HE",
+      "lat": 49.9847,
+      "lon": 8.71293,
+      "altM": 245.8,
+      "source": "dwd"
+    },
+    {
+      "id": "PRO",
+      "name": "PROETZEL",
+      "state": "BB",
+      "lat": 52.64867,
+      "lon": 13.85821,
+      "altM": 193.92,
+      "source": "dwd"
+    },
+    {
+      "id": "ROS",
+      "name": "ROSTOCK",
+      "state": "MV",
+      "lat": 54.17566,
+      "lon": 12.05808,
+      "altM": 37.0,
+      "source": "dwd"
+    },
+    {
+      "id": "TUR",
+      "name": "TUERKHEIM",
+      "state": "BY",
+      "lat": 48.58528,
+      "lon": 9.78278,
+      "altM": 767.62,
+      "source": "dwd"
+    },
+    {
+      "id": "UMD",
+      "name": "UMMENDORF",
+      "state": "ST",
+      "lat": 52.16009,
+      "lon": 11.17609,
+      "altM": 183.0,
+      "source": "dwd"
+    }
+  ]
+}

--- a/engine/data/fixture.json
+++ b/engine/data/fixture.json
@@ -3,6 +3,7 @@
   "product": "REF",
   "productName": "Reflectivity",
   "units": "dBZ",
+  "source": "NOAA NEXRAD",
   "elevationDeg": 0.48,
   "scanTime": "2013-05-20T20:16:43Z",
   "sweepEnd": "2013-05-20T20:17:00Z",

--- a/engine/src/catalog.rs
+++ b/engine/src/catalog.rs
@@ -250,6 +250,7 @@ mod tests {
             gate_spacing_m: 250,
             scale: 2.0,
             offset: 66.0,
+            source: "NOAA NEXRAD".into(),
             site: Geometry {
                 lat: 35.0,
                 lon: -97.0,

--- a/engine/src/dwd.rs
+++ b/engine/src/dwd.rs
@@ -1,0 +1,635 @@
+//! DWD DX single-site product (`docs/protocol.md`, polar radar path):
+//! decode the German Weather Service DX sweep and poll it live, without
+//! new dependencies.
+//!
+//! DX is a 5-minute single-sweep product per radar (`sweep 0.8°`, 360 rays of
+//! 128 1 km gates, RLE-packed uint16 words after an ASCII header), fetched
+//! over plain HTTPS from `opendata.dwd.de`. It maps onto `Sweep` by
+//! converting dBZ into NEXRAD-style moment codes (`scale` 2.0, `offset`
+//! 66.0): undetect (`-32.5` dBZ, raw data 0) becomes code 0
+//! (below threshold), measured gates become 2..=255. DX carries no
+//! range-folding flag, so code 1 never appears.
+//!
+//! Unlike the NEXRAD chunk stream, each DX file is one complete sweep, so
+//! the poller only ever reports complete frames: a backfill of the newest
+//! catalogued-missing files on join, then the `-latest-` file every minute.
+
+use crate::live::Event;
+use crate::sweep::{Ray, Sweep};
+
+/// DX geometry: one ray per degree, 128 one-kilometre gates.
+pub const RAYS: usize = 360;
+pub const GATES: usize = 128;
+/// Gate geometry the shader consumes as uniforms (`docs/protocol.md`).
+pub const FIRST_GATE_M: u32 = 0;
+pub const GATE_SPACING_M: u32 = 1000;
+/// NEXRAD-style code mapping: dBZ = (code - offset) / scale.
+pub const SCALE: f32 = 2.0;
+pub const OFFSET: f32 = 66.0;
+/// dBZ value the format assigns to undetect (raw data part 0).
+pub const UNDETECT_DBZ: f32 = -32.5;
+/// Ray marker word (wradlib's bit 14) and zero-run flag (wradlib's bit 13;
+/// both counted from 1, so `1 << 13` and `1 << 12`) in the body.
+const RAY_MARK: u16 = 1 << 13;
+const ZERO_FLAG: u16 = 1 << 12;
+const DATA_MASK: u16 = (1 << 13) - 1;
+/// A zero run carries its count in bits 0..11 (wradlib: `data = 4095`).
+const RUN_MASK: u16 = (1 << 12) - 1;
+const CLUTTER_FLAG: u16 = 1 << 15;
+
+/// One decoded DX file: the volume scan time plus a polar grid of raw gate
+/// words (clutter flag in bit 15, data in bits 0..12).
+#[allow(dead_code, reason = "spike: clutter overlay not wired yet")]
+pub struct DxSweep {
+    pub radar_id: String,
+    /// Volume scan time, milliseconds since the Unix epoch (UTC).
+    pub time_ms: i64,
+    pub azimuths_deg: Vec<f32>,
+    pub elevations_deg: Vec<f32>,
+    pub words: Vec<Vec<u16>>,
+    pub clutter: Vec<Vec<bool>>,
+}
+
+/// dBZ of one raw gate word: `(word & 0x1FFF) * 0.5 - 32.5`.
+pub fn dbz_of(word: u16) -> f32 {
+    f32::from(word & DATA_MASK) * 0.5 - 32.5
+}
+
+/// NEXRAD-style moment code for a gate: 0 when undetect, otherwise
+/// `round(dbz * 2 + 66)` clamped to 2..=255.
+pub fn code_of(word: u16) -> u8 {
+    if dbz_of(word) == UNDETECT_DBZ {
+        return 0;
+    }
+    (dbz_of(word) * SCALE + OFFSET).round().clamp(2.0, 255.0) as u8
+}
+
+/// Decode one DX product file (`read_dx` in wradlib, same word layout).
+pub fn decode_dx(bytes: &[u8]) -> Result<DxSweep, String> {
+    let header_end = header_len(bytes)?;
+    let header = std::str::from_utf8(&bytes[..header_end])
+        .map_err(|e| format!("DX header is not ASCII: {e}"))?;
+    let header_text = header.trim_end_matches('\x03');
+    let (radar_id, time_ms) = parse_header_fixed(header_text)?;
+    let mut body = &bytes[header_end..];
+    // The declared length is occasionally off by one (`bytes` in wradlib's
+    // attributes); drop a trailing byte rather than fail the whole sweep.
+    if !body.len().is_multiple_of(2) {
+        body = &body[..body.len() - 1];
+    }
+    let words: Vec<u16> = body
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|w| u16::from_le_bytes(*w))
+        .collect();
+    let mut azimuths_deg = Vec::new();
+    let mut elevations_deg = Vec::new();
+    let mut rays: Vec<Vec<u16>> = Vec::new();
+    let mut clutter: Vec<Vec<bool>> = Vec::new();
+    let mut i = 0;
+    while i < words.len() {
+        if words[i] != RAY_MARK {
+            return Err(format!(
+                "DX ray {} starts with {:04X}, not the ray marker",
+                rays.len(),
+                words[i]
+            ));
+        }
+        if i + 2 >= words.len() {
+            return Err("DX ray header is truncated".into());
+        }
+        azimuths_deg.push(f32::from(words[i + 1] & DATA_MASK) / 10.0);
+        elevations_deg.push(f32::from(words[i + 2] & DATA_MASK) / 10.0);
+        i += 3;
+        let mut ray = Vec::new();
+        let mut mask = Vec::new();
+        while i < words.len() && words[i] != RAY_MARK {
+            let word = words[i];
+            if word & ZERO_FLAG != 0 {
+                let run = usize::from(word & RUN_MASK);
+                ray.resize(ray.len() + run, 0);
+                mask.resize(mask.len() + run, false);
+            } else {
+                ray.push(word);
+                mask.push(word & CLUTTER_FLAG != 0);
+            }
+            i += 1;
+        }
+        rays.push(ray);
+        clutter.push(mask);
+    }
+    if rays.is_empty() {
+        return Err("DX file holds no rays".into());
+    }
+    // Real files are 360 rays of 128 gates, but the format does not
+    // guarantee it (wradlib notes 361-beam files in the wild), so require
+    // only a rectangular grid; the azimuth lookup handles any ray count.
+    let gates = rays[0].len();
+    if let Some((n, len)) = rays
+        .iter()
+        .enumerate()
+        .map(|(n, ray)| (n, ray.len()))
+        .find(|&(_, len)| len != gates)
+    {
+        return Err(format!(
+            "DX rays disagree on gate count: ray 0 has {gates} gates, ray {n} has {len}"
+        ));
+    }
+    Ok(DxSweep {
+        radar_id,
+        time_ms,
+        azimuths_deg,
+        elevations_deg,
+        words: rays,
+        clutter,
+    })
+}
+
+/// Length of the ASCII header including its 0x03 terminator(s).
+fn header_len(bytes: &[u8]) -> Result<usize, String> {
+    let end = bytes
+        .iter()
+        .position(|&b| b == 0x03)
+        .ok_or("DX file has no header terminator")?;
+    Ok(if bytes.get(end + 1) == Some(&0x03) {
+        end + 2
+    } else {
+        end + 1
+    })
+}
+
+/// Radar id (`header[8:13]`) and UTC scan time from `DDHHMM` + `MMyy`.
+fn parse_header_fixed(header: &str) -> Result<(String, i64), String> {
+    if !header.starts_with("DX") || header.len() < 17 {
+        return Err("DX header is too short for the fixed fields".into());
+    }
+    let digits = |range: std::ops::Range<usize>, what: &str| {
+        header[range]
+            .parse::<u32>()
+            .map_err(|_| format!("DX header {what} is not numeric"))
+    };
+    let day = digits(2..4, "day")?;
+    let hour = digits(4..6, "hour")?;
+    let minute = digits(6..8, "minute")?;
+    let radar_id = header[8..13].to_owned();
+    let month = digits(13..15, "month")?;
+    let year = 2000 + digits(15..17, "year")?;
+    if !(1..=31).contains(&day) || hour > 23 || minute > 59 || !(1..=12).contains(&month) {
+        return Err("DX header time fields are out of range".into());
+    }
+    Ok((radar_id, unix_ms(year, month, day, hour, minute)))
+}
+
+/// Milliseconds since the Unix epoch for a UTC calendar time (Howard
+/// Hinnant's `days_from_civil`, no date library needed here).
+fn unix_ms(year: u32, month: u32, day: u32, hour: u32, minute: u32) -> i64 {
+    let y = year as i64 - i64::from(month <= 2);
+    let era = y.div_euclid(400);
+    let yoe = y - era * 400;
+    let mp = (i64::from(month) + 9) % 12;
+    let doy = (153 * mp + 2) / 5 + i64::from(day) - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    let days = era * 146097 + doe - 719468;
+    ((days * 24 + i64::from(hour)) * 60 + i64::from(minute)) * 60_000
+}
+
+impl DxSweep {
+    /// The sweep in the engine's polar texture encoding: rays in ascending
+    /// azimuth order (a stable sort, as `Sweep::from_radials` does), one
+    /// volume time for every ray since DX names no per-ray times.
+    pub fn to_sweep(&self) -> Result<Sweep, String> {
+        let mut order: Vec<usize> = (0..self.words.len()).collect();
+        order.sort_by(|&a, &b| {
+            self.azimuths_deg[a]
+                .total_cmp(&self.azimuths_deg[b])
+                .then_with(|| a.cmp(&b))
+        });
+        let rays = order
+            .into_iter()
+            .map(|i| Ray {
+                azimuth_deg: self.azimuths_deg[i],
+                elevation_deg: self.elevations_deg[i],
+                time_ms: self.time_ms,
+                codes: self.words[i].iter().map(|&w| code_of(w)).collect(),
+            })
+            .collect();
+        let gates = self.words[0].len();
+        if gates > u16::MAX as usize {
+            return Err("DX ray is wider than u16 gates".into());
+        }
+        Ok(Sweep {
+            rays,
+            start_ms: self.time_ms,
+            end_ms: self.time_ms,
+            gates: gates as u16,
+            first_gate_m: FIRST_GATE_M,
+            gate_spacing_m: GATE_SPACING_M,
+            scale: SCALE,
+            offset: OFFSET,
+        })
+    }
+}
+
+/// The 17 DWD radar sites: uppercase id to WMO number, mirroring
+/// `engine/data/dwd_sites.json` (a unit test keeps the two in step).
+pub const SITES: [(&str, u32); 17] = [
+    ("ASB", 10103),
+    ("BOO", 10132),
+    ("DRS", 10488),
+    ("EIS", 10780),
+    ("ESS", 10410),
+    ("FBG", 10908),
+    ("FLD", 10440),
+    ("HNR", 10339),
+    ("ISN", 10873),
+    ("MEM", 10950),
+    ("NEU", 10557),
+    ("NHB", 10605),
+    ("OFT", 10629),
+    ("PRO", 10392),
+    ("ROS", 10169),
+    ("TUR", 10832),
+    ("UMD", 10356),
+];
+
+/// WMO number for a DWD station id (`None` for NEXRAD ids).
+pub fn wmo_of(id: &str) -> Option<u32> {
+    SITES
+        .iter()
+        .find(|&&(code, _)| code == id)
+        .map(|&(_, wmo)| wmo)
+}
+
+/// Directory of one site's DX files; DWD spells the site lowercase.
+pub fn site_url(id: &str) -> String {
+    format!("{BASE}/{}", id.to_lowercase())
+}
+
+/// The rolling `-latest-` file: `raa00-dx_<wmo>-latest-<site>---bin`.
+pub fn latest_name(id: &str, wmo: u32) -> String {
+    format!("raa00-dx_{wmo}-latest-{}---bin", id.to_lowercase())
+}
+
+/// Dated files sort chronologically by name (`yyMMddHHmm` is fixed width).
+pub fn parse_listing(html: &str) -> Vec<String> {
+    let mut names: Vec<String> = html
+        .split('"')
+        .filter(|token| {
+            token.starts_with("raa00-dx_") && token.ends_with("---bin") && !token.contains("latest")
+        })
+        .map(str::to_owned)
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}
+
+const BASE: &str = "https://opendata.dwd.de/weather/radar/sites/dx";
+/// DX files land every 5 minutes; poll the `-latest-` file this often.
+const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+const CALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+/// Wait before the backfill so a hand-off passed while panning costs
+/// nothing (`live.rs` gives its backfill the same delay).
+const BACKFILL_DELAY: std::time::Duration = std::time::Duration::from_secs(3);
+/// Earlier files fetched on joining a station, newest first area covered
+/// by the same count as the NEXRAD backfill.
+const BACKFILL_FILES: usize = 12;
+/// Report `offline` from the second consecutive failure, like `live.rs`.
+const OFFLINE_AFTER: u32 = 2;
+const BACK_OFF: std::time::Duration = std::time::Duration::from_secs(5);
+const MAX_BACK_OFF: std::time::Duration = std::time::Duration::from_secs(60);
+
+fn dwd_log(site: &str, message: impl std::fmt::Display) {
+    eprintln!(
+        "{} Dwd {site}: {message}",
+        chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ")
+    );
+}
+
+async fn fetch(client: &reqwest::Client, url: &str) -> Result<Vec<u8>, String> {
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("GET {url}: {e}"))?;
+    if !response.status().is_success() {
+        return Err(format!("GET {url}: HTTP {}", response.status()));
+    }
+    response
+        .bytes()
+        .await
+        .map(|body| body.to_vec())
+        .map_err(|e| format!("reading {url}: {e}"))
+}
+
+fn decode_named(site: &str, name: &str, bytes: &[u8]) -> Result<Sweep, String> {
+    let dx = decode_dx(bytes).map_err(|e| format!("{name}: {e}"))?;
+    if dx.words.len() != RAYS || dx.words[0].len() != GATES {
+        return Err(format!(
+            "{name}: {}x{} grid, {RAYS}x{GATES} expected",
+            dx.words.len(),
+            dx.words[0].len()
+        ));
+    }
+    dwd_log(site, format_args!("decoded {name}"));
+    dx.to_sweep()
+}
+
+/// Fetch the newest `BACKFILL_FILES` dated files missing from `known`
+/// and report each as `Event::Backfill`, newest first. Delivered start
+/// times join `known` so the live loop never republishes them.
+async fn backfill(
+    client: &reqwest::Client,
+    site: &str,
+    events: &tokio::sync::mpsc::Sender<Event>,
+    known: &mut Vec<i64>,
+) -> bool {
+    let listing = match fetch(client, &site_url(site)).await {
+        Ok(html) => String::from_utf8_lossy(&html).into_owned(),
+        Err(e) => {
+            dwd_log(site, format_args!("backfill listing: {e}"));
+            return true;
+        }
+    };
+    let names = parse_listing(&listing);
+    let window = &names[names.len().saturating_sub(BACKFILL_FILES)..];
+    for name in window.iter().rev() {
+        let url = format!("{}/{name}", site_url(site));
+        let bytes = match fetch(client, &url).await {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                dwd_log(site, format_args!("backfill {name}: {e}"));
+                continue;
+            }
+        };
+        let sweep = match decode_named(site, name, &bytes) {
+            Ok(sweep) => sweep,
+            Err(e) => {
+                dwd_log(site, format_args!("{e}"));
+                continue;
+            }
+        };
+        if known.contains(&sweep.start_ms) {
+            continue;
+        }
+        known.push(sweep.start_ms);
+        let provenance = format!("dwd-dx/{site}/{name}");
+        if events
+            .send(Event::Backfill {
+                site: site.to_owned(),
+                sweep,
+                provenance,
+            })
+            .await
+            .is_err()
+        {
+            return false;
+        }
+    }
+    true
+}
+
+/// Poll a DWD station until the task is aborted or the event channel
+/// closes. `cached` holds the start times already catalogued, so neither
+/// the backfill nor a respawned poller republishes them.
+pub async fn poll(
+    site: String,
+    wmo: u32,
+    events: tokio::sync::mpsc::Sender<Event>,
+    cached: Vec<i64>,
+) {
+    let client = match reqwest::Client::builder().timeout(CALL_TIMEOUT).build() {
+        Ok(client) => client,
+        Err(e) => {
+            dwd_log(&site, format_args!("HTTP client: {e}"));
+            let _ = events
+                .send(Event::Offline {
+                    site,
+                    reason: "HTTP client failed to build".into(),
+                })
+                .await;
+            return;
+        }
+    };
+    tokio::time::sleep(BACKFILL_DELAY).await;
+    let mut known = cached;
+    if !backfill(&client, &site, &events, &mut known).await {
+        return;
+    }
+    let latest = format!("{}/{}", site_url(&site), latest_name(&site, wmo));
+    let mut failures = 0;
+    let mut back_off = BACK_OFF;
+    loop {
+        tokio::time::sleep(POLL_INTERVAL).await;
+        let bytes = match fetch(&client, &latest).await {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                failures += 1;
+                if failures >= OFFLINE_AFTER
+                    && events
+                        .send(Event::Offline {
+                            site: site.clone(),
+                            reason: e.clone(),
+                        })
+                        .await
+                        .is_err()
+                {
+                    return;
+                }
+                dwd_log(&site, format_args!("{e}; retrying"));
+                tokio::time::sleep(back_off).await;
+                back_off = (back_off * 2).min(MAX_BACK_OFF);
+                continue;
+            }
+        };
+        failures = 0;
+        back_off = BACK_OFF;
+        let sweep = match decode_named(&site, "latest", &bytes) {
+            Ok(sweep) => sweep,
+            Err(e) => {
+                dwd_log(&site, format_args!("{e}"));
+                continue;
+            }
+        };
+        if known.contains(&sweep.start_ms) {
+            continue;
+        }
+        known.push(sweep.start_ms);
+        let provenance = format!("dwd-dx/{site}/latest");
+        if events
+            .send(Event::Sweep {
+                site: site.clone(),
+                sweep,
+                complete: true,
+                provenance,
+            })
+            .await
+            .is_err()
+        {
+            return;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal synthetic DX file: header plus two rays (azimuths 1.0° and
+    /// 0.0° to prove the ascending sort), each four gates: a zero run, a
+    /// measured gate, and a clutter-flagged gate.
+    fn synthetic() -> Vec<u8> {
+        let mut bytes =
+            b"DX121040101320926BY0000VS 2CO0CD4CS0EP0.80.80.80.80.80.80.80.8MS  0\x03\x03".to_vec();
+        let mut words: Vec<u16> = Vec::new();
+        // Ray 1.0°: az 10, el 8 (0.8°); run of 2 zeros, data 65 (-0.0 dBZ),
+        // clutter-flagged data 65.
+        words.extend([RAY_MARK, 10, 8, 0x1000 | 2, 65, CLUTTER_FLAG | 65]);
+        // Ray 0.0°: az 0, el 8; data 100 (17.5 dBZ), then a run of 3 zeros.
+        words.extend([RAY_MARK, 0, 8, 100, 0x1000 | 3]);
+        for word in words {
+            bytes.extend_from_slice(&word.to_le_bytes());
+        }
+        bytes
+    }
+
+    #[test]
+    fn header_time_and_rays_decode() {
+        let sweep = decode_dx(&synthetic()).unwrap();
+        assert_eq!(sweep.radar_id, "10132");
+        // 2026-09-12T10:40:00Z.
+        assert_eq!(sweep.time_ms, 1_789_209_600_000);
+        assert_eq!(sweep.azimuths_deg, [1.0, 0.0]);
+        assert_eq!(sweep.elevations_deg, [0.8, 0.8]);
+        assert_eq!(sweep.words.len(), 2);
+        assert_eq!(sweep.words[0].len(), 4);
+        assert_eq!(sweep.words[1].len(), 4);
+    }
+
+    #[test]
+    fn codes_follow_the_nexrad_mapping() {
+        assert_eq!(code_of(0), 0, "undetect is below threshold");
+        assert_eq!(dbz_of(0), UNDETECT_DBZ);
+        // 17.5 dBZ -> round(17.5 * 2 + 66) = 101.
+        assert_eq!(code_of(100), 101);
+        // Clutter flag does not change the value bits.
+        assert_eq!(code_of(CLUTTER_FLAG | 100), 101);
+        assert_eq!(code_of(0x1FFF), 255, "clamp the top");
+    }
+
+    #[test]
+    fn sweep_sorts_rays_and_shares_the_palette() {
+        let sweep = decode_dx(&synthetic()).unwrap().to_sweep().unwrap();
+        assert_eq!(sweep.gates, 4);
+        assert_eq!(sweep.first_gate_m, FIRST_GATE_M);
+        assert_eq!(sweep.gate_spacing_m, GATE_SPACING_M);
+        assert_eq!(sweep.scale, SCALE);
+        assert_eq!(sweep.offset, OFFSET);
+        // Ascending azimuth: the 0.0° ray first.
+        assert_eq!(sweep.rays[0].azimuth_deg, 0.0);
+        assert_eq!(sweep.rays[1].azimuth_deg, 1.0);
+        assert_eq!(sweep.rays[0].codes, [code_of(100), 0, 0, 0]);
+        assert_eq!(sweep.rays[1].codes, [0, 0, code_of(65), code_of(65)]);
+        assert!((sweep.elevation_deg() - 0.8).abs() < 1e-6);
+    }
+
+    #[test]
+    fn urls_name_the_site_and_wmo() {
+        assert_eq!(
+            site_url("BOO"),
+            "https://opendata.dwd.de/weather/radar/sites/dx/boo"
+        );
+        assert_eq!(latest_name("BOO", 10132), "raa00-dx_10132-latest-boo---bin");
+        assert_eq!(wmo_of("BOO"), Some(10132));
+        assert_eq!(wmo_of("UMD"), Some(10356));
+        assert_eq!(wmo_of("KTLX"), None);
+    }
+
+    #[test]
+    fn listing_keeps_dated_files_newest_sortable() {
+        let html = r#"<a href="raa00-dx_10132-2609121040-boo---bin">x</a>
+<a href="raa00-dx_10132-latest-boo---bin">latest</a>
+<a href="raa00-dx_10132-2609121035-boo---bin">x</a>"#;
+        assert_eq!(
+            parse_listing(html),
+            [
+                "raa00-dx_10132-2609121035-boo---bin",
+                "raa00-dx_10132-2609121040-boo---bin",
+            ]
+        );
+    }
+
+    /// The `SITES` map and `dwd_sites.json` name the same 17 stations, all
+    /// inside Germany, with no id shared with the NEXRAD table.
+    #[test]
+    fn station_table_and_wmo_map_agree() {
+        use crate::protocol::SiteTable;
+        let table: SiteTable =
+            serde_json::from_str(include_str!("../data/dwd_sites.json")).unwrap();
+        assert_eq!(table.sites.len(), SITES.len());
+        let nexrad: SiteTable = serde_json::from_str(include_str!("../data/sites.json")).unwrap();
+        for site in &table.sites {
+            assert!(
+                SITES.iter().any(|&(code, _)| code == site.id),
+                "SITES has no WMO for {}",
+                site.id
+            );
+            assert!(
+                nexrad.sites.iter().all(|entry| entry.id != site.id),
+                "{} collides with a NEXRAD id",
+                site.id
+            );
+            assert!(
+                (47.0..=55.5).contains(&site.lat) && (5.5..=15.5).contains(&site.lon),
+                "{} is outside Germany",
+                site.id
+            );
+            assert!(site.alt_m > 0.0);
+        }
+    }
+
+    /// Real-file spike, ignored by default: `DWD_DX_SAMPLE` names a DX file
+    /// (see /tmp/opencode/dwd/dx_sample.bin). Decodes it, checks it against
+    /// wradlib's reading, and writes the polar texture PNG plus the raw code
+    /// grid for cross-checking in Python.
+    #[test]
+    #[ignore]
+    fn real_file_matches_wradlib_and_renders() {
+        let path = std::env::var("DWD_DX_SAMPLE").expect("DWD_DX_SAMPLE names a DX file");
+        let bytes = std::fs::read(path).unwrap();
+        let sweep = decode_dx(&bytes).unwrap();
+        assert_eq!(sweep.radar_id, "10132");
+        assert_eq!(sweep.words.len(), 360, "one ray per degree");
+        assert!(sweep.words.iter().all(|ray| ray.len() == GATES));
+        let polar = sweep.to_sweep().unwrap();
+        assert_eq!(polar.rows(), 360, "a complete 1° cut needs no blank row");
+        let bounds = [-32, 0, 10, 20, 30, 40, 45, 50, 55, 60, 65, 70, 96];
+        let pixels = polar.texture(&bounds, 12);
+        let out = std::env::var("DWD_DX_OUTDIR").unwrap_or_else(|_| "/tmp/opencode/dwd".into());
+        std::fs::create_dir_all(&out).unwrap();
+        std::fs::write(
+            format!("{out}/dx_render.png"),
+            crate::sweep::png(u32::from(polar.gates), polar.rows(), &pixels).unwrap(),
+        )
+        .unwrap();
+        let grid: Vec<u8> = polar
+            .rays
+            .iter()
+            .flat_map(|ray| ray.codes.iter().copied())
+            .collect();
+        std::fs::write(format!("{out}/dx_grid_codes.bin"), grid).unwrap();
+        let measured = polar
+            .rays
+            .iter()
+            .flat_map(|ray| ray.codes.iter())
+            .filter(|&&c| c >= 2)
+            .count();
+        eprintln!(
+            "DX {}x{} el {:.1}° measured {measured} gates",
+            polar.rays.len(),
+            polar.gates,
+            polar.elevation_deg()
+        );
+    }
+}

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -1,4 +1,5 @@
 mod catalog;
+mod dwd;
 mod live;
 mod osm;
 mod protocol;
@@ -10,7 +11,7 @@ use chrono::{DateTime, Utc};
 use protocol::{
     Basemap, Command, Connection, ConnectionStatus, Frame, FrameStatus, Geometry, Handshake, Hello,
     Message, NaturalEarth, Places, Rejection, SiteSelection, SiteTable, Source, State, Station,
-    TileReady, TimelineEntry, VERSION, is_texture_path,
+    StationSource, TileReady, TimelineEntry, VERSION, is_texture_path,
 };
 use serde::Deserialize;
 use serde_json::Value;
@@ -90,9 +91,17 @@ fn fingerprint() -> io::Result<String> {
 fn build_id() -> &'static str {
     BUILD.get().expect("fingerprint is computed before use")
 }
-/// The embedded station snapshot (`engine/data/sites.json`).
+/// The embedded station snapshots (`engine/data/sites.json` for NEXRAD,
+/// `engine/data/dwd_sites.json` for DWD). Entries without a `source` key
+/// are NEXRAD (`protocol::StationSource` default).
 fn site_table() -> SiteTable {
-    serde_json::from_str(include_str!("../data/sites.json")).unwrap()
+    let mut table: SiteTable = serde_json::from_str(include_str!("../data/sites.json")).unwrap();
+    let dwd: SiteTable = serde_json::from_str(include_str!("../data/dwd_sites.json")).unwrap();
+    table.sites.extend(dwd.sites);
+    table.source = format!("{}; {}", table.source, dwd.source);
+    table.retrieved = table.retrieved.max(dwd.retrieved);
+    table.notes = format!("{} {}", table.notes, dwd.notes);
+    table
 }
 fn hello() -> Hello {
     let table = site_table();
@@ -325,6 +334,10 @@ fn live_frame(template: &Frame, station: &Station, sweep: &sweep::Sweep, complet
         product: template.product.clone(),
         product_name: template.product_name.clone(),
         units: template.units.clone(),
+        source: match station.source {
+            StationSource::Dwd => "DWD DX".into(),
+            StationSource::Nexrad => template.source.clone(),
+        },
         elevation_deg: (sweep.elevation_deg() * 100.0).round() / 100.0,
         scan_time: iso(sweep.start_ms),
         sweep_end: iso(sweep.end_ms),
@@ -371,6 +384,7 @@ fn empty_frame(template: &Frame, station: &Station) -> Frame {
         gate_spacing_m: template.gate_spacing_m.max(1),
         scale: 0.0,
         offset: 0.0,
+        source: template.source.clone(),
         site: Geometry {
             lat: station.lat,
             lon: station.lon,
@@ -392,6 +406,7 @@ fn startup_frame(template: &Frame) -> Frame {
         lat: 39.8,
         lon: -98.6,
         alt_m: 0.0,
+        source: StationSource::Nexrad,
     };
     empty_frame(template, &nowhere)
 }
@@ -592,7 +607,9 @@ impl Shared {
     /// Abort the current poller, if any, and start another on the selected
     /// station. Timeline and the frame on screen stay; the next *new* sweep
     /// clears `unavailable` / `offline`. `skip_known` is true on a respawn
-    /// so a catalogued replay is not published again.
+    /// so a catalogued replay is not published again. DWD stations poll
+    /// their DX files (`dwd.rs`); the events both pollers send share one
+    /// channel and one timeline.
     fn restart_live(&mut self, why: &str, skip_known: bool) {
         let site = self.state.site.id.clone();
         if site.is_empty() || self.state.source != Source::Live {
@@ -603,12 +620,12 @@ impl Shared {
             task.abort();
         }
         let cached: Vec<i64> = self.timeline.stored.iter().map(|e| e.start_ms).collect();
-        self.live = Some(tokio::spawn(live::poll(
-            site,
-            self.events.clone(),
-            cached,
-            skip_known,
-        )));
+        let events = self.events.clone();
+        self.live = Some(if let Some(wmo) = dwd::wmo_of(&site) {
+            tokio::spawn(dwd::poll(site, wmo, events, cached))
+        } else {
+            tokio::spawn(live::poll(site, events, cached, skip_known))
+        });
         self.last_live_restart = Instant::now();
     }
     /// Go live on a station: the newest cached frame (or an empty one)
@@ -753,12 +770,22 @@ impl Shared {
     }
     /// An earlier volume's frame joined the catalog: it takes its place in
     /// the timeline without touching the frame on screen, unless the pin
-    /// fell off the ring. The age keeps following the newest frame.
+    /// fell off the ring. The age keeps following the newest frame. When
+    /// the screen still shows the loading placeholder, the backfill is the
+    /// first real picture (the DWD poller only ever backfills), so it shows
+    /// at once and clears `loading`.
     fn backfilled(&mut self, entry: Entry) -> io::Result<()> {
         if self.frame_ms.is_none_or(|ms| entry.start_ms > ms) {
             self.frame_ms = Some(entry.start_ms);
         }
-        let shown = if self.timeline.insert(entry) {
+        let placeholder = self.state.frame.id.ends_with("-loading");
+        let evicted = self.timeline.insert(entry);
+        let shown = if placeholder {
+            if self.state.connection.status == ConnectionStatus::Loading {
+                self.state.connection.status = ConnectionStatus::Ok;
+            }
+            self.show_position(self.timeline.stored.len().saturating_sub(1))
+        } else if evicted {
             self.show_position(0)
         } else {
             Ok(())
@@ -2111,7 +2138,7 @@ mod tests {
 #[cfg(test)]
 mod handoff_tests {
     use super::{great_circle_km, handoff, site_table};
-    use crate::protocol::Station;
+    use crate::protocol::{Station, StationSource};
 
     fn station(id: &str, lat: f64, lon: f64) -> Station {
         Station {
@@ -2121,6 +2148,7 @@ mod handoff_tests {
             lat,
             lon,
             alt_m: 0.0,
+            source: StationSource::Nexrad,
         }
     }
     /// A point `fraction` of the way from `a` to `b` along the parallel.

--- a/engine/src/protocol.rs
+++ b/engine/src/protocol.rs
@@ -117,6 +117,20 @@ pub struct Station {
     pub lat: f64,
     pub lon: f64,
     pub alt_m: f64,
+    /// Which network serves the station's sweeps; absent in older tables,
+    /// which are all NEXRAD.
+    #[serde(default)]
+    pub source: StationSource,
+}
+
+/// The radar network behind a station: NOAA NEXRAD Level II chunks or DWD
+/// DX single-site sweeps. The engine dispatches its live poller on this.
+#[derive(Serialize, Deserialize, PartialEq, Clone, Copy, Debug, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum StationSource {
+    #[default]
+    Nexrad,
+    Dwd,
 }
 
 #[derive(Serialize, PartialEq, Debug)]
@@ -295,6 +309,10 @@ pub struct Frame {
     pub scale: f32,
     #[serde(default)]
     pub offset: f32,
+    /// Display attribution for the sweep's network (`NOAA NEXRAD`, `DWD
+    /// DX`); the engine owns product vocabulary, the UI lays it out.
+    #[serde(default)]
+    pub source: String,
     pub site: Geometry,
     pub palette: Vec<String>,
     pub bounds: Vec<i32>,

--- a/engine/src/tiles.rs
+++ b/engine/src/tiles.rs
@@ -265,7 +265,7 @@ impl Geography {
     }
 }
 
-/// GeoNames cities with population ≥ 5000, clipped to the NEXRAD envelope.
+/// GeoNames cities with population ≥ 5000, clipped to the station envelope.
 /// Location search uses this; map labels stay on Natural Earth `places`.
 fn gazetteer() -> &'static [Place] {
     static GAZETTEER_PLACES: OnceLock<Vec<Place>> = OnceLock::new();
@@ -755,14 +755,19 @@ mod tests {
                 }
             }
         }
-        // Every 1:10m vertex sits in the envelope or next to one that does.
+        // Every 1:10m vertex sits in the station envelope or next to one
+        // that does (mirrors `engine/build.rs` `in_envelope`).
+        fn in_envelope(lon: f64, lat: f64) -> bool {
+            ((5.0..=75.0).contains(&lat) && (lon <= -20.0 || lon >= 120.0))
+                || ((47.0..=56.0).contains(&lat) && (5.0..=16.0).contains(&lon))
+        }
         for polyline in geography.sets[1].layers.iter().flat_map(|l| &l.polylines) {
             let inside: Vec<bool> = polyline
                 .points
                 .iter()
                 .map(|&(x, y)| {
                     let (lon, lat) = (f64::from(x) * QUANTUM, f64::from(y) * QUANTUM);
-                    (5.0..=75.0).contains(&lat) && (lon <= -20.0 || lon >= 120.0)
+                    in_envelope(lon, lat)
                 })
                 .collect();
             for i in 0..inside.len() {
@@ -806,6 +811,10 @@ mod tests {
         let stokesdale = search_places("stokesdale", None, 4);
         assert_eq!(stokesdale[0].name, "Stokesdale");
         assert_eq!(stokesdale[0].region, "North Carolina");
+        let hannover = search_places("hannover", Some((52.37, 9.73)), 4);
+        assert_eq!(hannover[0].name, "Hannover");
+        assert_eq!(hannover[0].region, "Lower Saxony");
+        assert_eq!(hannover[0].country, "DE");
         assert!(gazetteer().len() > 15_000);
         assert!(gazetteer().len() > Geography::embedded().places.len());
     }

--- a/engine/tests/protocol.rs
+++ b/engine/tests/protocol.rs
@@ -117,19 +117,29 @@ fn fixture_transport_and_shared_commands() {
     assert_eq!(hello["v"], 1);
     assert_eq!(hello["build"].as_str().unwrap().len(), 16);
     let sites = hello["sites"].as_array().unwrap();
-    assert_eq!(sites.len(), 163);
+    assert_eq!(sites.len(), 163 + 17);
     let mut ids = std::collections::HashSet::new();
     for site in sites {
         assert!(ids.insert(site["id"].as_str().unwrap()));
         assert!((-90.0..=90.0).contains(&site["lat"].as_f64().unwrap()));
         assert!((-180.0..=180.0).contains(&site["lon"].as_f64().unwrap()));
         assert!(site["altM"].as_f64().unwrap() > -500.0);
+        let source = site["source"].as_str().unwrap();
+        assert!(source == "nexrad" || source == "dwd");
     }
     for id in ["KTLX", "PABC", "PHKI", "PGUA", "TJUA", "RKJK", "LPLA"] {
         assert!(ids.contains(id));
     }
+    for id in ["BOO", "DRS", "UMD"] {
+        assert!(ids.contains(id));
+    }
+    let boo = sites.iter().find(|site| site["id"] == "BOO").unwrap();
+    assert_eq!(boo["source"], "dwd");
+    let ktlx = sites.iter().find(|site| site["id"] == "KTLX").unwrap();
+    assert_eq!(ktlx["source"], "nexrad");
     let initial = read(&mut first);
     assert_eq!(initial["frame"]["scanTime"], "2013-05-20T20:16:43Z");
+    assert_eq!(initial["frame"]["source"], "NOAA NEXRAD");
     assert_eq!(initial["source"], "archived");
     // The timeline lists what `seek` accepts: here the one archived frame.
     assert_eq!(
@@ -268,6 +278,16 @@ fn fixture_transport_and_shared_commands() {
     );
     let places = read(&mut second);
     assert_eq!(places["results"][0]["name"], "Norman");
+    // The station envelope reaches Germany: DWD cities resolve with
+    // admin-1 region and country.
+    send(
+        &mut second,
+        json!({"type":"search_places","query":"hannover","lat":52.37,"lon":9.73}),
+    );
+    let places = read(&mut second);
+    assert_eq!(places["results"][0]["name"], "Hannover");
+    assert_eq!(places["results"][0]["region"], "Lower Saxony");
+    assert_eq!(places["results"][0]["country"], "DE");
     send(
         &mut first,
         json!({"type":"search_places","query":"x","lat":95.0,"lon":0.0}),

--- a/scripts/check-engine-ui.sh
+++ b/scripts/check-engine-ui.sh
@@ -17,7 +17,7 @@ ShellRoot {
         interval: 1000; running: true
         onTriggered: {
             check(!!engine.state, "No socket state received");
-            check(engine.sites.length === 163, "No site table received");
+            check(engine.sites.length === 180, "No site table received");
             check(engine.texture.indexOf("file://") === 0, "No engine texture");
             check(engine.azimuthLut.indexOf("file://") === 0 && engine.azimuthLut !== engine.texture, "No engine azimuth lookup");
             check(engine.state.frame.rays > 0 && engine.state.frame.gates > 0 && engine.state.frame.gateSpacingM > 0, "No sweep geometry in state");

--- a/scripts/check-location.sh
+++ b/scripts/check-location.sh
@@ -110,6 +110,13 @@ for _ in {1..40}; do
   sleep .1
 done
 [[ $matches == *Stokesdale* && $matches == *North\ Carolina* ]] || fail "Stokesdale was not in the gazetteer: $matches"
+quickshell ipc --pid "$pid" call location open hannover
+for _ in {1..40}; do
+  matches=$(quickshell ipc --pid "$pid" call location matches)
+  [[ $matches == *Hannover* && $matches == *Lower\ Saxony* ]] && break
+  sleep .1
+done
+[[ $matches == *Hannover* && $matches == *Lower\ Saxony* ]] || fail "Hannover was not in the gazetteer: $matches"
 quickshell ipc --pid "$pid" call location close
 stop
 

--- a/scripts/check-picker.sh
+++ b/scripts/check-picker.sh
@@ -25,7 +25,7 @@ for _ in {1..50}; do [[ $(call matches) != '[]' ]] && break; sleep .1; done
 # The fixture's home view centres north-west of KTLX: KTLX first, the Norman pair next.
 m=$(call matches)
 [[ $m == '["KTLX","K'* && $m == *KOUN* && $m == *KCRI* ]] || fail "Empty query did not list the nearest stations first: $m"
-expect 'Empty query counts the whole table' '{"open":true,"query":"","selected":0,"total":163,"focused":true}' "$(call status)"
+expect 'Empty query counts the whole table' '{"open":true,"query":"","selected":0,"total":180,"focused":true}' "$(call status)"
 call open tlx
 expect 'ID without its leading letter ranks first' '"KTLX"' "$(call matches | cut -d, -f1 | tr -d '[]')"
 call open tulsa

--- a/tests/map-sites.qml
+++ b/tests/map-sites.qml
@@ -36,7 +36,7 @@ ShellRoot {
         onTriggered: {
             try {
                 if (stage === 0) {
-                    check(map.sites.length === 163, "Missing engine station table");
+                    check(map.sites.length === 180, "Missing engine station table");
                     checkCoverageOrigin();
                     check(map.siteLabels.some(s => s.name === "KOUN"), "Nearby station ID hidden by collision layout");
                     check(!map.siteLabels.some(s => s.name === "KTLX"), "Duplicate active marker label");

--- a/ui/Popover.qml
+++ b/ui/Popover.qml
@@ -242,7 +242,9 @@ FocusScope {
             font.pixelSize: 8
             opacity: .5
             elide: Text.ElideRight
-            text: map.osmOnScreen ? "NOAA · © OpenStreetMap" : "NOAA · Natural Earth"
+            // Radar credit follows the frame's network (engine-owned
+            // `frame.source`); the full attribution lives in README.
+            text: (scan && scan.source === "DWD DX" ? "DWD" : "NOAA") + (map.osmOnScreen ? " · © OpenStreetMap" : " · Natural Earth")
         }
     }
 }

--- a/ui/RadarWindow.qml
+++ b/ui/RadarWindow.qml
@@ -511,7 +511,7 @@ Item {
             //   brand row     — mark, OMASTORM, status light, LIVE/ARCHIVED
             //   site row      — station title, radar lock (yellow when outside coverage)
             //   product stack — product line + meta line (right of site row)
-            //   product line  — REFLECTIVITY / tilt + NOAA NEXRAD
+            //   product line  — REFLECTIVITY / tilt + radar source (frame.source)
             //   meta line     — age, right-aligned under the product line
             //   map stage     — radar map frame
             //   follow chip   — crosshair (place follow); hidden until GPS
@@ -614,7 +614,7 @@ Item {
                             text: !app.scan ? "" : app.scan.productName.toUpperCase() + (app.scan.scanTime ? " / " + app.scan.elevationDeg.toFixed(1) + "°" : "")
                         }
                         LabelText {
-                            text: "NOAA NEXRAD"
+                            text: !app.scan || !app.scan.source ? "NOAA NEXRAD" : app.scan.source
                             font.letterSpacing: 1; opacity: .55
                         }
                     }


### PR DESCRIPTION
Related to #38 — covers the Germany slice with the cheapest option that fits the current renderer.

**What this adds**
You can now pick any of the 17 German weather radars (BOO, HNR, ESS, …) and watch live precipitation exactly like a NEXRAD station: same map, same timeline loop, same three treatments, same keyboard. Germany's radar network is free and open (no key), publishing a fresh snapshot per radar every 5 minutes, so I taught the engine to fetch and display those snapshots.

**Why DX, in plain terms**
German radar data comes in several shapes. I checked them all and picked DX because it matches what the app already draws: a polar sweep (a circle scanned beam by beam). That meant zero new libraries and zero changes to the map, the colors, or the legend — the German picture flows through the exact same path as the American one. The sharper 250 m products are grids, not sweeps, so they need the new mosaic render path from #38; this PR deliberately doesn't go there.

**What's in it**
- New decoder + poller (`engine/src/dwd.rs`): downloads each station's latest snapshot, translates its values onto the app's shared color scale, backfills the last 12 snapshots on join. Output verified bit-for-bit against wradlib, the reference radar library.
- New station table (`engine/data/dwd_sites.json`): the 17 sites, merged into the hello list (now 180 stations).
- Protocol, additive only (still v1): stations carry their network (`nexrad`/`dwd`), frames carry a display name (`NOAA NEXRAD`/`DWD DX`). Old clients ignore the new fields.
- Window + popover show the frame's network instead of a hardcoded label; DWD credit added to README.
- Search and the detailed map layer now cover Germany (was Americas-only); Hannover resolves with region + country.
- One shared-behavior tweak: a backfill replaces the loading placeholder, so a fresh German station paints its first picture immediately instead of waiting up to a minute. Same path NEXRAD backfills already use.

**Known limits (honest, all in the code or docs)**
- DX is 1 km gates out to 128 km — chunkier and shorter-range than NEXRAD. The 250 m options need an HDF5 reader or the grid path; noted in the code, not attempted here.
- No live “painting” sweep: each German file is one finished snapshot, so frames arrive complete every 5 minutes, never partial.
- No release-pin bump, no fixture changes, no new dependencies.

**Verified**
- `mise check`: all 19 pass (three site-count checks bumped 163→180; Hannover added to the location check).
- Live against `opendata.dwd.de`: BOO/HNR/NHB stream, backfill → loop → seek/step all exercised over the socket; empty skies correctly show an empty circle.